### PR TITLE
fix(UI): スマホでロゴが切れる/「標準」の語衝突/お知らせ画面のゲスト誤エラーを修正

### DIFF
--- a/src/app/(dashboard)/notifications/page.test.tsx
+++ b/src/app/(dashboard)/notifications/page.test.tsx
@@ -282,6 +282,15 @@ describe('NotificationsPage', () => {
         expect(arrayUnion).toHaveBeenCalledWith('notification-2');
     });
 
+    it('未ログインでは既読化エラーの警告を出さない（uid 不在同士の一致を誤検出しない）', () => {
+        vi.mocked(useAuth).mockReturnValue({ user: null, loading: false } as never);
+        const { tree } = renderContent();
+
+        expect(getText(tree)).not.toContain('全てのお知らせを既読にできませんでした');
+        expect(findButton(tree, 'もう一度既読にする')).toBeNull();
+        expect(findButton(tree, '全て既読にする')).toBeNull();
+    });
+
     it('本体コラムは左揃えの読み幅制限で、中央寄せ（mx-auto）へ戻さない', () => {
         const { tree } = renderContent();
         const container = findElement(

--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -94,7 +94,9 @@ function NotificationsPageContent() {
         : [];
     const hasUnread = unreadIds.length > 0;
     const isMarkingAllAsRead = Boolean(activeReadMutation?.saving);
-    const markReadError = markReadErrorUid === currentUid;
+    // 未ログインは currentUid が null。エラー未発生(null)との一致を「エラー」と誤検出しないよう
+    // エラーが記録済みであることを先に確かめる（ゲストで開くだけで赤帯が出ていた）。
+    const markReadError = markReadErrorUid !== null && markReadErrorUid === currentUid;
 
     const handleMarkAllAsRead = async () => {
         if (!user?.uid) return;

--- a/src/components/AppHeader.test.tsx
+++ b/src/components/AppHeader.test.tsx
@@ -162,8 +162,15 @@ describe('AppHeader ナビゲーション (E3)', () => {
         expect(navLikeTags.every(tag => tag.includes('min-h-11'))).toBe(true);
     });
 
-    it('中央固定のための 3 カラムグリッドを使う', () => {
-        expect(render()).toContain('grid-cols-[1fr_auto_1fr]');
+    it('デスクトップは中央固定の 3 カラム、モバイルは 2 カラム（空の右列でロゴ幅を奪わない）', () => {
+        const html = render();
+        const gridTag = html.match(/<div class="[^"]*\bgrid h-20[^"]*"/)?.[0] ?? '';
+
+        expect(gridTag).toContain('lg:grid-cols-[1fr_auto_1fr]');
+        expect(gridTag).toContain('grid-cols-[minmax(0,1fr)_auto]');
+        // 接頭辞なしの 3 カラムが残ると、モバイルで空の右列が幅の半分を取り
+        // ワードマークがメニューボタンと重なる（390px 実測で 15px 重複）。
+        expect(gridTag).not.toMatch(/[\s"]grid-cols-\[1fr_auto_1fr\]/);
     });
 });
 

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -254,7 +254,9 @@ export const AppHeader: React.FC = () => {
     return (
         <header className="sticky top-0 z-40 border-b border-elevation-persistent-boundary bg-surface shadow-elevation-persistent">
             <div className="container mx-auto max-w-7xl px-4">
-                <div className="grid h-20 grid-cols-[1fr_auto_1fr] items-center gap-3 py-2">
+                {/* モバイルはナビが非表示で 2 要素だけになるため 2 列にする。3 列のままだと空の右列が
+                    幅の半分を取り、ロゴ列が 390px 幅で不足してワードマークがメニューボタンと重なる。 */}
+                <div className="grid h-20 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-2 lg:grid-cols-[1fr_auto_1fr]">
                     {/* 左側: ロゴとタイトル */}
                     <div className="flex min-w-0 items-center">
                         <Link
@@ -268,7 +270,7 @@ export const AppHeader: React.FC = () => {
                             >
                                 <Music className="h-6 w-6 text-white" />
                             </span>
-                            <span className="whitespace-nowrap text-xl font-bold text-text-primary sm:text-2xl">
+                            <span className="truncate text-xl font-bold text-text-primary sm:text-2xl">
                                 商談くんミニ
                             </span>
                             <span className="hidden shrink-0 rounded-full border border-brand-border bg-brand-subtle px-2 py-0.5 text-xs font-bold text-brand sm:inline">

--- a/src/components/DocumentDetailPanel.test.tsx
+++ b/src/components/DocumentDetailPanel.test.tsx
@@ -646,7 +646,7 @@ describe('DocumentDetailPanel', () => {
         }) as React.ReactNode;
 
         expect(getText(tree)).toContain('使用モデル: Gemini 3.7 Flash');
-        expect(getText(tree)).not.toContain('標準を選択');
+        expect(getText(tree)).not.toContain('（おまかせ）');
     });
 
     it('デフォルト選択で生成した文書には注記を添える', () => {
@@ -661,7 +661,7 @@ describe('DocumentDetailPanel', () => {
         }) as React.ReactNode;
 
         expect(getText(tree)).toContain(
-            '使用モデル: Gemini 3.7 Flash（標準を選択）',
+            '使用モデル: Gemini 3.7 Flash（おまかせ）',
         );
     });
 
@@ -1694,7 +1694,7 @@ describe('DocumentPrintPortal PDF テーマ', () => {
 
         expect(header).not.toBeNull();
         expect(getText(PdfDocumentHeader(header!.props))).toContain(
-            '使用モデルGemini 3.7 Flash（標準を選択）・思考: 標準',
+            '使用モデルGemini 3.7 Flash（おまかせ）・思考: 標準',
         );
     });
 

--- a/src/components/DocumentDetailPanel.tsx
+++ b/src/components/DocumentDetailPanel.tsx
@@ -606,7 +606,7 @@ export function DocumentDetailPanelView({
                             {document.generatedByModel && (
                                 <p>
                                     使用モデル: {getGeminiModelLabel(document.generatedByModel)}
-                                    {document.modelSelection === 'default' && '（標準を選択）'}
+                                    {document.modelSelection === 'default' && '（おまかせ）'}
                                     {document.generatedByThinkingLevel &&
                                         `・思考: ${getThinkingLevelLabel(document.generatedByThinkingLevel)}`}
                                 </p>

--- a/src/components/ModelComparisonTable.tsx
+++ b/src/components/ModelComparisonTable.tsx
@@ -51,7 +51,7 @@ export const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
     const resolvedDefaultModel = resolveGeminiModel(GEMINI_DEFAULT_MODEL_SENTINEL);
     const defaultOption = {
         value: GEMINI_DEFAULT_MODEL_SENTINEL,
-        label: `標準（現在: ${getGeminiModelLabel(resolvedDefaultModel)}）`,
+        label: `おまかせ（現在: ${getGeminiModelLabel(resolvedDefaultModel)}）`,
         description: 'アプリの推奨モデルに自動追従します',
     };
     const comparisonOptions = [defaultOption, ...GEMINI_MODEL_OPTIONS];

--- a/src/components/PdfDocumentHeader.tsx
+++ b/src/components/PdfDocumentHeader.tsx
@@ -37,7 +37,7 @@ export function PdfDocumentHeader({
                         <dt>使用モデル</dt>
                         <dd>
                             {getGeminiModelLabel(document.generatedByModel)}
-                            {document.modelSelection === 'default' && '（標準を選択）'}
+                            {document.modelSelection === 'default' && '（おまかせ）'}
                             {document.generatedByThinkingLevel &&
                                 `・思考: ${getThinkingLevelLabel(document.generatedByThinkingLevel)}`}
                         </dd>

--- a/src/constants/geminiModels.test.ts
+++ b/src/constants/geminiModels.test.ts
@@ -118,7 +118,7 @@ describe('geminiModels', () => {
             );
             expect(defaultOption).toBeDefined();
             expect(getGeminiModelLabel(GEMINI_DEFAULT_MODEL_SENTINEL)).toBe(
-                `標準（${defaultOption?.label}）`,
+                `おまかせ（${defaultOption?.label}）`,
             );
         });
 

--- a/src/constants/geminiModels.ts
+++ b/src/constants/geminiModels.ts
@@ -220,7 +220,7 @@ export function getGeminiModelLabel(model?: string | null): string {
     if (canonicalModel === GEMINI_DEFAULT_MODEL_SENTINEL) {
         const defaultModelLabel = GEMINI_MODEL_MAP.get(DEFAULT_GEMINI_MODEL)?.label
             ?? DEFAULT_GEMINI_MODEL;
-        return `標準（${defaultModelLabel}）`;
+        return `おまかせ（${defaultModelLabel}）`;
     }
     return GEMINI_MODEL_MAP.get(canonicalModel)?.label || canonicalModel;
 }


### PR DESCRIPTION
## 変更の趣旨
前回の文言整理 (#1) の目視で見つかった 3 件の修正です。

### 1. スマホでアプリ名がメニューボタンと重なる
ヘッダーは常に 3 列グリッド (`1fr_auto_1fr`) でしたが、モバイルではナビが非表示で要素が 2 つしか無く、空の右列が幅の半分を取ってロゴ列が不足していました。

| 画面幅 | 修正前 (本番実測) | 修正後 |
|---|---|---|
| 360px | 「商談くんミ」で切れ、30px 重なる | 重なりなし |
| 390px | 15px 重なる | 重なりなし |
| 430px | 問題なし | 問題なし |

モバイルは `grid-cols-[minmax(0,1fr)_auto]`、`lg` 以上で従来の 3 列に戻します。

### 2. 「標準」の語衝突
モデル未指定のラベル「標準（Gemini 3.7 Flash）」が、思考レベルの「標準（推奨）」「思考: 標準」と同じ画面に並んでいました。PDF フォントの「テーマおまかせ」と同じ語を使い「おまかせ（Gemini 3.7 Flash）」に変更します (比較表は「おまかせ（現在: …）」、文書情報の注記は「（おまかせ）」)。

### 3. お知らせ画面をログインせずに開くと赤帯が出る
「全てのお知らせを既読にできませんでした」の判定が `markReadErrorUid === currentUid` で、ゲストは両方 `null` のため常に真でした。エラーが記録済みであることを先に確かめます。

## 検証
- `tsc --noEmit` 0 / `vitest run` 67 files・1005 tests passed (新規 2 件)
- 新規テスト 2 件は修正前コードで落ちることを変異注入で確認 (ヘッダー錠は接頭辞なし 3 列の残存も拒否)
- Firebase エミュレータ + 実 Chrome で 360/390/430px のヘッダー、ゲスト/ログイン後のお知らせ画面、編集モーダルのラベル並びを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
