### PR TITLE
polish(文言): 「デフォルト」の3義を分離し、プロンプト選択/管理の名前を揃える

### DIFF
--- a/src/components/AddDefaultPromptsModal.tsx
+++ b/src/components/AddDefaultPromptsModal.tsx
@@ -136,7 +136,7 @@ export function AddDefaultPromptsModal({
                         tabIndex={templates.length === 0 ? -1 : undefined}
                         className="text-xl font-bold text-gray-900 focus:outline-none"
                     >
-                        デフォルトプロンプトを追加
+                        テンプレートから追加
                     </h2>
                     <button
                         type="button"

--- a/src/components/BulkPromptSelector.tsx
+++ b/src/components/BulkPromptSelector.tsx
@@ -22,10 +22,13 @@ export const BulkPromptSelector: React.FC<BulkPromptSelectorProps> = ({
     }
 
     return (
-        <fieldset className="rounded-lg border border-purple-200 bg-purple-50 p-4">
+        <fieldset className="min-w-0 rounded-lg border border-purple-200 bg-purple-50 p-4">
             <legend className="px-1 text-sm font-medium text-purple-900">
-                デフォルトプロンプト（ファイル追加時に適用します）
+                適用するプロンプトを選ぶ
             </legend>
+            <p className="mb-3 text-xs leading-relaxed text-purple-800">
+                これから追加するファイルすべてに適用されます。ファイルごとの変更は追加後にできます。プロンプトの追加・編集は「プロンプトの管理」から行えます。
+            </p>
             <div className="space-y-1">
                 {availablePrompts.map(prompt => {
                     const checkboxId = `${groupId}-${prompt.id}`;

--- a/src/components/DocumentDetailPanel.test.tsx
+++ b/src/components/DocumentDetailPanel.test.tsx
@@ -646,7 +646,7 @@ describe('DocumentDetailPanel', () => {
         }) as React.ReactNode;
 
         expect(getText(tree)).toContain('使用モデル: Gemini 3.7 Flash');
-        expect(getText(tree)).not.toContain('デフォルト選択');
+        expect(getText(tree)).not.toContain('標準を選択');
     });
 
     it('デフォルト選択で生成した文書には注記を添える', () => {
@@ -661,7 +661,7 @@ describe('DocumentDetailPanel', () => {
         }) as React.ReactNode;
 
         expect(getText(tree)).toContain(
-            '使用モデル: Gemini 3.7 Flash（デフォルト選択）',
+            '使用モデル: Gemini 3.7 Flash（標準を選択）',
         );
     });
 
@@ -1694,7 +1694,7 @@ describe('DocumentPrintPortal PDF テーマ', () => {
 
         expect(header).not.toBeNull();
         expect(getText(PdfDocumentHeader(header!.props))).toContain(
-            '使用モデルGemini 3.7 Flash（デフォルト選択）・思考: 標準',
+            '使用モデルGemini 3.7 Flash（標準を選択）・思考: 標準',
         );
     });
 

--- a/src/components/DocumentDetailPanel.tsx
+++ b/src/components/DocumentDetailPanel.tsx
@@ -606,7 +606,7 @@ export function DocumentDetailPanelView({
                             {document.generatedByModel && (
                                 <p>
                                     使用モデル: {getGeminiModelLabel(document.generatedByModel)}
-                                    {document.modelSelection === 'default' && '（デフォルト選択）'}
+                                    {document.modelSelection === 'default' && '（標準を選択）'}
                                     {document.generatedByThinkingLevel &&
                                         `・思考: ${getThinkingLevelLabel(document.generatedByThinkingLevel)}`}
                                 </p>

--- a/src/components/FilePromptSelector.tsx
+++ b/src/components/FilePromptSelector.tsx
@@ -30,7 +30,7 @@ export const FilePromptSelector: React.FC<FilePromptSelectorProps> = ({
       {selectedFiles.map((fileWithPrompts, fileIndex) => (
         <fieldset
           key={`${groupId}-${fileIndex}`}
-          className="rounded-lg border border-gray-200 bg-gray-50 p-4"
+          className="min-w-0 rounded-lg border border-gray-200 bg-gray-50 p-4"
         >
           <legend className="px-1 text-sm font-medium text-gray-900">
             {fileWithPrompts.file.name}

--- a/src/components/ModelComparisonTable.tsx
+++ b/src/components/ModelComparisonTable.tsx
@@ -51,7 +51,7 @@ export const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
     const resolvedDefaultModel = resolveGeminiModel(GEMINI_DEFAULT_MODEL_SENTINEL);
     const defaultOption = {
         value: GEMINI_DEFAULT_MODEL_SENTINEL,
-        label: `デフォルト（現在: ${getGeminiModelLabel(resolvedDefaultModel)}）`,
+        label: `標準（現在: ${getGeminiModelLabel(resolvedDefaultModel)}）`,
         description: 'アプリの推奨モデルに自動追従します',
     };
     const comparisonOptions = [defaultOption, ...GEMINI_MODEL_OPTIONS];

--- a/src/components/PdfDocumentHeader.tsx
+++ b/src/components/PdfDocumentHeader.tsx
@@ -37,7 +37,7 @@ export function PdfDocumentHeader({
                         <dt>使用モデル</dt>
                         <dd>
                             {getGeminiModelLabel(document.generatedByModel)}
-                            {document.modelSelection === 'default' && '（デフォルト選択）'}
+                            {document.modelSelection === 'default' && '（標準を選択）'}
                             {document.generatedByThinkingLevel &&
                                 `・思考: ${getThinkingLevelLabel(document.generatedByThinkingLevel)}`}
                         </dd>

--- a/src/components/PromptEditModal.tsx
+++ b/src/components/PromptEditModal.tsx
@@ -282,7 +282,7 @@ const PromptEditSessionModal: React.FC<PromptEditSessionModalProps> = ({
                         このプロンプトは編集・削除できません。
                     </p>
                     <p className="mt-1 text-xs text-amber-700">
-                        未ログインユーザー向けのデフォルトプロンプトは保護されています。
+                        全員に共通のプロンプトです。ログインすると、自分のプロンプトを作成・編集できます。
                     </p>
                 </div>
             </div>
@@ -290,7 +290,7 @@ const PromptEditSessionModal: React.FC<PromptEditSessionModalProps> = ({
     ) : prompt.isDefault ? (
         <div className="rounded-lg border border-blue-200 bg-blue-50 p-3">
             <p className="text-xs text-blue-800">
-                ℹ️ このプロンプトはデフォルトプロンプトです。
+                ℹ️ テンプレートから追加したプロンプトです。編集しても元のテンプレートは変わりません。
             </p>
         </div>
     ) : undefined;

--- a/src/components/PromptListSidebar.deleteflow.test.tsx
+++ b/src/components/PromptListSidebar.deleteflow.test.tsx
@@ -296,12 +296,12 @@ describe('PromptListSidebar 削除フローとインラインエラー', () => {
             findButton(container, '新規プロンプト')!.click();
         });
         await act(async () => {
-            findButton(container, 'デフォルトプロンプトを追加')!.click();
+            findButton(container, 'テンプレートから追加')!.click();
             await vi.runAllTimersAsync();
         });
 
         const inlineError = container.querySelector('[role="alert"]');
         expect(inlineError?.textContent)
-            .toContain('デフォルトプロンプトを取得できませんでした。時間をおいて再度お試しください。');
+            .toContain('テンプレートを取得できませんでした。時間をおいて再度お試しください。');
     });
 });

--- a/src/components/PromptListSidebar.tsx
+++ b/src/components/PromptListSidebar.tsx
@@ -246,7 +246,7 @@ export const PromptListSidebar: React.FC<PromptListSidebarProps> = ({
 
         // ゲストのデフォルトプロンプトは削除不可（削除ボタン自体を出していないが多重防御）
         if (!user && prompt.ownerType === 'guest' && prompt.isDefault) {
-            setActionError('デフォルトプロンプトは削除できません。');
+            setActionError('共通プロンプトは削除できません。');
             return;
         }
 
@@ -320,7 +320,7 @@ export const PromptListSidebar: React.FC<PromptListSidebarProps> = ({
             setIsModalOpen(true);
         } catch (error) {
             promptListLogger.error('デフォルトプロンプトの取得に失敗', error, { userId: user?.uid });
-            setActionError('デフォルトプロンプトを取得できませんでした。時間をおいて再度お試しください。');
+            setActionError('テンプレートを取得できませんでした。時間をおいて再度お試しください。');
         }
     };
 
@@ -352,7 +352,7 @@ export const PromptListSidebar: React.FC<PromptListSidebarProps> = ({
                     <div className="flex items-center space-x-2">
                         <FileText className="w-6 h-6 text-blue-600" />
                         <h2 className="text-xl font-bold text-gray-900">
-                            プロンプト一覧
+                            プロンプトの管理
                         </h2>
                     </div>
                     <div className="flex items-center space-x-2">
@@ -370,7 +370,7 @@ export const PromptListSidebar: React.FC<PromptListSidebarProps> = ({
 
                             {/* ログインユーザー用ドロップダウンメニュー */}
                             {user && isMenuOpen && (
-                                <div className="absolute right-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50">
+                                <div className="absolute left-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50">
                                     <button
                                         onClick={() => {
                                             setIsMenuOpen(false);
@@ -385,7 +385,7 @@ export const PromptListSidebar: React.FC<PromptListSidebarProps> = ({
                                         disabled={isInitializing}
                                         className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-blue-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                                     >
-                                        {isInitializing ? '追加中...' : 'デフォルトプロンプトを追加'}
+                                        {isInitializing ? '追加中...' : 'テンプレートから追加'}
                                     </button>
                                 </div>
                             )}
@@ -480,13 +480,17 @@ export const PromptListSidebar: React.FC<PromptListSidebarProps> = ({
                                 <div className={`p-4 ${canDeletePrompt(prompt) ? 'pr-14' : ''}`}>
                                     <div className="min-w-0">
                                         <div className="flex items-center space-x-2">
-                                            <h3 className="text-sm font-semibold text-gray-900 truncate group-hover:text-blue-700 transition-colors">
+                                            <h3 className="min-w-0 text-sm font-semibold text-gray-900 truncate group-hover:text-blue-700 transition-colors">
                                                 {prompt.name}
                                             </h3>
-                                            {prompt.isDefault && (
-                                                <span className="text-xs text-blue-600 bg-blue-50 px-2 py-0.5 rounded flex items-center gap-1">
-                                                    {prompt.ownerType === 'guest' && <Lock className="w-3 h-3" />}
-                                                    デフォルト
+                                            {prompt.isDefault && prompt.ownerType === 'guest' && (
+                                                <span
+                                                    className="flex shrink-0 items-center gap-1 whitespace-nowrap rounded bg-blue-50 px-2 py-0.5 text-xs text-blue-600"
+                                                    title="全員に共通のプロンプト（編集・削除はできません）"
+                                                >
+                                                    <Lock className="w-3 h-3" aria-hidden="true" />
+                                                    共通
+                                                    <span className="sr-only">（編集不可）</span>
                                                 </span>
                                             )}
                                         </div>

--- a/src/components/admin/AudioFilesPanel.tsx
+++ b/src/components/admin/AudioFilesPanel.tsx
@@ -144,7 +144,7 @@ export default function AudioFilesPanel() {
                         className="px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
                     >
                         <option value="all">すべて</option>
-                        <option value="default_all">デフォルトプロンプト（全種類）</option>
+                        <option value="default_all">テンプレート由来のプロンプト（全種類）</option>
                         {templateNames.map((name) => (
                             <option key={name} value={name}>
                                 {name}

--- a/src/components/admin/DefaultPromptEditModal.test.tsx
+++ b/src/components/admin/DefaultPromptEditModal.test.tsx
@@ -332,7 +332,7 @@ describe('DefaultPromptEditModal', () => {
         expect(onDelete).not.toHaveBeenCalled();
         expect(dialogElement().getAttribute('role')).toBe('alertdialog');
         expect(container.textContent).toContain('「保存済みプロンプト」を削除しますか？');
-        expect(container.textContent).toContain('削除したデフォルトプロンプトは元に戻せません。');
+        expect(container.textContent).toContain('削除したテンプレートは元に戻せません。');
 
         await act(async () => {
             findButton('削除する').click();

--- a/src/components/admin/DefaultPromptEditModal.tsx
+++ b/src/components/admin/DefaultPromptEditModal.tsx
@@ -186,7 +186,7 @@ export default function DefaultPromptEditModal({
             !== effectiveThinkingLevel(selectedModel, selectedThinkingLevel);
 
     const headingText = title
-        || (mode === 'create' ? 'デフォルトプロンプトを追加' : 'デフォルトプロンプトを編集');
+        || (mode === 'create' ? 'テンプレートを追加' : 'テンプレートを編集');
 
     const rememberConfirmationTrigger = () => {
         const activeElement = document.activeElement;
@@ -303,7 +303,7 @@ export default function DefaultPromptEditModal({
         ? `「${headingText}」を削除しますか？`
         : '未保存の変更があります';
     const confirmationDescription = confirmation?.type === 'delete'
-        ? '削除したデフォルトプロンプトは元に戻せません。'
+        ? '削除したテンプレートは元に戻せません。'
         : confirmation?.action === 'close'
             ? '閉じると、保存していない変更は失われます。'
             : '表示モードに戻ると、保存していない変更は失われます。';

--- a/src/components/admin/SettingsPanel.test.tsx
+++ b/src/components/admin/SettingsPanel.test.tsx
@@ -360,7 +360,7 @@ describe('SettingsPanel', () => {
         expect(loadSetters.guestSyncFailed).toHaveBeenLastCalledWith(true);
         expect(loadSetters.feedback).toHaveBeenLastCalledWith({
             kind: 'warning',
-            message: '前回のゲストユーザー向けデフォルトプロンプト同期が失敗しています。',
+            message: '前回のゲスト用共通プロンプトの同期が失敗しています。',
         });
 
         arrangePanelState({
@@ -368,7 +368,7 @@ describe('SettingsPanel', () => {
             originalSettings: failedSettings,
             feedback: {
                 kind: 'warning',
-                message: '前回のゲストユーザー向けデフォルトプロンプト同期が失敗しています。',
+                message: '前回のゲスト用共通プロンプトの同期が失敗しています。',
             },
             guestSyncFailed: true,
         });
@@ -376,7 +376,7 @@ describe('SettingsPanel', () => {
         const restoredTree = renderPanel();
 
         expect(getText(restoredTree)).toContain(
-            '前回のゲストユーザー向けデフォルトプロンプト同期が失敗しています。',
+            '前回のゲスト用共通プロンプトの同期が失敗しています。',
         );
         expect(findButton(restoredTree, '同期を再試行')).not.toBeNull();
     });
@@ -397,7 +397,7 @@ describe('SettingsPanel', () => {
         expect(loadSetters.guestSyncFailed).toHaveBeenLastCalledWith(true);
         expect(loadSetters.feedback).toHaveBeenLastCalledWith({
             kind: 'warning',
-            message: 'ゲストユーザー向けデフォルトプロンプト同期が完了していません。',
+            message: 'ゲスト用共通プロンプトの同期が完了していません。',
         });
 
         arrangePanelState({
@@ -405,7 +405,7 @@ describe('SettingsPanel', () => {
             originalSettings: pendingSettings,
             feedback: {
                 kind: 'warning',
-                message: 'ゲストユーザー向けデフォルトプロンプト同期が完了していません。',
+                message: 'ゲスト用共通プロンプトの同期が完了していません。',
             },
             guestSyncFailed: true,
         });
@@ -444,7 +444,7 @@ describe('SettingsPanel', () => {
         expect(setters.guestSyncFailed).toHaveBeenCalledWith(true);
         expect(setters.feedback).toHaveBeenCalledWith({
             kind: 'warning',
-            message: '設定は保存しましたが、ゲストユーザーのデフォルトプロンプトを同期できませんでした。',
+            message: '設定は保存しましたが、ゲスト用共通プロンプトを同期できませんでした。',
         });
     });
 
@@ -482,7 +482,7 @@ describe('SettingsPanel', () => {
         const setters = arrangePanelState({
             feedback: {
                 kind: 'warning',
-                message: '設定は保存しましたが、ゲストユーザーのデフォルトプロンプトを同期できませんでした。',
+                message: '設定は保存しましたが、ゲスト用共通プロンプトを同期できませんでした。',
             },
             guestSyncFailed: true,
         });
@@ -497,7 +497,7 @@ describe('SettingsPanel', () => {
         expect(setters.guestSyncFailed).toHaveBeenCalledWith(false);
         expect(setters.feedback).toHaveBeenLastCalledWith({
             kind: 'success',
-            message: 'ゲストユーザーのデフォルトプロンプトを同期しました。',
+            message: 'ゲスト用共通プロンプトを同期しました。',
         });
     });
 
@@ -505,7 +505,7 @@ describe('SettingsPanel', () => {
         const setters = arrangePanelState({
             feedback: {
                 kind: 'warning',
-                message: '前回のゲストユーザー向けデフォルトプロンプト同期が失敗しています。',
+                message: '前回のゲスト用共通プロンプトの同期が失敗しています。',
             },
             guestSyncFailed: true,
         });
@@ -516,7 +516,7 @@ describe('SettingsPanel', () => {
         expect(setters.guestSyncFailed).toHaveBeenCalledWith(true);
         expect(setters.feedback).toHaveBeenLastCalledWith({
             kind: 'error',
-            message: 'ゲストユーザーのデフォルトプロンプトを同期できませんでした。再試行してください。',
+            message: 'ゲスト用共通プロンプトを同期できませんでした。再試行してください。',
         });
     });
 

--- a/src/components/admin/SettingsPanel.tsx
+++ b/src/components/admin/SettingsPanel.tsx
@@ -82,8 +82,8 @@ const SettingsPanel = forwardRef<SettingsPanelRef, object>((props, ref) => {
                 setFeedback({
                     kind: 'warning',
                     message: settingsData.lastGuestSyncStatus === 'failed'
-                        ? '前回のゲストユーザー向けデフォルトプロンプト同期が失敗しています。'
-                        : 'ゲストユーザー向けデフォルトプロンプト同期が完了していません。',
+                        ? '前回のゲスト用共通プロンプトの同期が失敗しています。'
+                        : 'ゲスト用共通プロンプトの同期が完了していません。',
                 });
             }
         } catch (error) {
@@ -123,7 +123,7 @@ const SettingsPanel = forwardRef<SettingsPanelRef, object>((props, ref) => {
         if (duplicateName) {
             setFeedback({
                 kind: 'error',
-                message: `デフォルトプロンプト名「${duplicateName}」が重複しています。名前は一意にしてください。`,
+                message: `テンプレート名「${duplicateName}」が重複しています。名前は一意にしてください。`,
             });
             return;
         }
@@ -146,7 +146,7 @@ const SettingsPanel = forwardRef<SettingsPanelRef, object>((props, ref) => {
             setFeedback(syncFailed
                 ? {
                     kind: 'warning',
-                    message: '設定は保存しましたが、ゲストユーザーのデフォルトプロンプトを同期できませんでした。',
+                    message: '設定は保存しましたが、ゲスト用共通プロンプトを同期できませんでした。',
                 }
                 : {
                     kind: 'success',
@@ -164,7 +164,7 @@ const SettingsPanel = forwardRef<SettingsPanelRef, object>((props, ref) => {
                 setFeedback({
                     kind: 'warning',
                     message: syncFailed
-                        ? '設定は保存しましたが、ゲストユーザーのデフォルトプロンプト同期と監査ログ記録に失敗しました。'
+                        ? '設定は保存しましたが、ゲスト用共通プロンプトの同期と監査ログ記録に失敗しました。'
                         : '設定は保存しましたが、監査ログを記録できませんでした。',
                 });
             }
@@ -187,14 +187,14 @@ const SettingsPanel = forwardRef<SettingsPanelRef, object>((props, ref) => {
             setGuestSyncFailed(false);
             setFeedback({
                 kind: 'success',
-                message: 'ゲストユーザーのデフォルトプロンプトを同期しました。',
+                message: 'ゲスト用共通プロンプトを同期しました。',
             });
         } catch (error) {
             adminSettingsPanelLogger.error('ゲストデフォルトプロンプトの再同期に失敗', error);
             setGuestSyncFailed(true);
             setFeedback({
                 kind: 'error',
-                message: 'ゲストユーザーのデフォルトプロンプトを同期できませんでした。再試行してください。',
+                message: 'ゲスト用共通プロンプトを同期できませんでした。再試行してください。',
             });
         } finally {
             setSyncingGuestPrompts(false);
@@ -258,7 +258,7 @@ const SettingsPanel = forwardRef<SettingsPanelRef, object>((props, ref) => {
             <div>
                 <div className="mb-6">
                     <h2 className="text-2xl font-bold text-gray-900">システム設定</h2>
-                    <p className="text-gray-600 text-sm mt-1">プロンプトと文書のサイズ上限、デフォルトプロンプトを設定</p>
+                    <p className="text-gray-600 text-sm mt-1">プロンプトと文書のサイズ上限、プロンプトテンプレートを設定</p>
                 </div>
                 <div role="alert" className="rounded-lg border border-red-200 bg-red-50 p-6 text-red-800">
                     <p className="font-medium">{loadError ?? '設定を読み込めませんでした。'}</p>
@@ -278,7 +278,7 @@ const SettingsPanel = forwardRef<SettingsPanelRef, object>((props, ref) => {
         <div>
             <div className="mb-6">
                 <h2 className="text-2xl font-bold text-gray-900">システム設定</h2>
-                <p className="text-gray-600 text-sm mt-1">プロンプトと文書のサイズ上限、デフォルトプロンプトを設定</p>
+                <p className="text-gray-600 text-sm mt-1">プロンプトと文書のサイズ上限、プロンプトテンプレートを設定</p>
             </div>
 
             {feedback && (
@@ -352,9 +352,9 @@ const SettingsPanel = forwardRef<SettingsPanelRef, object>((props, ref) => {
                 <div className="bg-gray-50 p-6 rounded-lg">
                     <div className="flex items-center justify-between mb-4">
                         <div>
-                            <h3 className="text-lg font-medium text-gray-900">デフォルトプロンプト</h3>
+                            <h3 className="text-lg font-medium text-gray-900">プロンプトテンプレート</h3>
                             <p className="text-xs text-gray-500 mt-1">
-                                新規ユーザーに自動的に作成されるプロンプトテンプレート
+                                新規ユーザーに自動で作成されるプロンプトの雛形。ユーザーは「テンプレートから追加」でも取り込め、ログイン前の共通プロンプトにも同期されます。
                             </p>
                         </div>
                         <button
@@ -400,7 +400,7 @@ const SettingsPanel = forwardRef<SettingsPanelRef, object>((props, ref) => {
 
                         {defaultPrompts.length === 0 && (
                             <div className="text-center py-8 text-gray-500">
-                                デフォルトプロンプトがありません。「追加」ボタンで作成してください。
+                                テンプレートがありません。「追加」ボタンで作成してください。
                             </div>
                         )}
                     </div>

--- a/src/constants/geminiModels.test.ts
+++ b/src/constants/geminiModels.test.ts
@@ -118,7 +118,7 @@ describe('geminiModels', () => {
             );
             expect(defaultOption).toBeDefined();
             expect(getGeminiModelLabel(GEMINI_DEFAULT_MODEL_SENTINEL)).toBe(
-                `デフォルト（${defaultOption?.label}）`,
+                `標準（${defaultOption?.label}）`,
             );
         });
 

--- a/src/constants/geminiModels.ts
+++ b/src/constants/geminiModels.ts
@@ -220,7 +220,7 @@ export function getGeminiModelLabel(model?: string | null): string {
     if (canonicalModel === GEMINI_DEFAULT_MODEL_SENTINEL) {
         const defaultModelLabel = GEMINI_MODEL_MAP.get(DEFAULT_GEMINI_MODEL)?.label
             ?? DEFAULT_GEMINI_MODEL;
-        return `デフォルト（${defaultModelLabel}）`;
+        return `標準（${defaultModelLabel}）`;
     }
     return GEMINI_MODEL_MAP.get(canonicalModel)?.label || canonicalModel;
 }


### PR DESCRIPTION
## 変更の趣旨
/home で「デフォルト」が同じ画面に 3 つの別の意味 (①追加ファイルへの事前適用選択 ②モデル未指定 ③管理者テンプレート由来) で同時に出ていた問題を、語を分けて解消します。あわせて左右で同じ一覧が別名で並ぶ紛らわしさを「適用するプロンプトを選ぶ」/「プロンプトの管理」で対比させます。

## 文言の対応表
| 場所 | 変更前 | 変更後 |
|---|---|---|
| ホーム左カード見出し | デフォルトプロンプト（ファイル追加時に適用します） | 適用するプロンプトを選ぶ + 補足文 |
| サイドバー見出し | プロンプト一覧 | プロンプトの管理 |
| モデル未指定ラベル | デフォルト（Gemini 3.7 Flash） | 標準（Gemini 3.7 Flash） |
| 文書表示の注記 | （デフォルト選択） | （標準を選択） |
| ゲスト共通バッジ | デフォルト | 🔒 共通 (sr-only「（編集不可）」) / ログインユーザーはバッジ無し |
| 新規メニュー・モーダル | デフォルトプロンプトを追加 | テンプレートから追加 |
| 管理画面の節 | デフォルトプロンプト | プロンプトテンプレート |
| 管理画面の同期メッセージ | ゲストユーザー向けデフォルトプロンプト | ゲスト用共通プロンプト |

## 同梱した既存不具合の修正
- 「新規プロンプト」ドロップダウンが aside の `overflow-hidden` で左端が切れて「作成」「プレートから追加」としか読めない → 左寄せに変更
- サイドバーのバッジが「デフォル／ト」と語中で折れる → 折り返し・縮小を禁止
- モバイル幅でプロンプト選択の fieldset がカードを突き抜けページ幅が 565px になる (本番でも再現) → `min-w-0` で 390px に収束

## 検証
- `tsc --noEmit` エラー 0 / `vitest run` 67 files・1004 tests passed
- Firebase エミュレータ + 実 Chrome でゲスト・ログイン後・管理画面・モバイル幅を撮影し目視。DOM に「デフォルト」残存 0
- lib 層の例外文言 (adminSettings.ts / prompts.ts) は画面に基本出ないため据え置き

🤖 Generated with [Claude Code](https://claude.com/claude-code)
