### PR TITLE
feat(モデル): Gemini 3.8 Flash を追加し★を再基準化・比較表を全幅で表示

### DIFF
--- a/src/components/ModelComparisonTable.test.tsx
+++ b/src/components/ModelComparisonTable.test.tsx
@@ -66,3 +66,23 @@ describe('ModelComboboxSelect', () => {
         expect(markup).toMatch(/<button[^>]*class="[^"]*min-h-11[^"]*"/);
     });
 });
+
+describe('ModelComparisonTable: 3.8 Flash と表幅 (2026-09-03)', () => {
+    it('3.8 Flash にもプロモ期限が付く（3.7・3.8・おまかせ→3.7 の 3 行 × mobile/desktop = 6 回）', () => {
+        const markup = renderToStaticMarkup(
+            <ModelComparisonTable selectedModel="gemini-3.8-flash" />,
+        );
+        expect(markup).toContain('Gemini 3.8 Flash');
+        const promoRows = ['gemini-3.7-flash', 'gemini-3.8-flash', 'default'].length;
+        expect(markup.match(/期限2026\/12\/31/g)).toHaveLength(promoRows * 2);
+    });
+
+    it('デスクトップ表の最小幅は 48rem（モーダル全幅 ≈844px に収まる）で、おすすめ列は min-w-48', () => {
+        const markup = renderToStaticMarkup(
+            <ModelComparisonTable selectedModel="default" />,
+        );
+        expect(markup).toContain('min-w-[48rem]');
+        expect(markup).not.toContain('min-w-[56rem]');
+        expect(markup).not.toContain('min-w-80');
+    });
+});

--- a/src/components/ModelComparisonTable.tsx
+++ b/src/components/ModelComparisonTable.tsx
@@ -6,6 +6,7 @@ import {
     GEMINI_MODEL_OPTIONS,
     getGeminiModelLabel,
     getGeminiPricingLabelShort,
+    hasIntroductoryPricing,
     resolveGeminiModel,
 } from '../constants/geminiModels';
 
@@ -63,7 +64,7 @@ export const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
         return (
             <span>
                 {priceLabel}
-                {model === 'gemini-3.7-flash' && (
+                {hasIntroductoryPricing(model) && (
                     <span className="mt-1 block text-[10px] font-medium text-amber-700">
                         プロモ価格（期限2026/12/31）
                     </span>
@@ -227,7 +228,7 @@ export const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                 role={onSelect ? 'radiogroup' : undefined}
                 aria-label={onSelect ? 'モデルを選択' : undefined}
             >
-                <table className="w-full min-w-[56rem] text-xs">
+                <table className="w-full min-w-[48rem] text-xs">
                     <caption className="sr-only">Geminiモデル性能比較</caption>
                     <thead className="border-b border-gray-200 bg-gray-50">
                         <tr>
@@ -263,7 +264,7 @@ export const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                             <th scope="col" className="px-3 py-2 text-left font-semibold text-gray-700 whitespace-nowrap">
                                 料金（1Mトークン）
                             </th>
-                            <th scope="col" className="min-w-80 px-3 py-2 text-left font-semibold text-gray-700">
+                            <th scope="col" className="min-w-48 px-3 py-2 text-left font-semibold text-gray-700">
                                 おすすめ用途
                             </th>
                         </tr>
@@ -308,11 +309,11 @@ export const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                                             </label>
                                         </td>
                                     )}
-                                    <th scope="row" className="px-3 py-4 text-left font-medium text-gray-900 whitespace-nowrap">
-                                        <div className="flex items-center gap-1.5">
+                                    <th scope="row" className="min-w-44 px-3 py-4 text-left font-medium text-gray-900">
+                                        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
                                             <span>{option.label}</span>
                                             {isDefaultOption && (
-                                                <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700">
+                                                <span className="shrink-0 whitespace-nowrap rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700">
                                                     現在の既定
                                                 </span>
                                             )}
@@ -355,10 +356,10 @@ export const ModelComparisonTable: React.FC<ModelComparisonTableProps> = ({
                                             <span className="text-gray-400">-</span>
                                         )}
                                     </td>
-                                    <td className="px-3 py-4 text-gray-700 whitespace-nowrap">
+                                    <td className="px-3 py-4 text-gray-700">
                                         {renderPrice(metadataModel)}
                                     </td>
-                                    <td className="min-w-80 px-3 py-4 text-gray-700">
+                                    <td className="min-w-48 px-3 py-4 text-gray-700">
                                         {benchmark?.recommendedFor ?? '-'}
                                     </td>
                                 </tr>

--- a/src/components/PromptCreateModal.tsx
+++ b/src/components/PromptCreateModal.tsx
@@ -365,7 +365,8 @@ export const PromptCreateModal: React.FC<PromptCreateModalProps> = ({
                             </div>
 
                             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                                <div>
+                                {/* 比較表を開いている間は 2 列ぶち抜き（:has で状態を持たずに判定・左列だけだと 6 列中 2 列しか見えない） */}
+                                <div className="md:has-[[aria-expanded=true]]:col-span-2">
                                     <span className="mb-2 block text-sm font-medium text-gray-700">
                                         使用するGeminiモデル
                                     </span>

--- a/src/components/PromptEditModal.tsx
+++ b/src/components/PromptEditModal.tsx
@@ -152,7 +152,8 @@ const PromptModelField: React.FC<PromptModelFieldProps> = ({
 
     return (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div className="space-y-2">
+            {/* 比較表を開いている間は 2 列ぶち抜き（:has で状態を持たずに判定・左列だけだと 6 列中 2 列しか見えない） */}
+            <div className="space-y-2 md:has-[[aria-expanded=true]]:col-span-2">
                 <span className="block text-sm font-semibold text-gray-700">
                     使用するGeminiモデル
                 </span>

--- a/src/components/admin/DefaultPromptEditModal.tsx
+++ b/src/components/admin/DefaultPromptEditModal.tsx
@@ -464,7 +464,8 @@ export default function DefaultPromptEditModal({
 
                     <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
                         {/* Geminiモデル選択 */}
-                        <div>
+                        {/* 比較表を開いている間は 2 列ぶち抜き（:has で状態を持たずに判定・左列だけだと 6 列中 2 列しか見えない） */}
+                        <div className="md:has-[[aria-expanded=true]]:col-span-2">
                             <span className="block text-sm font-semibold text-gray-700 mb-2">
                                 使用するGeminiモデル
                             </span>

--- a/src/components/modelFieldLayout.test.ts
+++ b/src/components/modelFieldLayout.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * モデル選択の「性能を比較」表は 6 列あり、2 列グリッドの左列（約 400px）に置くと
+ * 2 列しか見えない。比較表が開いている間（トリガーの aria-expanded="true"）だけ
+ * モデル欄を 2 列ぶち抜きにする。状態を持たず :has() で判定するので、
+ * 3 つのモーダルすべてで同じクラスが必要。
+ */
+const SPAN_CLASS = 'md:has-[[aria-expanded=true]]:col-span-2';
+const MODAL_FILES = [
+    'src/components/PromptEditModal.tsx',
+    'src/components/PromptCreateModal.tsx',
+    'src/components/admin/DefaultPromptEditModal.tsx',
+];
+
+function stripComments(source: string): string {
+    return source.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+describe('モデル選択欄のレイアウト錠', () => {
+    it.each(MODAL_FILES)('%s: ModelComboboxSelect を包む欄が比較表を開くと 2 列ぶち抜きになる', file => {
+        const source = stripComments(readFileSync(resolve(process.cwd(), file), 'utf8'));
+        const mount = source.indexOf('<ModelComboboxSelect');
+        expect(mount).toBeGreaterThan(0);
+        const before = source.slice(Math.max(0, mount - 700), mount);
+        expect(before).toContain('md:grid-cols-2');
+        const wrapperOpen = before.lastIndexOf('<div');
+        const wrapperTag = before.slice(wrapperOpen);
+        expect(wrapperTag).toContain(SPAN_CLASS);
+    });
+
+    it('錠の自己検査: クラスを外した断片では落ちる', () => {
+        const fragment = '<div className="grid md:grid-cols-2"><div className="space-y-2"><ModelComboboxSelect />';
+        const mount = fragment.indexOf('<ModelComboboxSelect');
+        const before = fragment.slice(0, mount);
+        const wrapperTag = before.slice(before.lastIndexOf('<div'));
+        expect(wrapperTag).not.toContain(SPAN_CLASS);
+    });
+});

--- a/src/constants/geminiModels.test.ts
+++ b/src/constants/geminiModels.test.ts
@@ -6,6 +6,7 @@ import {
     canonicalizeGeminiModel,
     getGeminiModelLabel,
     getGeminiPricingLabelShort,
+    hasIntroductoryPricing,
     resolveGeminiModel,
 } from './geminiModels';
 
@@ -448,5 +449,49 @@ describe('reducePromptEditSession', () => {
 
         expect(backToSupported.draft.thinkingLevel).toBe('high');
         expect(hasPromptEditChanges(backToSupported)).toBe(false);
+    });
+});
+
+describe('Gemini 3.8 Flash の追加と★の再基準化 (2026-09-03)', () => {
+    const stars = (value: string) => {
+        const option = GEMINI_MODEL_OPTIONS.find(o => o.value === value);
+        if (!option?.benchmark) throw new Error(`benchmark not found: ${value}`);
+        return option.benchmark;
+    };
+
+    it('3.8 Flash が先頭の選択肢で、ラベルとプロモ価格を持つ', () => {
+        expect(GEMINI_MODEL_OPTIONS[0].value).toBe('gemini-3.8-flash');
+        expect(getGeminiModelLabel('gemini-3.8-flash')).toBe('Gemini 3.8 Flash');
+        expect(getGeminiPricingLabelShort('gemini-3.8-flash')).toBe('入力 $0.75 / 出力 $3.75');
+    });
+
+    it('プロモ価格の注記は 3.7 と 3.8 の両方に付き、他には付かない', () => {
+        expect(hasIntroductoryPricing('gemini-3.7-flash')).toBe(true);
+        expect(hasIntroductoryPricing('gemini-3.8-flash')).toBe(true);
+        expect(hasIntroductoryPricing('gemini-3.5-flash')).toBe(false);
+        expect(hasIntroductoryPricing(DEFAULT_GEMINI_MODEL)).toBe(true);
+    });
+
+    it('★は 3.8 Flash を最上位(5/5)として世代順に単調に下がる', () => {
+        expect(stars('gemini-3.8-flash')).toMatchObject({ recognitionQuality: 5, analysisQuality: 5 });
+        expect(stars('gemini-3.7-flash')).toMatchObject({ recognitionQuality: 5, analysisQuality: 4 });
+        expect(stars('gemini-3.5-flash')).toMatchObject({ recognitionQuality: 4, analysisQuality: 4 });
+        expect(stars('gemini-3.1-pro-preview').analysisQuality).toBe(3);
+        expect(stars('gemini-2.5-pro').analysisQuality).toBe(2);
+        expect(stars('gemini-2.5-flash-lite').analysisQuality).toBe(1);
+        const flashGenerations = ['gemini-3.8-flash', 'gemini-3.7-flash', 'gemini-3.5-flash', 'gemini-2.5-flash'];
+        for (let i = 1; i < flashGenerations.length; i += 1) {
+            expect(stars(flashGenerations[i]).analysisQuality).toBeLessThanOrEqual(stars(flashGenerations[i - 1]).analysisQuality);
+            expect(stars(flashGenerations[i]).recognitionQuality).toBeLessThanOrEqual(stars(flashGenerations[i - 1]).recognitionQuality);
+        }
+        // 「差が見える」錠: 3 モデル以上が両軸とも 5/5 で並ぶ状態には戻さない
+        const topTies = GEMINI_MODEL_OPTIONS.filter(o => o.benchmark?.recognitionQuality === 5 && o.benchmark?.analysisQuality === 5);
+        expect(topTies.map(o => o.value)).toEqual(['gemini-3.8-flash']);
+    });
+
+    it('3.8 Flash の体感時間は 3.7 Flash と同じ★帯（同速度）', () => {
+        const s38 = stars('gemini-3.8-flash').estimatedSeconds;
+        const s37 = stars('gemini-3.7-flash').estimatedSeconds;
+        expect(Math.abs(s38 - s37)).toBeLessThanOrEqual(5);
     });
 });

--- a/src/constants/geminiModels.test.ts
+++ b/src/constants/geminiModels.test.ts
@@ -459,8 +459,10 @@ describe('Gemini 3.8 Flash の追加と★の再基準化 (2026-09-03)', () => {
         return option.benchmark;
     };
 
-    it('3.8 Flash が先頭の選択肢で、ラベルとプロモ価格を持つ', () => {
+    it('3.8 Flash が先頭の選択肢かつ既定モデルで、ラベルとプロモ価格を持つ', () => {
         expect(GEMINI_MODEL_OPTIONS[0].value).toBe('gemini-3.8-flash');
+        expect(DEFAULT_GEMINI_MODEL).toBe('gemini-3.8-flash');
+        expect(resolveGeminiModel('default')).toBe('gemini-3.8-flash');
         expect(getGeminiModelLabel('gemini-3.8-flash')).toBe('Gemini 3.8 Flash');
         expect(getGeminiPricingLabelShort('gemini-3.8-flash')).toBe('入力 $0.75 / 出力 $3.75');
     });

--- a/src/constants/geminiModels.ts
+++ b/src/constants/geminiModels.ts
@@ -50,7 +50,7 @@ export interface GeminiModelOption {
     benchmark?: GeminiModelBenchmark;
 }
 
-export const DEFAULT_GEMINI_MODEL = 'gemini-3.7-flash';
+export const DEFAULT_GEMINI_MODEL = 'gemini-3.8-flash';
 export const GEMINI_DEFAULT_MODEL_SENTINEL = 'default';
 
 /**
@@ -92,13 +92,13 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
             analysisQuality: 5,
             // 出力 ≈302 tok/s・TTFT 13.3s（Artificial Analysis 2026-09-03）。思考レベルは low/medium/high（minimal 不可・公式 docs）。
             estimatedSeconds: 41,
-            recommendedFor: '動画・音声→文書の総合おすすめ。3.7と同価格・同速度で分析品質が最高',
+            recommendedFor: '動画・音声→文書の総合おすすめ。現行の既定モデル（おまかせ）',
         },
     },
     {
         value: 'gemini-3.7-flash',
         label: 'Gemini 3.7 Flash',
-        description: '現行の既定モデル（2026-08 GA）。動画・音声・PDF入力対応、1Mコンテキスト。3.8 Flashと同価格・同速度',
+        description: '前世代のFlash（2026-08 GA）。動画・音声・PDF入力対応、1Mコンテキスト。3.8 Flashと同価格・同速度',
         // ⚠️ プロモ価格: 2026-12-31まで。2027-01-01から入力$1.50/出力$7.50に倍額（公式料金表に明記）。
         pricing: {
             inputPerMTok: 0.75,
@@ -110,7 +110,7 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
             analysisQuality: 4,
             // 出力 ≈287 tok/s・TTFT 11.4s（Artificial Analysis 2026-09-03）。⚠️思考は既定ON・レベルmedium（OFF不可・公式docs確認済2026-09-01）のため実測待ち時間には思考分が含まれる
             estimatedSeconds: 40,
-            recommendedFor: '動画・音声→文書の総合おすすめ。現行の既定モデル',
+            recommendedFor: '3.8 と同価格・同速度の前世代。固定したい場合の互換用途',
         },
     },
     {

--- a/src/constants/geminiModels.ts
+++ b/src/constants/geminiModels.ts
@@ -9,27 +9,31 @@ export interface GeminiModelPricing {
 }
 
 // 各モデルのベンチマーク評価。当サービス（音声/動画 → 文書）で重要な軸に絞っている。
+// ★は「現時点の最上位モデルを5とした相対評価」。新世代が出たら全体を再基準化する（最終再基準化: 2026-09-03、3.8 Flash 公開時）。
 //
 // recognitionQuality（動画・音声の認識力）: ★1〜5
-//   公式ベンチマークから相対順位を決定。
-//   - FLEURS WER（多言語音声書き起こし精度）
-//   - Video-MME（動画理解の総合スコア）
-//   - MMMU-Pro（マルチモーダル理解の補完指標）
-//   出典: Gemini 2.5 技術レポート (arxiv:2507.06261)、各モデル公式モデルカード。
+//   Gemini 3 系は公式に音声ベンチを公開していないため、モデルカード（同一手法・同一表内）の
+//   動画/図表理解で相対順位を決める。3.8 Flash は 3.7 Flash ベースで音声経路は同一。
+//   - LVBench（長尺動画理解）: 3.8=87.1 / 3.7=85.4 / 3.6=84.2（3.5 は未掲載）
+//   - CharXiv Reasoning（図表からの情報統合）: 3.8=86.2 / 3.7=84.5 / 3.6=85.2 / 3.5=84.2
+//   出典: Gemini 3.8 / 3.7 / 3.6 Flash Model Card（deepmind.google/models/model-cards）。
+//   2.5 系は Gemini 2.5 技術レポート (arxiv:2507.06261) の FLEURS / Video-MME による従来評価を据え置き。
 //
 // analysisQuality（分析・出力品質）: ★1〜5
-//   プロンプト指示への追従と推論能力を相対評価。
-//   - IFEval（指示追従の遵守度）
-//   - MMMU-Pro（マルチモーダル推論）
-//   - GPQA Diamond（難問理解）
-//   出典: Artificial Analysis、各モデル公式モデルカード。
+//   全モデルを同じ物差しで並べるため Artificial Analysis Intelligence Index（推論あり版・2026-09-03 取得）を帯で★化:
+//     ≥58 → ★5 / 50〜57 → ★4 / 40〜49 → ★3 / 25〜39 → ★2 / <25 → ★1
+//   実測値: 3.8 Flash=59 / 3.7 Flash=56 / 3.5 Flash=52 / 3.5 Flash Lite=37 / 3.1 Pro=48 / 2.5 Pro=26 / 2.5 Flash Lite=7
+//   （3 Pro は同サイトから削除済みのため 3.1 Pro と同帯、2.5 Flash は推論版の掲載が無く 2.5 Pro と同帯に置く）
+//   補助指標（同一モデルカード表）: DeepSWE 3.8=73.7 / 3.7=65.3、HLE-Verified 3.8=54.9 / 3.7=53.6、OSWorld-2.0 3.8=59.0 / 3.7=50.6。
+//   ⚠ この指標はコーディング/エージェント課題の比重が大きく、「音声→議事録」の品質そのものではない。
 //
 // estimatedSeconds（速度の素データ）: 「2時間音声 → A4 1〜2枚」の体感処理時間（秒）
 //   計算式: 入力処理時間 + 思考時間（推論モデルのみ） + 出力tokens ÷ 出力tok/s
 //   - 入力: 音声 32 tokens/sec × 7,200秒 = 230,400 tokens（Gemini API 公式レート）
 //   - 出力: 約 3,000 tokens 想定（A4 1〜2枚相当）
 //   - 出力 tok/s: Artificial Analysis 実測（Flash 系 ≈199 / Pro 系 ≈120-150）
-//   - 思考時間: 推論モデルは TTFT 実測（3.5 Flash ≈22.8s）から逆算
+//   - 思考時間: Artificial Analysis の TTFT 実測（2026-09-03: 3.8 Flash 13.3s / 3.7 Flash 11.4s / 3.5 Flash 13.9s /
+//     3.5 Flash Lite 7.6s / 3.1 Pro 22.2s / 2.5 Pro 24.8s）を採用。入力処理は 18s で固定（3.7 Flash の実測 40s から逆算）。
 //   表示時は ModelComparisonTable 内の speedRatingFromSeconds で★に変換。
 export interface GeminiModelBenchmark {
     recognitionQuality: 1 | 2 | 3 | 4 | 5;
@@ -75,10 +79,10 @@ export function resolveGeminiModel(model?: string | null): string {
 // 配列順 = ドロップダウン・比較表での表示順。新しい世代のモデルを上に並べる。
 export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
     {
-        value: 'gemini-3.7-flash',
-        label: 'Gemini 3.7 Flash',
-        description: 'Google推奨の現行フラッグシップFlash（2026-08 GA）。動画・音声・PDF入力対応、1Mコンテキスト。3.5 Flashより高速・低価格',
-        // ⚠️ プロモ価格: 2026-12-31まで。2027-01-01から入力$1.50/出力$7.50に倍額（公式料金表に明記）。
+        value: 'gemini-3.8-flash',
+        label: 'Gemini 3.8 Flash',
+        description: 'Google最新のFlash（2026-09-02 GA、3.7 Flashベース）。動画・音声・PDF入力対応、1Mコンテキスト。3.7と同価格・同速度で分析・エージェント性能が向上',
+        // ⚠️ プロモ価格: 3.7 Flash と同じく 2026-12-31 まで。2027-01-01 から入力$1.50/出力$7.50に倍額（公式料金表・モデルカードに明記）。
         pricing: {
             inputPerMTok: 0.75,
             outputPerMTok: 3.75,
@@ -86,7 +90,25 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
         benchmark: {
             recognitionQuality: 5,
             analysisQuality: 5,
-            // 出力 ≈287-308 tok/s（Artificial Analysis実測）。⚠️思考は既定ON・レベルmedium（OFF不可・公式docs確認済2026-09-01）のため実測待ち時間には思考分が含まれる
+            // 出力 ≈302 tok/s・TTFT 13.3s（Artificial Analysis 2026-09-03）。思考レベルは low/medium/high（minimal 不可・公式 docs）。
+            estimatedSeconds: 41,
+            recommendedFor: '動画・音声→文書の総合おすすめ。3.7と同価格・同速度で分析品質が最高',
+        },
+    },
+    {
+        value: 'gemini-3.7-flash',
+        label: 'Gemini 3.7 Flash',
+        description: '現行の既定モデル（2026-08 GA）。動画・音声・PDF入力対応、1Mコンテキスト。3.8 Flashと同価格・同速度',
+        // ⚠️ プロモ価格: 2026-12-31まで。2027-01-01から入力$1.50/出力$7.50に倍額（公式料金表に明記）。
+        pricing: {
+            inputPerMTok: 0.75,
+            outputPerMTok: 3.75,
+        },
+        benchmark: {
+            recognitionQuality: 5,
+            // Intelligence Index 56 → ★4（3.8 Flash=59 を★5に再基準化）
+            analysisQuality: 4,
+            // 出力 ≈287 tok/s・TTFT 11.4s（Artificial Analysis 2026-09-03）。⚠️思考は既定ON・レベルmedium（OFF不可・公式docs確認済2026-09-01）のため実測待ち時間には思考分が含まれる
             estimatedSeconds: 40,
             recommendedFor: '動画・音声→文書の総合おすすめ。現行の既定モデル',
         },
@@ -100,10 +122,11 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
             outputPerMTok: 9.0,
         },
         benchmark: {
-            recognitionQuality: 5,
-            analysisQuality: 5,
-            estimatedSeconds: 60,
-            recommendedFor: '動画・音声→文書の総合おすすめ。品質最高クラス',
+            // CharXiv 84.2（3.8=86.2）・2世代前 → ★4 / Intelligence Index 52 → ★4 / 189 tok/s・TTFT 13.9s
+            recognitionQuality: 4,
+            analysisQuality: 4,
+            estimatedSeconds: 48,
+            recommendedFor: '前世代のFlash。認識力は高いが 3.7/3.8 より価格が2倍',
         },
     },
     {
@@ -115,9 +138,10 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
             outputPerMTok: 2.5,
         },
         benchmark: {
+            // Intelligence Index 37 → ★2 / 347 tok/s・TTFT 7.6s
             recognitionQuality: 3,
-            analysisQuality: 3,
-            estimatedSeconds: 30,
+            analysisQuality: 2,
+            estimatedSeconds: 34,
             recommendedFor: '大量バッチ処理・コスト重視の運用',
         },
     },
@@ -135,10 +159,11 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
             },
         },
         benchmark: {
+            // Intelligence Index 48 → ★3 / 102 tok/s・TTFT 22.2s
             recognitionQuality: 4,
-            analysisQuality: 5,
-            estimatedSeconds: 95,
-            recommendedFor: '最高難度の推論・専門的な解析',
+            analysisQuality: 3,
+            estimatedSeconds: 70,
+            recommendedFor: '深い推論が要る専門的な解析（現行Flashより低速・高価格）',
         },
     },
     {
@@ -155,8 +180,9 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
             },
         },
         benchmark: {
+            // Artificial Analysis に掲載無し → 3.1 Pro と同帯 ★3（速度は据え置き）
             recognitionQuality: 4,
-            analysisQuality: 5,
+            analysisQuality: 3,
             estimatedSeconds: 85,
             recommendedFor: '複雑な構造化文書・難しい要約',
         },
@@ -170,8 +196,9 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
             outputPerMTok: 0.4,
         },
         benchmark: {
+            // Intelligence Index 7（非推論版）→ ★1
             recognitionQuality: 2,
-            analysisQuality: 2,
+            analysisQuality: 1,
             estimatedSeconds: 30,
             recommendedFor: '大量バッチ処理・最安運用',
         },
@@ -185,8 +212,9 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
             outputPerMTok: 2.5,
         },
         benchmark: {
+            // 推論版の掲載無し → 2.5 Pro と同帯 ★2
             recognitionQuality: 3,
-            analysisQuality: 3,
+            analysisQuality: 2,
             estimatedSeconds: 35,
             recommendedFor: '日常的な変換・標準利用',
         },
@@ -194,7 +222,7 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
     {
         value: 'gemini-2.5-pro',
         label: 'Gemini 2.5 Pro',
-        description: '複雑な推論・コーディング・マルチモーダルタスク向けフラッグシップ。最高精度だがコスト高',
+        description: '2.5世代のフラッグシップ。当時は最高精度だったが現行の3.x Flashに品質・価格とも劣る',
         pricing: {
             inputPerMTok: 1.25,
             outputPerMTok: 10.0,
@@ -205,10 +233,11 @@ export const GEMINI_MODEL_OPTIONS: GeminiModelOption[] = [
             },
         },
         benchmark: {
+            // Intelligence Index 26 → ★2 / 122 tok/s・TTFT 24.8s
             recognitionQuality: 4,
-            analysisQuality: 4,
-            estimatedSeconds: 55,
-            recommendedFor: '安定運用したい高品質な文書生成',
+            analysisQuality: 2,
+            estimatedSeconds: 67,
+            recommendedFor: '旧世代の互換用途。現行Flashより低品質・高価格',
         },
     },
 ];
@@ -236,4 +265,14 @@ export function getGeminiPricingLabelShort(model: string): string | undefined {
     const pricing = GEMINI_MODEL_MAP.get(resolveGeminiModel(model))?.pricing;
     if (!pricing) return undefined;
     return `入力 ${PRICE_FORMATTER.format(pricing.inputPerMTok)} / 出力 ${PRICE_FORMATTER.format(pricing.outputPerMTok)}`;
+}
+
+/**
+ * プロモ価格（2026-12-31 まで）が適用されるモデル。
+ * 2027-01-01 に入力 $1.50 / 出力 $7.50 へ倍額（公式料金表・モデルカードに明記）。
+ */
+const INTRODUCTORY_PRICING_MODELS = new Set(['gemini-3.7-flash', 'gemini-3.8-flash']);
+
+export function hasIntroductoryPricing(model: string): boolean {
+    return INTRODUCTORY_PRICING_MODELS.has(model);
 }

--- a/src/constants/geminiThinking.test.ts
+++ b/src/constants/geminiThinking.test.ts
@@ -104,3 +104,23 @@ describe('geminiThinking', () => {
         });
     });
 });
+
+describe('Gemini 3.8 系の思考レベル対応 (2026-09-03)', () => {
+    it.each([
+        ['default', 'MEDIUM'],
+        ['low', 'LOW'],
+        ['medium', 'MEDIUM'],
+        ['high', 'HIGH'],
+    ])('Gemini 3.8 系では %s を %s に解決する', (level, expected) => {
+        expect(resolveThinkingLevelForModel(level, 'gemini-3.8-flash')).toBe(expected);
+    });
+
+    it('前方一致により将来の Gemini 3.8 系モデルにも適用する', () => {
+        expect(resolveThinkingLevelForModel('high', 'gemini-3.8-flash-preview')).toBe('HIGH');
+    });
+
+    it('3.8 と紛らわしい非対応 ID では undefined を返す', () => {
+        expect(resolveThinkingLevelForModel('high', 'gemini-3.8')).toBeUndefined();
+        expect(resolveThinkingLevelForModel('high', 'gemini-3.80-flash')).toBeUndefined();
+    });
+});

--- a/src/constants/geminiThinking.ts
+++ b/src/constants/geminiThinking.ts
@@ -33,7 +33,7 @@ const DEFAULT_THINKING_LEVEL: GeminiThinkingLevel = 'default';
 const THINKING_LEVEL_IDS = new Set<string>(THINKING_LEVELS.map(level => level.id));
 
 // 思考レベル指定に対応するモデル世代。対応モデルが増えたら prefix を追加する。
-const THINKING_LEVEL_MODEL_PREFIXES = ['gemini-3.7-'] as const;
+const THINKING_LEVEL_MODEL_PREFIXES = ['gemini-3.7-', 'gemini-3.8-'] as const;
 
 /**
  * Firestore/UI で扱う思考レベルを canonical な保存表現へ揃える。


### PR DESCRIPTION
## 変更の趣旨
Gemini 3.8 Flash (2026-09-02 公開) を選べるようにし、比較表の★を「現時点の最上位を 5 とする相対評価」で再基準化します。あわせて、比較表がモーダルの左列に押し込まれて 6 列中 1 列しか見えなかった問題を直します。

## 一次情報 (すべて 2026-09-03 取得)
- [Google 公式発表](https://blog.google/innovation-and-ai/models-and-research/gemini-models/3-8-flash-and-3-8-flash-cyber/): 3.7 と同速度・同価格、$0.75/$3.75 (2026-12-31 まで、以後 $1.50/$7.50)
- [Gemini API モデル一覧](https://ai.google.dev/gemini-api/docs/models): `gemini-3.8-flash` は Stable、音声・動画・PDF 入力、思考レベル low/medium/high (minimal 不可)
- [3.8 Flash モデルカード PDF](https://storage.googleapis.com/deepmind-media/Model-Cards/Gemini-3-8-Flash-Model-Card.pdf) の同一表: DeepSWE 73.7 vs 65.3、OSWorld-2.0 59.0 vs 50.6、HLE-Verified 54.9 vs 53.6、LVBench 87.1 vs 85.4、CharXiv 86.2 vs 84.5 (3.8 vs 3.7)
- [Artificial Analysis](https://artificialanalysis.ai/models/gemini-3-8-flash): Intelligence Index 3.8=59 / 3.7=56 / 3.5=52 / 3.5 Lite=37 / 3.1 Pro=48 / 2.5 Pro=26、出力 302 tok/s、TTFT 13.3s

## ★の変更 (認識力 / 分析)
| モデル | 変更前 | 変更後 | 根拠 |
|---|---|---|---|
| 3.8 Flash | (新規) | 5 / 5 | 最上位 |
| 3.7 Flash | 5 / 5 | 5 / 4 | AA 56 |
| 3.5 Flash | 5 / 5 | 4 / 4 | CharXiv 84.2 (2 世代前)・AA 52 |
| 3.5 Flash Lite | 3 / 3 | 3 / 2 | AA 37 |
| 3.1 Pro | 4 / 5 | 4 / 3 | AA 48 |
| 3 Pro | 4 / 5 | 4 / 3 | AA 掲載なし→3.1 Pro と同帯 |
| 2.5 Pro | 4 / 4 | 4 / 2 | AA 26 |
| 2.5 Flash | 3 / 3 | 3 / 2 | 推論版掲載なし→2.5 Pro と同帯 |
| 2.5 Flash Lite | 2 / 2 | 2 / 1 | AA 7 |

⚠ AA Intelligence Index はコーディング/エージェント課題の比重が大きく、「音声→議事録」の品質そのものではありません。音声ベンチは Gemini 3 系で非公開のため、認識力は同一モデルカード表の LVBench / CharXiv で順位付けしています。

## 比較表の幅
比較表を開いている間だけモデル欄を 2 列ぶち抜き (`md:has-[[aria-expanded=true]]:col-span-2`) にします。状態を持たず CSS の `:has()` で判定するので 3 つのモーダルに同じ 1 クラスを足すだけです。表の最小幅を 56rem→48rem、おすすめ列を min-w-80→48 に縮め、モデル名・価格セルの折り返しを許可しています。

## 既定モデル
「おまかせ」の既定を **3.8 Flash に切替** (2 コミット目)。保存済みプロンプトは `model='default'` のまま自動追従するので、マージ・配備直後から「おまかせ」の生成が 3.8 で走ります。3.7 は「前世代・固定したい場合の互換用途」の文言に変更。

## 検証
- `tsc --noEmit` 0 / vitest 全量 68 ファイル 1021 件緑 (新規テスト 16 件を含む)
- 変異注入: 3.8 の思考レベル prefix を外す / モーダルの col-span クラスを外す / 3.7 の★を 5 に戻す → 対応する錠 7 件が赤、復元で緑
- 実 Chrome (エミュレータ・1440px) で比較表の幅を実測

| | 枠の幅 | 表の幅 | 完全に見える列 | 横スクロール |
|---|---|---|---|---|
| 変更前 (本番) | 413px | 1098px | 1 / 6 | あり |
| 変更後 | 844px | 844px | 6 / 6 | なし |

- 390px (スマホ) はカード表示のまま (変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
