### PR TITLE
fix(S2): 全域調査の S2 所見 10 件を統合 (#6〜#15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+# CI ゲート (S2-7)
+#
+# main は Vercel の git 統合で即本番になる。ここで tsc / lint / vitest を回し、
+# main へのマージ条件 (branch protection の required status check) に使う。
+# ジョブ名 `check` は branch protection 側から参照するので変えない
+# (変えるときは docs/ops-runbook.md の「復旧後の恒久策」も併せて更新する)。
+#
+# ローカルで同じ手順を再現する: npm ci && npx tsc --noEmit && npm run lint && npm run test
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+# 同じブランチ/PR の古い実行は打ち切る (連続 push で走行が積み上がるのを防ぐ)
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NEXT_TELEMETRY_DISABLED: "1"
+  CI: "true"
+
+jobs:
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install (lockfile 厳密一致)
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -60,11 +60,11 @@ Thumbs.db
 /temp
 *.tmp
 
-# Firebase service account key
+# Firebase service account keys
+# 鍵はリポジトリ外 (~/.config 配下) に置き GOOGLE_APPLICATION_CREDENTIALS で指す
+# (docs/ops-runbook.md §3)。ここは誤って置いたときの保険。
 serviceAccountKey.json
-
-# docs
-/docs
+*-firebase-adminsdk-*.json
 
 # review-with-ai-agent
 /pre-commit-review-v3

--- a/README.md
+++ b/README.md
@@ -229,8 +229,16 @@ npm run dev
 
 1. [Firebase Console](https://console.firebase.google.com/) > プロジェクト設定 > **サービスアカウント**
 2. 「**新しい秘密鍵の生成**」をクリック
-3. ダウンロードした JSON ファイルをプロジェクトルートに配置
-4. ファイル名を `serviceAccountKey.json` に変更
+3. ダウンロードした JSON ファイルを **リポジトリの外** (`~/.config/gcloud/keys/`) に移動し、`GOOGLE_APPLICATION_CREDENTIALS` で指す (このリポジトリは public のため、プロジェクトルートには置かない)
+
+```bash
+mkdir -p ~/.config/gcloud/keys && chmod 700 ~/.config/gcloud/keys
+mv ~/Downloads/<project>-firebase-adminsdk-*.json ~/.config/gcloud/keys/<project>-admin.json
+chmod 600 ~/.config/gcloud/keys/<project>-admin.json
+export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/keys/<project>-admin.json
+```
+
+詳細 (impersonation で鍵を持たない方法・作業後の `gcloud auth application-default revoke`) は `docs/ops-runbook.md` §3 と `scripts/README.md`。
 
 #### ステップ2: firebase-admin をインストール
 
@@ -246,8 +254,12 @@ npm install -D tsx firebase-admin
 
 #### ステップ4: 管理者権限を付与
 
+`create-admin.ts` は現状カレントディレクトリの `serviceAccountKey.json` しか読まないため、実行の直前にシンボリックリンクを張り、直後に外します (鍵の実体はリポジトリ外のまま):
+
 ```bash
+ln -s "$GOOGLE_APPLICATION_CREDENTIALS" serviceAccountKey.json
 npx tsx scripts/create-admin.ts YOUR_USER_UID
+rm serviceAccountKey.json
 ```
 
 **例**:
@@ -421,15 +433,20 @@ src/
     ├── ffmpeg.ts / gemini.ts / videoConversionService.ts
     └── constants・utils
 
-scripts/                       # 管理スクリプト
+scripts/                       # 管理スクリプト (本番 Firestore を直接操作。scripts/README.md 参照)
 ├── create-admin.ts            # 初回管理者作成
-└── migrate-existing-data.ts   # データ移行
+├── create-system-notification.ts  # お知らせ作成
+├── migrate-existing-data.ts   # 旧データ移行
+├── migrate-text-to-transcription.mjs  # text→transcription 二段階移行 (dry-run 既定)
+└── ops-gemini37-rollout.mjs   # Gemini 3.7 ロールアウト (dry-run 既定)
 
-docs/                          # ドキュメント
-├── admin-setup-guide.md       # 管理者セットアップ
-└── account-deletion-guide.md  # アカウント削除ガイド
+docs/
+└── ops-runbook.md             # 運用手順書 (リリースゲート・バックアップ/復旧・配備・資格情報)
 
+.github/workflows/ci.yml       # CI (tsc / lint / vitest)
 firestore.rules                # Firestore セキュリティルール
+firestore.indexes.json         # Firestore 複合インデックス
+storage.rules                  # Storage セキュリティルール
 ```
 
 ## 🛠️ ビルド
@@ -445,6 +462,21 @@ npm run build
 ```bash
 npm run start
 ```
+
+## 🚦 リリースゲートと運用
+
+`main` は Vercel の git 統合で **push した瞬間に本番** になります (ステージング無し)。壊れたコードが本番に出ないよう、次の 2 段でゲートします。詳細は `docs/ops-runbook.md` §1。
+
+1. **Vercel の Build Command を `npm test && npm run build` にする** (Settings → Build & Development Settings)。テストが赤ならビルドが止まり、本番は前のデプロイのまま残ります。GitHub Actions が停止していても効く即効策です。
+2. **CI workflow + ブランチ保護**: `.github/workflows/ci.yml` が push / PR (main 宛) で `npm ci` → `npx tsc --noEmit` → `npm run lint` → `npm run test` を Node 20 で走らせます (job 名 `check`)。Actions が動く状態になったら、main を **PR 必須 + status check `check` 必須** にします (手順とコマンドは runbook §1.3)。
+
+ローカルで CI と同じ検査を回す:
+
+```bash
+npm ci && npx tsc --noEmit && npm run lint && npm run test
+```
+
+バックアップ (Firestore PITR / 日次バックアップ / Storage soft delete) と誤削除からの復旧、Rules・indexes の配備コマンド、Vercel 環境変数の一覧、資格情報の扱いは `docs/ops-runbook.md` にまとめています。
 
 ## 🔒 セキュリティとプライバシー
 
@@ -477,6 +509,7 @@ npm run start
   - 文書: 500KB（デフォルト）
 - **再認証**: アカウント削除などの重要操作は再認証が必要
 - **環境変数の保護**: `.env.local` ファイルはGitにコミットされません
+- **サービスアカウント鍵**: リポジトリ外 (`~/.config/gcloud/keys/`) に置き `GOOGLE_APPLICATION_CREDENTIALS` で指す。`.gitignore` の `serviceAccountKey.json` / `*-firebase-adminsdk-*.json` は誤配置時の保険 (`docs/ops-runbook.md` §3)
 
 ## 🔧 トラブルシューティング
 
@@ -567,8 +600,7 @@ MIT
 ## 📚 ドキュメント
 
 - **セットアップガイド**: このREADME（上記）
-- **管理者セットアップ**: `docs/admin-setup-guide.md`
-- **アカウント削除ガイド**: `docs/account-deletion-guide.md`
+- **運用手順書** (リリースゲート・バックアップ/復旧・Rules 配備・資格情報): `docs/ops-runbook.md`
 - **スクリプト使用方法**: `scripts/README.md`
 
 ## 🙏 謝辞

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -1,0 +1,392 @@
+# 運用手順書 (ops runbook)
+
+商談くんミニ (videos-to-docs) の本番運用手順。対象 issue: #12 (S2-7 CI とリリースゲート)・#14 (S2-9 バックアップ/PITR/復旧)・#15 (S2-10 資格情報の運用)。
+
+**この文書は手順書であり、ここに書いたコマンドを機械的に実行する仕組みは無い。** 本番プロジェクトに対する操作は、実行者が内容を読んでから 1 行ずつ手で実行する。
+
+## 0. 前提 (本番の構成)
+
+| 項目 | 値 |
+|---|---|
+| Firebase / GCP プロジェクト | `hy-docs-generated-from-audio` (`.firebaserc` の default) |
+| Firestore データベース | `(default)` (アプリは `getFirestore(app)` = database id 指定なし) |
+| Storage バケット | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` の値 (以下 `$BUCKET` と表記)。音声は `audio/{ownerId}/{timestamp}_{name}.mp3` |
+| ホスティング | Vercel の git 統合。**`main` への push = 即本番** (ステージング無し) |
+| GitHub | `harumichi-yamamoto-freedom/videos-to-docs`。**public リポジトリ** (鍵の混入は即時公開と同義) |
+| 配備対象ファイル | `firestore.rules` / `firestore.indexes.json` / `storage.rules` (`firebase.json` に 3 つとも登録済み) |
+| ローカル CLI | `firebase` (firebase-tools), `gcloud`, `gh`, Node 20 |
+
+以下、コマンド中の `$PROJECT` は `hy-docs-generated-from-audio`、`$BUCKET` は `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` の値を指す。
+
+```bash
+export PROJECT=hy-docs-generated-from-audio
+export BUCKET=<NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET の値>   # 例: gs:// を付けずに指定
+```
+
+---
+
+## 1. リリースゲート (S2-7 / #12)
+
+### 1.1 現状
+- `.github/workflows/ci.yml` (tsc → lint → vitest) をリポジトリに置いた。ジョブ名は `check`。
+- GitHub Actions は組織側の事情で停止していることがある。**Actions が止まっていても Vercel のビルドは走る**ので、まず 1.2 の即効策を入れる。
+- main にブランチ保護・ruleset は無い (2026-09-03 時点で 404 / `[]`)。
+
+### 1.2 即効策: Vercel の Build Command でテストを走らせる (Actions 停止中でも効く)
+Vercel ダッシュボード → Project → **Settings → Build & Development Settings → Build Command** を Override して:
+
+```
+npm test && npm run build
+```
+
+- `npm test` は `vitest run` (約 1,000 件・10 秒前後)。赤ならビルドが止まり、**本番は前のデプロイのまま**残る。
+- lint も止めたいなら `npm run lint && npm test && npm run build`。(Next 16 は `next build` で lint を走らせない。)
+- 注意: Vercel の環境変数に `NODE_ENV=production` を**手で入れない**こと。入れると devDependencies (vitest / eslint / typescript) がインストールされず、このコマンド自体が失敗する。
+- 確認: 保存後に空コミットを push するか Vercel の Redeploy を押し、Deployment のビルドログに `Test Files … passed` が出ることを見る。
+
+### 1.3 復旧後の恒久策: PR 必須 + status check 必須
+Actions が動くようになったら (`gh run list` で `check` が走っているのを確認してから):
+
+1. workflow の初回成功を 1 回作る (PR を 1 本開けば `pull_request` で走る)。
+2. main のブランチ保護を入れる:
+
+```bash
+cat > /tmp/main-protection.json <<'EOF'
+{
+  "required_status_checks": { "strict": true, "contexts": ["check"] },
+  "enforce_admins": true,
+  "required_pull_request_reviews": { "required_approving_review_count": 0 },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+gh api -X PUT repos/harumichi-yamamoto-freedom/videos-to-docs/branches/main/protection \
+  --input /tmp/main-protection.json
+```
+
+- `required_approving_review_count` は 0 でも **PR 経由が必須**になる (直接 push は拒否)。レビュアーが常時いる体制になったら 1 に上げる。
+- `contexts` の `check` は `ci.yml` の job 名。job 名を変えたらここも変える。
+- 確認: `gh api repos/harumichi-yamamoto-freedom/videos-to-docs/branches/main/protection` が 200 で返り、`git push origin main` が直接 push で拒否される。
+- Vercel 側は変更不要 (PR ブランチは Preview、main は Production のまま)。
+
+### 1.4 補足
+- リポジトリは public。public リポジトリの Actions 分は無料枠なので、組織の spending limit 枯渇の影響を受けない可能性がある。復旧の判定は推測せず `gh run list` で実測する。
+- ローカルで CI と同じ手順を再現する: `npm ci && npx tsc --noEmit && npm run lint && npm run test`。
+
+---
+
+## 2. バックアップ / PITR / 復旧 (S2-9 / #14)
+
+### 2.1 現状と方針
+- アプリには「一括削除」が 3 系統ある (退会時の `writeBatch` 全消し・ゲスト共通プロンプトの全削除再作成・移行スクリプト)。Firestore は既定では削除の取り消しができない (版の保持は 1 時間だけ)。
+- 方針: **PITR (7 日) + 日次スケジュールバックアップ (14 日保持) + 削除保護** を Firestore に、**soft delete + versioning** を Storage に入れる。いずれも設定 1 回で継続する。
+- 2026-09-03 に読み取り専用で確認した時点では、PITR 無効・バックアップスケジュール無し・削除保護無効だった (実行前に 2.2 の確認コマンドで再確認する)。
+
+### 2.2 いまの状態を確認する (読み取り専用)
+
+```bash
+gcloud firestore databases describe --database='(default)' --project "$PROJECT"
+#   pointInTimeRecoveryEnablement / versionRetentionPeriod / deleteProtectionState を見る
+gcloud firestore backups schedules list --database='(default)' --project "$PROJECT"
+gcloud storage buckets describe "gs://$BUCKET" --format='yaml(versioning,softDeletePolicy,lifecycle)'
+```
+
+firebase CLI しか認証が生きていない場合の代替: `firebase firestore:databases:get "(default)" --project "$PROJECT"`。
+
+### 2.3 Firestore: PITR と削除保護を有効化 (1 回)
+
+```bash
+# PITR (有効化後、7 日分の版が保持される。有効化以前の時点へは戻れない)
+gcloud firestore databases update --database='(default)' --project "$PROJECT" --enable-pitr
+
+# データベース自体の誤削除を防ぐ
+gcloud firestore databases update --database='(default)' --project "$PROJECT" --delete-protection
+
+# 確認
+gcloud firestore databases describe --database='(default)' --project "$PROJECT" \
+  --format='value(pointInTimeRecoveryEnablement,versionRetentionPeriod,deleteProtectionState)'
+#   期待: POINT_IN_TIME_RECOVERY_ENABLED  604800s  DELETE_PROTECTION_ENABLED
+```
+
+費用: PITR は保持する版の分だけストレージ課金が増える (このアプリのデータ量では小額)。
+
+### 2.4 Firestore: 日次スケジュールバックアップ (1 回)
+
+```bash
+# 日次・14 日保持
+gcloud firestore backups schedules create --database='(default)' --project "$PROJECT" \
+  --recurrence=daily --retention=14d
+
+# 任意: 週次・8 週保持を重ねる (長期の巻き戻し用)
+gcloud firestore backups schedules create --database='(default)' --project "$PROJECT" \
+  --recurrence=weekly --day-of-week=SUN --retention=8w
+
+# 確認 (翌日以降、実際のバックアップが並ぶ)
+gcloud firestore backups schedules list --database='(default)' --project "$PROJECT"
+gcloud firestore backups list --project "$PROJECT"
+```
+
+### 2.5 Firestore: 危険な操作の直前に手動エクスポート
+移行スクリプトや Rules 変更など、後戻りしにくい操作の**直前**に取る。エクスポート先の GCS バケットは初回だけ作る。
+
+```bash
+# 初回のみ: エクスポート専用バケット (音声バケットとは分ける)
+gcloud storage buckets create "gs://$PROJECT-firestore-exports" --project "$PROJECT" \
+  --location=asia-northeast1 --uniform-bucket-level-access
+
+# 毎回
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+gcloud firestore export "gs://$PROJECT-firestore-exports/manual/$STAMP" \
+  --database='(default)' --project "$PROJECT"
+echo "$STAMP"   # 作業記録に残す
+```
+
+location はデータベースと同じリージョンにする (`gcloud firestore databases describe` の `locationId`)。
+
+### 2.6 Storage: soft delete と versioning (1 回)
+
+```bash
+# 削除しても 30 日間は復元できる
+gcloud storage buckets update "gs://$BUCKET" --soft-delete-duration=30d
+
+# 上書きの旧版を残す (同名再アップロード対策)
+gcloud storage buckets update "gs://$BUCKET" --versioning
+
+# 旧版が無限に溜まらないよう lifecycle で上限 (非現行版は 3 世代 or 30 日で削除)
+cat > /tmp/lifecycle.json <<'EOF'
+{ "rule": [
+  { "action": {"type": "Delete"}, "condition": {"numNewerVersions": 3, "isLive": false} },
+  { "action": {"type": "Delete"}, "condition": {"daysSinceNoncurrentTime": 30, "isLive": false} }
+] }
+EOF
+gcloud storage buckets update "gs://$BUCKET" --lifecycle-file=/tmp/lifecycle.json
+
+# 確認
+gcloud storage buckets describe "gs://$BUCKET" --format='yaml(versioning,softDeletePolicy,lifecycle)'
+```
+
+補足: 現在のアプリコードは Storage の音声を削除しない (S1-3 で削除経路を足す予定)。削除経路を足した後も、この設定があれば 30 日は取り戻せる。
+
+### 2.7 復旧手順: Firestore の誤削除・誤更新
+
+**手順の順番が重要。先に被害を止め、次に「いつの状態に戻すか」を決めてから触る。**
+
+1. **止血**: 原因の操作を止める (スクリプトなら kill。アプリ経由なら該当機能の告知/停止を判断)。事故時刻 `T_bad` (UTC) を記録する。
+2. **範囲の特定**: 影響コレクションと doc id の範囲を決める (`auditLogs` コレクション、スクリプトの backup JSONL / plan ファイル、Vercel/ブラウザのログ)。
+3. **戻し先の選択**
+   - `T_bad` から 7 日以内で PITR が有効 → **PITR** (分単位で時刻を選べる)。
+   - それより前、または PITR が無効だった期間 → **スケジュールバックアップ** か **2.5 の手動エクスポート**。
+4. **別データベースへ復元する** (本番 `(default)` を直接上書きしない)
+
+```bash
+# PITR から: T_bad の直前の時刻を指定
+gcloud firestore databases restore --project "$PROJECT" \
+  --source-database='(default)' --snapshot-time='2026-09-03T01:23:00Z' \
+  --destination-database='restore-20260903'
+
+# バックアップから: gcloud firestore backups list で name を取る
+gcloud firestore databases restore --project "$PROJECT" \
+  --source-backup='projects/'"$PROJECT"'/locations/<location>/backups/<backup-id>' \
+  --destination-database='restore-20260903'
+```
+
+5. **復元 DB から本番へ戻す** (コレクション単位。import は同 id の doc を上書きし、無い doc は消さない)
+
+```bash
+# 復元 DB を GCS へ書き出し (必要なコレクションだけ)
+gcloud firestore export "gs://$PROJECT-firestore-exports/restore/20260903" \
+  --database='restore-20260903' --project "$PROJECT" \
+  --collection-ids=prompts,transcriptions
+
+# 本番へ import。--collection-ids を必ず付け、範囲外を触らない
+gcloud firestore import "gs://$PROJECT-firestore-exports/restore/20260903" \
+  --database='(default)' --project "$PROJECT" \
+  --collection-ids=prompts,transcriptions
+```
+
+   - 数件だけ戻す場合は、import ではなく firebase-admin で復元 DB (`getFirestore(app, 'restore-20260903')`) から読み、`(default)` へ書く小スクリプトにする (dry-run 既定 + `--confirm`。§3.3 の方針)。
+   - **注意**: import は事故後に作られた新しい doc を消さない。事故後に「消されるべきだった / 変更された」doc がある場合は、手順 2 で特定した id 集合との差分を先に取る。
+6. **検証**: 本番アプリで該当ユーザーの文書一覧・プロンプト一覧を開き、件数と最新更新時刻を確認。`auditLogs` に復旧作業の記録 (誰が・いつ・何を・どの backup から) を残す。
+7. **後片付け**: 復元 DB は確認が終わったら削除する (課金対象)。
+
+```bash
+gcloud firestore databases delete --database='restore-20260903' --project "$PROJECT"
+```
+
+### 2.8 復旧手順: Storage の誤削除
+
+```bash
+# soft delete 中のオブジェクトを探す
+gcloud storage ls --soft-deleted --recursive "gs://$BUCKET/audio/<ownerId>/"
+
+# 復元 (generation 付きで指定)
+gcloud storage restore "gs://$BUCKET/audio/<ownerId>/<file>.mp3#<generation>"
+
+# 上書きされた旧版を戻す (versioning)
+gcloud storage ls --all-versions "gs://$BUCKET/audio/<ownerId>/<file>.mp3"
+gcloud storage cp "gs://$BUCKET/audio/<ownerId>/<file>.mp3#<generation>" \
+                  "gs://$BUCKET/audio/<ownerId>/<file>.mp3"
+```
+
+Firestore 側 `transcriptions.audioStoragePath` が指すパスと一致していることを確認する。
+
+### 2.9 Rules / indexes / storage.rules の配備
+
+`firebase.json` に 3 種すべてが登録されているため、**引数無しの `firebase deploy` は 3 種を同時に配備する**。必ず `--only` で対象を 1 つに限定する。
+
+```bash
+# 配備前: いま本番で動いている Rules を退避 (巻き戻し用)
+TOKEN=$(gcloud auth print-access-token)
+REL=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://firebaserules.googleapis.com/v1/projects/$PROJECT/releases/cloud.firestore" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["rulesetName"])')
+curl -s -H "Authorization: Bearer $TOKEN" "https://firebaserules.googleapis.com/v1/$REL" \
+  > "rules-live-$(date -u +%Y%m%d).json"
+# (gcloud が失効している場合は Firebase Console → Firestore → ルール → 履歴 で前版を控える)
+
+# 配備前: ローカルの錠を回す (firestore.rules の構造テスト)
+npx vitest run src/lib/firestoreRules.team.test.ts
+
+# Firestore Rules だけ
+firebase deploy --only firestore:rules --project "$PROJECT"
+
+# Storage Rules だけ
+firebase deploy --only storage --project "$PROJECT"
+
+# インデックスだけ。⚠ firestore.indexes.json に無い既存インデックスは削除対象になる。
+#   対話プロンプトで削除の可否を聞かれるので、--force や非対話で流さない。
+firebase deploy --only firestore:indexes --project "$PROJECT"
+```
+
+配備後の確認:
+- Rules: 未ログイン (ゲスト) と本人ログインで、`/home` のプロンプト一覧と `/documents` が開けること。未ログインで他人の文書が list できないことを SDK 経路で 1 回確認 (REST `:runQuery` は Rules を評価しないので確認には使えない)。
+- 巻き戻し: Firebase Console → Firestore → ルール → 履歴 から前版を選んで公開、または退避した JSON の `source.files[].content` を `firestore.rules` に戻して再配備。
+
+### 2.10 Vercel の環境変数 (7 種)
+アプリが読む環境変数は次の 7 つだけ (`src/lib/firebase.ts` と `src/lib/gemini.ts`)。すべて `NEXT_PUBLIC_` = **クライアントバンドルに埋め込まれ、閲覧者から見える**。
+
+| 変数 | 用途 | 秘密か |
+|---|---|---|
+| `NEXT_PUBLIC_FIREBASE_API_KEY` | Firebase Web API key | 公開前提 (Rules と API 制限で守る) |
+| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | Auth ドメイン | 公開 |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | プロジェクト id | 公開 |
+| `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | 音声バケット | 公開 |
+| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | Firebase 設定 | 公開 |
+| `NEXT_PUBLIC_FIREBASE_APP_ID` | Firebase 設定 | 公開 |
+| `NEXT_PUBLIC_GEMINI_API_KEY` | Gemini API key | **本来は秘密**。現行設計ではクライアント露出 (S1-2 でサーバ経由化予定)。Google AI Studio 側で HTTP リファラ制限と日次上限を必ず設定する |
+
+- 設定場所: Vercel → Project → Settings → Environment Variables (Production / Preview 両方)。
+- 変更は**再デプロイしないと反映されない** (ビルド時に埋め込まれる)。
+- Gemini key のローテーション: AI Studio で新キー作成 → Vercel の値を更新 → Redeploy → 本番で 1 件生成して疎通確認 → 旧キーを削除。
+- サーバ側の秘密 (サービスアカウント鍵) は Vercel に**置かない** (現行アプリにサーバ層は無い)。
+
+---
+
+## 3. 資格情報の運用 (S2-10 / #15)
+
+### 3.1 原則
+1. **サービスアカウント鍵はリポジトリの外**に置く。置き場所は `~/.config/gcloud/keys/` (パーミッション 600)。リポジトリ直下には置かない (public リポジトリなので `git add -A` 一発で公開される)。
+2. スクリプトへは **`GOOGLE_APPLICATION_CREDENTIALS`** で渡す。
+3. 鍵をダウンロードせず済むなら **ADC + サービスアカウント impersonation** を優先する (鍵ファイルが存在しない状態が最も安全)。
+4. 作業が終わったら **ADC を revoke** する。この Mac の ADC が本番に書けるままだと、`--project-id` 一致だけで本番を書き換えるスクリプトが動いてしまう。
+5. 本番を変更するスクリプトは **dry-run 既定 + `--apply` + `--confirm`** (3.3)。
+
+### 3.2 鍵の置き方
+
+```bash
+mkdir -p ~/.config/gcloud/keys && chmod 700 ~/.config/gcloud/keys
+# Firebase Console → プロジェクト設定 → サービスアカウント → 新しい秘密鍵の生成 でダウンロードした
+# <project>-firebase-adminsdk-xxxxx-xxxxxxxxxx.json を移動する (リポジトリ内に一度も置かない)
+mv ~/Downloads/hy-docs-generated-from-audio-firebase-adminsdk-*.json \
+   ~/.config/gcloud/keys/hy-docs-generated-from-audio-admin.json
+chmod 600 ~/.config/gcloud/keys/hy-docs-generated-from-audio-admin.json
+
+# 使うシェルでだけ export (~/.zshrc に恒久設定しない)
+export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/keys/hy-docs-generated-from-audio-admin.json
+```
+
+鍵を使わない代替 (推奨):
+
+```bash
+gcloud auth application-default login \
+  --impersonate-service-account=firebase-adminsdk-<id>@$PROJECT.iam.gserviceaccount.com
+# → firebase-admin は ADC を自動で拾う。作業後は 3.4 で revoke
+```
+
+`.gitignore` には `serviceAccountKey.json` と `*-firebase-adminsdk-*.json` を入れてあるが、これは**誤って置いたときの保険**であり、置いてよい理由にはならない。
+
+### 3.3 スクリプト側の現状と実行ルール
+
+| スクリプト | 資格情報の読み方 (現状) | dry-run | 確認値 |
+|---|---|---|---|
+| `scripts/ops-gemini37-rollout.mjs` | ADC / `GOOGLE_APPLICATION_CREDENTIALS` | 既定 | `--apply --project-id <id>` (資格情報の project と一致必須) |
+| `scripts/migrate-text-to-transcription.mjs` | `./serviceAccountKey.json` 固定 | 既定 (plan JSONL 生成) | `--apply --plan-sha256 --expected-count --confirm <値>` |
+| `scripts/create-admin.ts` | `./serviceAccountKey.json` 固定 | **無し (即書込)** | 無し |
+| `scripts/migrate-existing-data.ts` | `./serviceAccountKey.json` 固定 | **無し (即書込)** | 無し |
+| `scripts/create-system-notification.ts` | `./serviceAccountKey.json` 固定 | **無し (即書込)** | 無し |
+
+運用ルール:
+- **新規/改修するスクリプトは `ops-gemini37-rollout.mjs` の形に揃える**: 既定 dry-run・`--apply` には `--project-id` 明示と資格情報 project の一致検査・書き込み前に旧値を backup JSONL へ全件保存・`FIRESTORE_EMULATOR_HOST` の有無を出力に明記。破壊的な (削除・全件更新) スクリプトは `migrate-text-to-transcription.mjs` と同じく plan の SHA-256 と件数、`--confirm <plan 由来の値>` を要求する。
+- `./serviceAccountKey.json` 固定のスクリプトを、それらが `GOOGLE_APPLICATION_CREDENTIALS` を読むよう改修されるまで使う場合は、**実行の直前にシンボリックリンクを張り、直後に外す**:
+
+```bash
+ln -s "$GOOGLE_APPLICATION_CREDENTIALS" serviceAccountKey.json   # 鍵の実体はリポジトリ外のまま
+npx tsx scripts/create-admin.ts <uid>
+rm serviceAccountKey.json
+git status --short   # serviceAccountKey.json が出ないこと (ignore 済みでも目視)
+```
+
+- dry-run の無い 3 本 (`create-admin.ts` / `migrate-existing-data.ts` / `create-system-notification.ts`) を本番に対して使う前に、§2.5 の手動エクスポートを取る。
+- 本番を変更するスクリプトは、実行者・時刻・コマンド行・出力ファイル名を作業記録 (issue または `auditLogs`) に残す。
+
+### 3.4 作業後の後片付け (毎回)
+
+```bash
+gcloud auth application-default revoke      # ADC を失効 (~/.config/gcloud/application_default_credentials.json が消える)
+unset GOOGLE_APPLICATION_CREDENTIALS
+rm -f serviceAccountKey.json                # 3.3 のシンボリックリンクを張った場合
+ls ~/.config/gcloud/application_default_credentials.json 2>/dev/null && echo "まだ ADC が残っている"
+```
+
+`firebase` CLI のログインも不要になったら `firebase logout`。
+
+### 3.5 鍵の棚卸しとローテーション (四半期ごと)
+
+```bash
+# 存在する鍵を列挙 (作成日が古いもの・用途不明のものを消す)
+gcloud iam service-accounts keys list \
+  --iam-account="firebase-adminsdk-<id>@$PROJECT.iam.gserviceaccount.com" --project "$PROJECT"
+gcloud iam service-accounts keys delete <KEY_ID> \
+  --iam-account="firebase-adminsdk-<id>@$PROJECT.iam.gserviceaccount.com" --project "$PROJECT"
+```
+
+### 3.6 鍵をコミットしてしまったときの対応 (順番が重要)
+1. **先に GCP 側で鍵を削除する** (3.5 の `keys delete`)。履歴を消しても push 済みの鍵は既に取得され得る。
+2. 次に履歴から除去する (`git filter-repo` 等) → force push → 関係者に再 clone を依頼。
+3. `auditLogs` と Cloud Audit Logs で鍵削除までの間に不審な操作が無いか確認する。
+4. 発生経緯と再発防止 (`.gitignore` 追加・pre-commit 検査) を issue に記録する。
+
+---
+
+## 4. チェックリスト
+
+### 本番を触る作業の前
+- [ ] `gcloud config get-value project` / `--project` の明示が `hy-docs-generated-from-audio` を指している
+- [ ] §2.5 の手動エクスポートを取り、`STAMP` を記録した
+- [ ] スクリプトを dry-run で流し、対象件数を目視した
+- [ ] 鍵の実体がリポジトリ外にある (`git status --short` に鍵が出ない)
+
+### 本番を触る作業の後
+- [ ] アプリ (ゲスト + ログイン) で該当画面を開いて確認した
+- [ ] `gcloud auth application-default revoke` を実行した
+- [ ] `serviceAccountKey.json` のシンボリックリンクを消した
+- [ ] 作業記録を issue / `auditLogs` に残した
+
+### 初回だけ (このリポジトリの現状から)
+- [ ] §1.2 Vercel Build Command を `npm test && npm run build` に変更
+- [ ] §2.3 PITR + 削除保護
+- [ ] §2.4 日次スケジュールバックアップ
+- [ ] §2.6 Storage soft delete + versioning + lifecycle
+- [ ] §1.3 Actions 復旧後にブランチ保護 (PR 必須 + `check` 必須)
+- [ ] `NEXT_PUBLIC_GEMINI_API_KEY` の HTTP リファラ制限と日次上限 (Google AI Studio)

--- a/firestore.rules
+++ b/firestore.rules
@@ -315,6 +315,18 @@ service cloud.firestore {
       // update / delete の許可文は意図的に無い: 監査ログは管理者を含め誰も改竄・削除できない。
     }
 
+    // clientErrors コレクション (S2-8 #13: クライアント未捕捉エラーの best-effort 収集)
+    // 書き手は src/lib/clientErrorReporter.ts のみ。userId は本人 uid か未ログインの 'GUEST' に限定し
+    // (auditLogs と同方針)、必須フィールドの欠落した形は受け付けない。更新・削除は誰もできない。
+    match /clientErrors/{errorId} {
+      allow create: if request.resource.data.userId == (request.auth != null ? request.auth.uid : 'GUEST')
+        && request.resource.data.keys().hasAll(['message', 'source', 'url', 'timestamp', 'userId', 'ownerType', 'createdAt'])
+        && request.resource.data.message is string
+        && request.resource.data.message.size() <= 4000
+        && request.resource.data.source in ['window.error', 'unhandledrejection'];
+      allow read: if isSuperuser();
+    }
+
     // systemNotifications コレクション（システムからのお知らせ）
     match /systemNotifications/{notificationId} {
       // 読み取り(単体): 管理者は全件 / 一般は公開中(published=true)のみ

--- a/firestore.rules
+++ b/firestore.rules
@@ -297,13 +297,22 @@ service cloud.firestore {
       allow write: if isSuperuser();
     }
 
-    // auditLogs コレクション
+    // auditLogs コレクション(クライアント書込の監査ログ)
+    //
+    // 書き手は src/lib/auditLog.ts logAudit() と src/lib/firestore.ts
+    // recordDocumentDeletionAudit() の2か所で、どちらも userId に
+    // getCurrentUserId() (= auth.currentUser?.uid ?? 'GUEST') を入れる。
     match /auditLogs/{logId} {
-      // 誰でも書き込み可能（システムログ記録用）
-      allow create: if true;
+      // 作成: 記録主体(userId)は「本人の uid」か「未ログインの 'GUEST'」に限る。
+      //   旧ルール(if true)では未ログインでも他人の uid を名乗る偽ログを書けた(S2-3)。
+      //   userId 欠落は参照の評価エラー=拒否(fail-closed・エミュレータ実測 2026-09-03)。
+      allow create: if (isSignedIn() && request.resource.data.userId == request.auth.uid)
+        || (!isSignedIn() && request.resource.data.userId == 'GUEST');
 
       // 管理者のみ読み取り可能
       allow read: if isSuperuser();
+
+      // update / delete の許可文は意図的に無い: 監査ログは管理者を含め誰も改竄・削除できない。
     }
 
     // systemNotifications コレクション（システムからのお知らせ）

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,40 +1,59 @@
 # 管理スクリプト
 
-このディレクトリには、データ移行と管理者作成のためのスクリプトが含まれています。
+このディレクトリには、本番 Firestore を firebase-admin で直接操作する運用スクリプトが入っています。**すべて本番データを書き換えます。** 実行前に `docs/ops-runbook.md` (§2.5 手動エクスポート・§3 資格情報) を読んでください。
 
 ## スクリプト一覧
 
-1. `migrate-existing-data.ts` - 既存データの移行
-2. `create-admin.ts` - 初回管理者の作成
+| スクリプト | 用途 | 資格情報の読み方 (現状) | dry-run |
+|---|---|---|---|
+| `create-admin.ts` | 初回管理者 (`superuser: true`) の付与 | `./serviceAccountKey.json` 固定 | 無し (即書込) |
+| `migrate-existing-data.ts` | `ownerType`/`ownerId` 無しの旧データ移行 | `./serviceAccountKey.json` 固定 | 無し (即書込) |
+| `create-system-notification.ts` | お知らせ (`systemNotifications`) の作成 | `./serviceAccountKey.json` 固定 | 無し (即書込) |
+| `migrate-text-to-transcription.mjs` | `text` → `transcription` の二段階移行 | `./serviceAccountKey.json` 固定 | 既定 (plan JSONL)。`--apply` に `--confirm` 等が必須 |
+| `ops-gemini37-rollout.mjs` | Gemini 3.7 ロールアウト (model リセット + お知らせ) | ADC / `GOOGLE_APPLICATION_CREDENTIALS` | 既定。`--apply --project-id <id>` |
+
+新しく書くスクリプトは `ops-gemini37-rollout.mjs` の形 (既定 dry-run・`--apply` + `--project-id` 一致検査・書き込み前の backup JSONL) に揃えてください。破壊的なものは `migrate-text-to-transcription.mjs` と同じく `--confirm` を要求してください。
 
 ## 使用方法
 
-### 1. 必要なパッケージのインストール
+### 1. 必要なパッケージ
+
+`tsx` と `firebase-admin` は devDependencies に入っています (`npm ci` で入ります)。
+
+### 2. 資格情報 (サービスアカウント鍵) の置き方
+
+**鍵はリポジトリの外に置き、`GOOGLE_APPLICATION_CREDENTIALS` で指します。リポジトリ直下には置きません** (このリポジトリは public です)。
+
+1. [Firebase Console](https://console.firebase.google.com/) → プロジェクトを選択
+2. ⚙️ **プロジェクト設定** > **サービスアカウント** > 「**新しい秘密鍵の生成**」
+3. ダウンロードした `<project>-firebase-adminsdk-xxxxx-xxxxxxxxxx.json` を `~/.config/gcloud/keys/` へ移動
 
 ```bash
-npm install -D tsx firebase-admin
+mkdir -p ~/.config/gcloud/keys && chmod 700 ~/.config/gcloud/keys
+mv ~/Downloads/<project>-firebase-adminsdk-*.json ~/.config/gcloud/keys/<project>-admin.json
+chmod 600 ~/.config/gcloud/keys/<project>-admin.json
+export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/keys/<project>-admin.json
 ```
 
-### 2. サービスアカウントキーの取得
+鍵をダウンロードせずに済む方法 (推奨): `gcloud auth application-default login --impersonate-service-account=<SA>`。firebase-admin は ADC を自動で使います。
 
-1. [Firebase Console](https://console.firebase.google.com/) にアクセス
-2. プロジェクトを選択
-3. ⚙️ **プロジェクト設定** > **サービスアカウント**
-4. 「**新しい秘密鍵の生成**」をクリック
-5. ダウンロードした JSON ファイルをプロジェクトルートに配置
-6. ファイル名を `serviceAccountKey.json` に変更
+⚠️ `.gitignore` の `serviceAccountKey.json` / `*-firebase-adminsdk-*.json` は誤って置いたときの保険であり、置いてよい理由ではありません。
 
-```
-videos-to-docs/
-├── serviceAccountKey.json  ← ここに配置
-├── scripts/
-│   └── migrate-existing-data.ts
-...
+#### `./serviceAccountKey.json` 固定のスクリプトを動かすとき
+
+`create-admin.ts` / `migrate-existing-data.ts` / `create-system-notification.ts` / `migrate-text-to-transcription.mjs` は、現状ではカレントディレクトリの `serviceAccountKey.json` しか読みません。改修されるまでは、**実行の直前にシンボリックリンクを張り、直後に外して**ください (鍵の実体はリポジトリ外のまま)。
+
+```bash
+ln -s "$GOOGLE_APPLICATION_CREDENTIALS" serviceAccountKey.json
+npx tsx scripts/create-admin.ts YOUR_USER_UID
+rm serviceAccountKey.json
+git status --short   # 鍵が出ないことを目視
 ```
 
-⚠️ **重要**: `serviceAccountKey.json` は `.gitignore` に追加されており、Git には含まれません。
+### 3. 実行前・実行後
 
-### 3. スクリプトの実行
+- 実行前: `docs/ops-runbook.md` §2.5 の手動エクスポートを取る。dry-run のあるスクリプトは必ず dry-run で件数を見る。
+- 実行後: `gcloud auth application-default revoke` で ADC を失効し、`unset GOOGLE_APPLICATION_CREDENTIALS`、シンボリックリンクを削除する。
 
 ```bash
 # プロジェクトルートで実行
@@ -44,13 +63,11 @@ npx tsx scripts/migrate-existing-data.ts
 ## 注意事項
 
 ⚠️ **本番環境で実行する前に:**
-1. Firebase Console でデータベースのバックアップを取ってください
-2. テスト環境で動作確認を行ってください
-3. スクリプトは既存のデータを変更します（元に戻せません）
+1. `docs/ops-runbook.md` §2.5 の手順で Firestore をエクスポートする (バックアップ)
+2. テスト環境 (Firestore エミュレータ) で動作確認を行う
+3. dry-run の無いスクリプトは既存のデータを即座に変更します (元に戻すには §2.7 の復旧手順が必要)
 
-## スクリプトの動作
-
-このスクリプトは以下の処理を行います：
+## `migrate-existing-data.ts` の動作
 
 1. `prompts` コレクションのすべてのドキュメントをスキャン
 2. `ownerType` フィールドがないドキュメントに以下を追加:
@@ -58,7 +75,6 @@ npx tsx scripts/migrate-existing-data.ts
    - `ownerId: 'GUEST'`
    - `createdBy: 'GUEST'`
    - `updatedAt: serverTimestamp()`
-
 3. `transcriptions` コレクションについても同様の処理を実行
 
 ## トラブルシューティング
@@ -66,28 +82,24 @@ npx tsx scripts/migrate-existing-data.ts
 ### エラー: "Cannot find module 'tsx'"
 
 ```bash
-npm install -D tsx
+npm ci
 ```
 
-### エラー: "Firebase configuration is missing"
+### エラー: "serviceAccountKey.json が見つかりません"
 
-`.env.local` ファイルに以下の環境変数が設定されているか確認:
-- `NEXT_PUBLIC_FIREBASE_API_KEY`
-- `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`
-- `NEXT_PUBLIC_FIREBASE_PROJECT_ID`
-- など
+上記「`./serviceAccountKey.json` 固定のスクリプトを動かすとき」のシンボリックリンクを張ってください。
 
 ### 権限エラー
 
-Firebase Console で Firestore の書き込み権限があることを確認してください。
+サービスアカウントに Firestore の書き込み権限 (Firebase Admin SDK の既定 SA なら付与済み) があることを確認してください。
 
 ---
 
-## スクリプト2: 初回管理者の作成
+## `create-admin.ts`: 初回管理者の作成
 
 ### 概要
 
-Firebase Authentication でアカウントを作成した後、そのユーザーに管理者権限（`superuser: true`）を付与します。
+Firebase Authentication でアカウントを作成した後、そのユーザーに管理者権限 (`superuser: true`) を付与します。管理者への昇格はこのスクリプト (firebase-admin) 専任で、アプリの UI からは行えません。
 
 ### 使用方法
 
@@ -99,19 +111,16 @@ Firebase Authentication でアカウントを作成した後、そのユーザ�
 
 1. [Firebase Console](https://console.firebase.google.com/) > **Authentication**
 2. ユーザー一覧で対象ユーザーを見つける
-3. **UID**（ユーザー識別子）をコピー
+3. **UID** (ユーザー識別子) をコピー
 
 例: `ylSoKJnLhQPgxcjdodQSOyqO5ym1`
 
 #### 3. スクリプトを実行
 
 ```bash
+ln -s "$GOOGLE_APPLICATION_CREDENTIALS" serviceAccountKey.json
 npx tsx scripts/create-admin.ts YOUR_USER_UID
-```
-
-**実行例:**
-```bash
-npx tsx scripts/create-admin.ts ylSoKJnLhQPgxcjdodQSOyqO5ym1
+rm serviceAccountKey.json
 ```
 
 #### 4. 確認
@@ -149,5 +158,4 @@ npx tsx scripts/create-admin.ts ylSoKJnLhQPgxcjdodQSOyqO5ym1
 
 #### エラー: "serviceAccountKey.json が見つかりません"
 
-→ 上記のデータ移行スクリプトと同じセットアップが必要です。
-
+→ 上記のシンボリックリンク手順が必要です。

--- a/src/app/(dashboard)/home/page.leaveGuard.test.tsx
+++ b/src/app/(dashboard)/home/page.leaveGuard.test.tsx
@@ -1,0 +1,418 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Prompt } from '@/lib/prompts';
+import { requestGuardedAction } from '@/hooks/useNavigationGuard';
+
+/**
+ * S2-2: 処理中 (実行中ジョブ or 保存待ち下書き) の離脱ガード。
+ * 文書画面の未保存ガードのテストと同じ作法で、beforeunload / SPA内クリック / history.back /
+ * ログアウト意図の 4 経路を jsdom で回す。
+ */
+
+const originalShowModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'showModal');
+const originalDialogClose = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'close');
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+const state = vi.hoisted(() => ({
+    hasActiveJobs: false,
+    pendingSaveCount: 0,
+    resetProcessing: vi.fn(),
+    // ページの認証 effect は user の同一性で発火する。描画ごとに作ると無限に再実行される
+    user: { uid: 'user-1' },
+}));
+
+vi.mock('next/navigation', () => ({
+    usePathname: () => '/home',
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+    useAuth: () => ({ user: state.user, loading: false }),
+}));
+
+// フック戻り値の関数は描画ごとに作り直さない。ページの effect 依存 (clearFiles /
+// forceDiscardProcessing) が毎回変わると effect が無限に再実行され、worker が OOM で落ちる
+vi.mock('@/hooks/usePromptManagement', () => {
+    const promptManagement = {
+        data: [],
+        availablePrompts: [] as Prompt[],
+        status: 'success',
+        error: null,
+        retry: vi.fn(),
+        reloadPrompts: vi.fn(),
+        bulkSelectedPromptIds: [],
+        toggleBulkPrompt: vi.fn(),
+    };
+    return { usePromptManagement: () => promptManagement };
+});
+
+vi.mock('@/hooks/useFileManagement', () => {
+    const fileManagement = {
+        selectedFiles: [],
+        handleFilesSelected: vi.fn(),
+        handleRemoveFile: vi.fn(),
+        toggleFilePrompt: vi.fn(),
+        clearFiles: vi.fn(),
+        cleanupDeletedPrompts: vi.fn(),
+    };
+    return { useFileManagement: () => fileManagement };
+});
+
+vi.mock('@/hooks/useVideoProcessing', () => {
+    const stable = {
+        processingStatuses: [],
+        setProcessingStatuses: vi.fn(),
+        isProcessing: false,
+        setIsProcessing: vi.fn(),
+        ffmpegLoaded: false,
+        setFfmpegLoaded: vi.fn(),
+        converterRef: { current: null },
+        geminiClientRef: { current: null },
+        audioConversionQueueRef: { current: false },
+        processTranscription: vi.fn(),
+        processTranscriptionResume: vi.fn(),
+        isCanceling: false,
+        claimJob: vi.fn(),
+        cancelJob: vi.fn(),
+        markJobCanceled: vi.fn(),
+        forceDiscardProcessing: vi.fn(),
+        countPendingSaves: vi.fn(() => 0),
+        pendingSavesForFile: () => state.pendingSaveCount,
+        needsRemovalConfirm: () => state.pendingSaveCount > 0,
+    };
+    return {
+        useVideoProcessing: () => ({
+            ...stable,
+            activeJobIds: state.hasActiveJobs ? ['f1'] : [],
+            hasActiveJobs: state.hasActiveJobs,
+            pendingSaveCount: state.pendingSaveCount,
+            needsDiscardConfirm: state.hasActiveJobs || state.pendingSaveCount > 0,
+            resetProcessing: state.resetProcessing,
+        }),
+    };
+});
+
+vi.mock('@/hooks/useProcessingWorkflow', () => {
+    const workflow = {
+        handleStartProcessing: vi.fn(),
+        handleResumeFile: vi.fn(),
+        workflowError: null,
+        clearWorkflowError: vi.fn(),
+        reportWorkflowError: vi.fn(),
+    };
+    return { useProcessingWorkflow: () => workflow };
+});
+
+vi.mock('@/components/FileDropZone', () => ({ FileDropZone: () => <div data-testid="drop-zone" /> }));
+vi.mock('@/components/ProcessingStatusList', () => ({ ProcessingStatusList: () => null }));
+vi.mock('@/components/BulkPromptSelector', () => ({ BulkPromptSelector: () => null }));
+vi.mock('@/components/FilePromptSelector', () => ({ FilePromptSelector: () => null }));
+vi.mock('@/components/PromptListSidebar', () => ({ PromptListSidebar: () => null }));
+vi.mock('@/components/prompts/PromptModals', () => ({ PromptModals: () => null }));
+vi.mock('@/components/NotificationBanner', () => ({ NotificationBanner: () => null }));
+vi.mock('@/components/DebugControls', () => ({ DebugControls: () => null }));
+vi.mock('@/lib/logger', () => ({
+    createLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+
+const HomePage = (await import('./page')).default;
+
+type Mounted = { container: HTMLDivElement; root: Root };
+const mountedPages = new Set<Mounted>();
+
+const GUARD_KEY = '__homeProcessingGuard';
+
+function guardRole(): string | undefined {
+    const marker = window.history.state?.[GUARD_KEY] as { role?: string } | undefined;
+    return marker?.role;
+}
+
+function waitForPopStates(count: number): Promise<PopStateEvent[]> {
+    return new Promise((resolve, reject) => {
+        const events: PopStateEvent[] = [];
+        const timeoutId = window.setTimeout(() => {
+            window.removeEventListener('popstate', handlePopState);
+            reject(new Error(`popstateが${count}回発火しませんでした`));
+        }, 1000);
+        const handlePopState = (event: PopStateEvent): void => {
+            events.push(event);
+            if (events.length < count) return;
+            window.clearTimeout(timeoutId);
+            window.removeEventListener('popstate', handlePopState);
+            resolve(events);
+        };
+        window.addEventListener('popstate', handlePopState);
+    });
+}
+
+async function mountPage(): Promise<Mounted> {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root = createRoot(container);
+    const mounted = { container, root };
+    mountedPages.add(mounted);
+    await act(async () => {
+        root.render(<HomePage />);
+    });
+    return mounted;
+}
+
+async function rerender(mounted: Mounted): Promise<void> {
+    await act(async () => {
+        mounted.root.render(<HomePage />);
+    });
+}
+
+async function unmountPage(mounted: Mounted): Promise<void> {
+    if (!mountedPages.delete(mounted)) return;
+    const sentinelCleanup = guardRole() === 'sentinel' ? waitForPopStates(1) : null;
+    await act(async () => {
+        mounted.root.unmount();
+    });
+    await sentinelCleanup;
+    mounted.container.remove();
+}
+
+function dialogOf(mounted: Mounted): HTMLDialogElement | null {
+    return mounted.container.querySelector('dialog');
+}
+
+function buttonByText(mounted: Mounted, label: string): HTMLButtonElement {
+    const button = Array.from(mounted.container.querySelectorAll<HTMLButtonElement>('button'))
+        .find(element => element.textContent?.trim() === label);
+    if (!button) throw new Error(`${label} ボタンがありません`);
+    return button;
+}
+
+async function click(element: HTMLElement): Promise<void> {
+    await act(async () => {
+        element.click();
+        await Promise.resolve();
+    });
+}
+
+function dispatchBeforeUnload(): boolean {
+    const event = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(event);
+    return event.defaultPrevented;
+}
+
+/** 文書画面のテストと同じく、document 直下に SPA 内リンクを置いてクリック監視を試す */
+function installInternalLink(): { anchor: HTMLAnchorElement; reached: () => number } {
+    const anchor = document.createElement('a');
+    anchor.href = '/documents';
+    anchor.textContent = '文書へ';
+    let reachedCount = 0;
+    anchor.addEventListener('click', event => {
+        if (!event.defaultPrevented) reachedCount += 1;
+        // jsdom の未実装ナビゲーションを起こさない
+        event.preventDefault();
+    });
+    document.body.append(anchor);
+    return { anchor, reached: () => reachedCount };
+}
+
+async function clickInternalLink(anchor: HTMLAnchorElement): Promise<MouseEvent> {
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    await act(async () => {
+        anchor.dispatchEvent(event);
+        await Promise.resolve();
+    });
+    return event;
+}
+
+describe('HomePage 離脱ガード (S2-2)', () => {
+    beforeAll(() => {
+        Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+            configurable: true,
+            value(this: HTMLDialogElement) {
+                this.setAttribute('open', '');
+            },
+        });
+        Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+            configurable: true,
+            value(this: HTMLDialogElement) {
+                if (!this.open) return;
+                this.removeAttribute('open');
+                queueMicrotask(() => {
+                    this.dispatchEvent(new Event('close'));
+                });
+            },
+        });
+    });
+
+    afterAll(() => {
+        if (originalShowModal) {
+            Object.defineProperty(HTMLDialogElement.prototype, 'showModal', originalShowModal);
+        } else {
+            delete (HTMLDialogElement.prototype as Partial<HTMLDialogElement>).showModal;
+        }
+        if (originalDialogClose) {
+            Object.defineProperty(HTMLDialogElement.prototype, 'close', originalDialogClose);
+        } else {
+            delete (HTMLDialogElement.prototype as Partial<HTMLDialogElement>).close;
+        }
+    });
+
+    beforeEach(() => {
+        state.hasActiveJobs = false;
+        state.pendingSaveCount = 0;
+        state.resetProcessing.mockReset().mockResolvedValue('settled');
+        Object.defineProperty(window, 'requestAnimationFrame', {
+            configurable: true,
+            value: vi.fn((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            }),
+        });
+        window.history.replaceState(null, '', '/history-far');
+        window.history.pushState(null, '', '/history-origin');
+        window.history.pushState(null, '', '/home');
+    });
+
+    afterEach(async () => {
+        for (const mounted of [...mountedPages]) {
+            await unmountPage(mounted);
+        }
+        document.body.replaceChildren();
+        vi.restoreAllMocks();
+    });
+
+    it('処理中でなければ何も止めない (beforeunload / リンク / ログアウト)', async () => {
+        const mounted = await mountPage();
+        const link = installInternalLink();
+
+        expect(dispatchBeforeUnload()).toBe(false);
+        expect(guardRole()).toBeUndefined();
+
+        const linkClick = await clickInternalLink(link.anchor);
+        // 監視は介入していない (preventDefault したのはテスト側のリスナーだけ)
+        expect(link.reached()).toBe(1);
+        expect(linkClick.defaultPrevented).toBe(true);
+        expect(dialogOf(mounted)).toBeNull();
+
+        const proceed = vi.fn();
+        requestGuardedAction('signout', proceed);
+        expect(proceed).toHaveBeenCalledTimes(1);
+        expect(dialogOf(mounted)).toBeNull();
+    });
+
+    it('実行中ジョブがある間だけ beforeunload を止め、終わったら解除する', async () => {
+        const mounted = await mountPage();
+        expect(dispatchBeforeUnload()).toBe(false);
+
+        state.hasActiveJobs = true;
+        await rerender(mounted);
+        expect(dispatchBeforeUnload()).toBe(true);
+        expect(guardRole()).toBe('sentinel');
+
+        state.hasActiveJobs = false;
+        const cleanup = waitForPopStates(1);
+        await rerender(mounted);
+        await cleanup;
+        expect(dispatchBeforeUnload()).toBe(false);
+        expect(guardRole()).toBeUndefined();
+    });
+
+    it('保存待ちの下書きだけでもガードが立ち、件数を示す', async () => {
+        state.pendingSaveCount = 2;
+        const mounted = await mountPage();
+        const link = installInternalLink();
+
+        expect(dispatchBeforeUnload()).toBe(true);
+        await clickInternalLink(link.anchor);
+
+        const dialog = dialogOf(mounted);
+        expect(dialog?.textContent).toContain('処理中です');
+        expect(dialog?.textContent).toContain('移動すると変換・生成結果が失われます。移動しますか？');
+        expect(dialog?.textContent).toContain('保存待ちの文書 2 件が失われます');
+        expect(link.reached()).toBe(0);
+    });
+
+    it('SPA内リンクのクリックを握り、「このページに残る」で留まり「移動する」でクリックを再生する', async () => {
+        state.hasActiveJobs = true;
+        const mounted = await mountPage();
+        const link = installInternalLink();
+
+        const firstClick = await clickInternalLink(link.anchor);
+        expect(firstClick.defaultPrevented).toBe(true);
+        expect(link.reached()).toBe(0);
+        expect(dialogOf(mounted)?.textContent).toContain('移動しますか？');
+
+        await click(buttonByText(mounted, 'このページに残る'));
+        expect(dialogOf(mounted)).toBeNull();
+        expect(link.reached()).toBe(0);
+
+        await clickInternalLink(link.anchor);
+        expect(dialogOf(mounted)).not.toBeNull();
+        const replay = waitForPopStates(1);
+        await click(buttonByText(mounted, '移動する'));
+        await replay;
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(dialogOf(mounted)).toBeNull();
+        // 承認後にだけ、元のリンクへクリックが届く
+        expect(link.reached()).toBe(1);
+    });
+
+    it('history.back を sentinel で保留し、承認すると本来の離脱をやり直す', async () => {
+        state.hasActiveJobs = true;
+        const mounted = await mountPage();
+        expect(guardRole()).toBe('sentinel');
+
+        const held = waitForPopStates(2);
+        await act(async () => {
+            window.history.back();
+            await held;
+        });
+
+        expect(window.location.pathname).toBe('/home');
+        expect(guardRole()).toBe('sentinel');
+        expect(dialogOf(mounted)?.textContent).toContain('移動しますか？');
+
+        await click(buttonByText(mounted, 'このページに残る'));
+        expect(dialogOf(mounted)).toBeNull();
+        expect(window.location.pathname).toBe('/home');
+
+        const heldAgain = waitForPopStates(2);
+        await act(async () => {
+            window.history.back();
+            await heldAgain;
+        });
+        const approved = waitForPopStates(1);
+        await click(buttonByText(mounted, '移動する'));
+        await approved;
+
+        expect(window.location.pathname).toBe('/history-origin');
+        expect(dialogOf(mounted)).toBeNull();
+    });
+
+    it('ログアウト意図を止め、「続行する」で初めて実行する', async () => {
+        state.hasActiveJobs = true;
+        const mounted = await mountPage();
+
+        const proceed = vi.fn();
+        await act(async () => {
+            requestGuardedAction('signout', proceed);
+        });
+        expect(proceed).not.toHaveBeenCalled();
+        expect(dialogOf(mounted)?.textContent).toContain('続行すると変換・生成結果が失われます');
+
+        await click(buttonByText(mounted, 'このページに残る'));
+        expect(proceed).not.toHaveBeenCalled();
+        expect(dialogOf(mounted)).toBeNull();
+
+        await act(async () => {
+            requestGuardedAction('signout', proceed);
+        });
+        await click(buttonByText(mounted, '続行する'));
+        expect(proceed).toHaveBeenCalledTimes(1);
+        expect(dialogOf(mounted)).toBeNull();
+    });
+});

--- a/src/app/(dashboard)/home/page.test.tsx
+++ b/src/app/(dashboard)/home/page.test.tsx
@@ -81,6 +81,11 @@ vi.mock('@/hooks/useProcessingWorkflow', () => ({
     }),
 }));
 
+// S2-2: 離脱ガードは next/navigation を使う。ここは見出し・文言の錠なので中身を差し替える
+vi.mock('@/hooks/useNavigationGuard', () => ({
+    useNavigationGuard: () => ({ leaveConfirmation: null, approveLeave: vi.fn(), denyLeave: vi.fn() }),
+}));
+
 vi.mock('@/components/PromptListSidebar', () => ({
     PromptListSidebar: () => <div>プロンプト一覧</div>,
 }));

--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { AlertCircle } from 'lucide-react';
 import { FileDropZone } from '@/components/FileDropZone';
+import { ConversionSettings, DEFAULT_AUDIO_BITRATE } from '@/components/ConversionSettings';
+import { Dialog } from '@/components/ui/Dialog';
 import { ProcessingStatusList } from '@/components/ProcessingStatusList';
 import { DebugControls } from '@/components/DebugControls';
 import { BulkPromptSelector } from '@/components/BulkPromptSelector';
@@ -14,12 +16,16 @@ import { useFileManagement } from '@/hooks/useFileManagement';
 import { usePromptManagement } from '@/hooks/usePromptManagement';
 import { useVideoProcessing } from '@/hooks/useVideoProcessing';
 import { useProcessingWorkflow } from '@/hooks/useProcessingWorkflow';
+import { useNavigationGuard } from '@/hooks/useNavigationGuard';
 import { DebugErrorMode, FileProcessingStatus } from '@/types/processing';
 import { Prompt } from '@/lib/prompts';
 import { useAuth } from '@/hooks/useAuth';
 import { createLogger } from '@/lib/logger';
 
 const homePageLogger = createLogger('HomePage');
+
+/** S2-2: 離脱ガードが history.state に埋める印。文書画面の印と衝突しない名前にする */
+const HOME_PROCESSING_GUARD_STATE_KEY = '__homeProcessingGuard';
 
 /**
  * V3: ファイル削除は fileIds と processingStatuses を同じ fileId で同時に落とす。
@@ -53,7 +59,8 @@ export default function HomePage() {
   // 🎬 動画を直接送信する機能（試験的）
   const [sendVideoDirectly, setSendVideoDirectly] = useState(false);
 
-  const bitrate = '192k';
+  // S2-1: 192k 固定だと約 10 分で inline 上限に達して失敗していた。既定を 128k に下げ、画面から選べるようにする
+  const [bitrate, setBitrate] = useState<string>(DEFAULT_AUDIO_BITRATE);
   const sampleRate = 44100;
 
   const {
@@ -101,6 +108,16 @@ export default function HomePage() {
     forceDiscardProcessing,
     countPendingSaves,
   } = useVideoProcessing(availablePrompts, debugErrorMode, () => { });
+
+  // S2-2: 実行中のジョブか保存待ちの下書きがある間は、離脱 (リロード/戻る/リンク/ログイン・ログアウト) を
+  // 確認してから通す。何もしないと unmount で全ジョブが中止され、課金済みの生成結果が無言で消える
+  const { leaveConfirmation, approveLeave, denyLeave } = useNavigationGuard({
+    active: needsDiscardConfirm,
+    stateKey: HOME_PROCESSING_GUARD_STATE_KEY,
+  });
+  const leaveDialogTitleId = useId();
+  const leaveDialogDescriptionId = useId();
+  const leaveStayButtonRef = useRef<HTMLButtonElement>(null);
 
   const {
     handleStartProcessing,
@@ -337,6 +354,15 @@ export default function HomePage() {
                     音声変換をスキップして動画をそのまま送信します。ファイルサイズが大きいと失敗することがあります。
                   </p>
                 </div>
+              )}
+
+              {/* S2-1: ビットレートは送れる長さを決める。開始前にだけ選べる */}
+              {selectedFiles.length > 0 && !hasStatuses && (
+                <ConversionSettings
+                  bitrate={bitrate}
+                  onBitrateChange={setBitrate}
+                  disabled={isBusy}
+                />
               )}
 
               {selectedFiles.length === 0 && (
@@ -604,6 +630,49 @@ export default function HomePage() {
         onSave={handlePromptSaved}
         onDelete={handlePromptDeleted}
       />
+
+      {/* S2-2: 処理中の離脱確認。文書画面の未保存ガードと同じ共通 Dialog で出す */}
+      {leaveConfirmation && (
+        <Dialog
+          isOpen
+          onClose={denyLeave}
+          initialFocusRef={leaveStayButtonRef}
+          aria-labelledby={leaveDialogTitleId}
+          aria-describedby={leaveDialogDescriptionId}
+          className="w-[calc(100%-2rem)] max-w-md rounded-xl border-0 bg-white p-6 shadow-2xl"
+        >
+          <h2 id={leaveDialogTitleId} className="text-lg font-bold text-gray-900">
+            処理中です
+          </h2>
+          <p id={leaveDialogDescriptionId} className="mt-2 text-sm leading-6 text-gray-600">
+            {leaveConfirmation.kind === 'action'
+              ? '続行すると変換・生成結果が失われます。続行しますか？'
+              : '移動すると変換・生成結果が失われます。移動しますか？'}
+          </p>
+          {pendingSaveCount > 0 && (
+            <p className="mt-2 text-sm font-medium text-red-900">
+              生成済みで保存待ちの文書 {pendingSaveCount} 件が失われます。
+            </p>
+          )}
+          <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <button
+              ref={leaveStayButtonRef}
+              type="button"
+              onClick={denyLeave}
+              className="min-h-11 rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              このページに残る
+            </button>
+            <button
+              type="button"
+              onClick={approveLeave}
+              className="min-h-11 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2"
+            >
+              {leaveConfirmation.kind === 'action' ? '続行する' : '移動する'}
+            </button>
+          </div>
+        </Dialog>
+      )}
     </div>
   );
 }

--- a/src/app/(dashboard)/home/page.wiring.test.tsx
+++ b/src/app/(dashboard)/home/page.wiring.test.tsx
@@ -15,6 +15,7 @@ const reactHarness = vi.hoisted(() => ({
 const hookMocks = vi.hoisted(() => ({
     resetProcessing: vi.fn(),
     forceDiscardProcessing: vi.fn(),
+    handleStartProcessing: vi.fn(),
     handleRemoveFile: vi.fn(),
     clearFiles: vi.fn(),
     statuses: [] as FileProcessingStatus[],
@@ -29,6 +30,9 @@ vi.mock('react', async () => {
     return {
         ...actual,
         useCallback: <T,>(callback: T) => callback,
+        // S2-2: 離脱ダイアログ用の ref / id。描画器なしで呼ぶので本物は使えない
+        useRef: <T,>(initialValue: T) => ({ current: initialValue }),
+        useId: () => 'home-test-id',
         useEffect: (effect: () => void | (() => void)) => {
             reactHarness.effects.push(() => { effect(); });
         },
@@ -123,12 +127,17 @@ vi.mock('@/hooks/useVideoProcessing', () => ({
 
 vi.mock('@/hooks/useProcessingWorkflow', () => ({
     useProcessingWorkflow: () => ({
-        handleStartProcessing: vi.fn(),
+        handleStartProcessing: hookMocks.handleStartProcessing,
         handleResumeFile: vi.fn(),
         workflowError: null,
         clearWorkflowError: vi.fn(),
         reportWorkflowError: vi.fn(),
     }),
+}));
+
+// S2-2: 離脱ガードは next/navigation を使う。この配線テストの対象外なので差し替える
+vi.mock('@/hooks/useNavigationGuard', () => ({
+    useNavigationGuard: () => ({ leaveConfirmation: null, approveLeave: vi.fn(), denyLeave: vi.fn() }),
 }));
 
 vi.mock('@/components/PromptListSidebar', () => ({ PromptListSidebar: () => null }));
@@ -456,5 +465,33 @@ describe('per-file removal gate (G3)', () => {
         expect(hookMocks.handleRemoveFile).not.toHaveBeenCalled();
         expect(hookMocks.statuses).toHaveLength(1);
         expect(render().text).not.toContain('保存されていない生成結果があります');
+    });
+});
+
+describe('bitrate wiring (S2-1)', () => {
+    beforeEach(() => {
+        hookMocks.fileIds = ['media-1'];
+        hookMocks.handleStartProcessing.mockResolvedValue({ ok: true });
+    });
+
+    it('既定の 128k を開始処理へ渡す (192k 固定だと約 10 分で送れなくなる)', async () => {
+        await click('変換・文書生成を開始する');
+
+        expect(hookMocks.handleStartProcessing).toHaveBeenCalledTimes(1);
+        expect(hookMocks.handleStartProcessing.mock.calls[0][2]).toBe('128k');
+        expect(hookMocks.handleStartProcessing.mock.calls[0][3]).toBe(44100);
+    });
+
+    it('画面で選んだビットレートを開始処理へ渡す', async () => {
+        const settings = render().elements.find(element =>
+            typeof element.props.onBitrateChange === 'function'
+        );
+        expect(settings, 'ConversionSettings が配線されていない').toBeDefined();
+        expect(settings!.props.bitrate).toBe('128k');
+
+        (settings!.props.onBitrateChange as (bitrate: string) => void)('64k');
+        await click('変換・文書生成を開始する');
+
+        expect(hookMocks.handleStartProcessing.mock.calls[0][2]).toBe('64k');
     });
 });

--- a/src/app/(dashboard)/layout.test.tsx
+++ b/src/app/(dashboard)/layout.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+/**
+ * (dashboard) レイアウトが未捕捉エラー観測 (S2-8) を起動する配線の錠。
+ * 純関数 (clientErrorReporter) だけ守っても、この1行が消えると観測は全滅するので
+ * マウント時の呼び出しを実マウントで検査する。
+ */
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setupClientErrorReporter = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/clientErrorReporter', () => ({ setupClientErrorReporter }));
+vi.mock('@/components/AppShell', () => ({
+    AppShell: ({ children }: { children: React.ReactNode }) => <div data-shell="">{children}</div>,
+}));
+
+import DashboardLayout from './layout';
+
+describe('DashboardLayout の未捕捉エラー観測 (S2-8)', () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeAll(() => {
+        (
+            globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+        ).IS_REACT_ACT_ENVIRONMENT = true;
+    });
+
+    afterAll(() => {
+        (
+            globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+        ).IS_REACT_ACT_ENVIRONMENT = false;
+    });
+
+    beforeEach(() => {
+        setupClientErrorReporter.mockClear();
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            root.unmount();
+        });
+        container.remove();
+    });
+
+    it('マウント時に setupClientErrorReporter を呼び、子をシェルの中へ描画する', async () => {
+        await act(async () => {
+            root.render(
+                <DashboardLayout>
+                    <p>本文</p>
+                </DashboardLayout>,
+            );
+        });
+
+        expect(setupClientErrorReporter).toHaveBeenCalledTimes(1);
+        expect(container.querySelector('[data-shell] p')?.textContent).toBe('本文');
+    });
+
+    it('StrictMode 配下でも子を描画し、setup を呼ぶ (冪等性は reporter 側が担う)', async () => {
+        await act(async () => {
+            root.render(
+                <React.StrictMode>
+                    <DashboardLayout>
+                        <p>本文</p>
+                    </DashboardLayout>
+                </React.StrictMode>,
+            );
+        });
+
+        expect(setupClientErrorReporter).toHaveBeenCalled();
+        expect(container.querySelector('[data-shell] p')?.textContent).toBe('本文');
+    });
+
+    it('静的レンダリング (SSR) では effect が走らず setup を呼ばない', () => {
+        const html = renderToStaticMarkup(
+            <DashboardLayout>
+                <p>本文</p>
+            </DashboardLayout>,
+        );
+
+        expect(html).toContain('<p>本文</p>');
+        expect(setupClientErrorReporter).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,12 +1,29 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AppShell } from '@/components/AppShell';
+import { setupClientErrorReporter } from '@/lib/clientErrorReporter';
+
+/* 未捕捉エラー観測 (S2-8) を1回だけ起動する最小のクライアント境界。
+   登録は setupClientErrorReporter 側で冪等なので、StrictMode の effect 二重実行や
+   レイアウト再マウントで二重登録にはならない。unmount で外さないのは、リスナーが
+   ページ寿命の観測用で、ルート遷移のたびに監視を切らないため。 */
+function ClientErrorReporterMount(): null {
+    useEffect(() => {
+        setupClientErrorReporter();
+    }, []);
+    return null;
+}
 
 export default function DashboardLayout({
     children,
 }: {
     children: React.ReactNode;
 }) {
-    return <AppShell>{children}</AppShell>;
+    return (
+        <>
+            <ClientErrorReporterMount />
+            <AppShell>{children}</AppShell>
+        </>
+    );
 }

--- a/src/components/AppHeader.guardedActions.test.tsx
+++ b/src/components/AppHeader.guardedActions.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SIGN_IN_LABEL } from '@/components/ui/labels';
+import { NAVIGATION_INTENT_EVENT, requestGuardedAction } from '@/hooks/useNavigationGuard';
+
+/**
+ * S2-2: ヘッダーのログイン/ログアウトは、処理中の画面に問い合わせてから実行する。
+ * 問い合わせ (requestGuardedAction) を止める側が居なければ即実行、居れば承認まで待つ。
+ */
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+
+const state = vi.hoisted(() => ({
+    user: { uid: 'u1', email: 'a@example.com', displayName: '東野', providerData: [{ providerId: 'password' }] } as
+        | { uid: string; email: string; displayName: string; providerData: { providerId: string }[] }
+        | null,
+    signOutNow: vi.fn(),
+    beginAccountDeletion: vi.fn(),
+    authModalOpen: [] as boolean[],
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+    useAuth: () => ({ user: state.user, loading: false }),
+}));
+vi.mock('@/hooks/useAdmin', async () => {
+    const { adminAccessResult } = await import('@/testUtils/hookResults');
+    return { useAdmin: () => adminAccessResult('denied') };
+});
+vi.mock('@/hooks/useSystemNotifications', async () => {
+    const { systemNotificationsResult } = await import('@/testUtils/hookResults');
+    return {
+        useSystemNotifications: () => systemNotificationsResult({
+            notifications: [],
+            dismissedIds: [],
+            error: null,
+        }),
+    };
+});
+vi.mock('next/navigation', () => ({
+    usePathname: () => '/home',
+    useSearchParams: () => new URLSearchParams(''),
+}));
+vi.mock('next/link', () => ({
+    default: ({
+        children,
+        href,
+        ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...props}>{children}</a>
+    ),
+}));
+vi.mock('@/lib/auth', () => ({ signOutNow: state.signOutNow }));
+vi.mock('./AccountDeletionFlow', () => ({
+    useAccountDeletionFlow: () => ({
+        beginAccountDeletion: state.beginAccountDeletion,
+        accountDeletionDialog: null,
+    }),
+}));
+vi.mock('@/lib/relationships', () => ({
+    subscribeToPendingSubordinateRelationships: vi.fn(() => vi.fn()),
+}));
+vi.mock('@/lib/logger', () => ({
+    createLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+vi.mock('./AuthModal', () => ({
+    default: ({ isOpen }: { isOpen: boolean }) => {
+        state.authModalOpen.push(isOpen);
+        return null;
+    },
+}));
+vi.mock('./PasswordChangeModal', () => ({ default: () => null }));
+vi.mock('./DisplayNameModal', () => ({ default: () => null }));
+
+const { AppHeader } = await import('./AppHeader');
+
+type Mounted = { container: HTMLDivElement; root: Root };
+const mountedHeaders = new Set<Mounted>();
+
+async function mountHeader(): Promise<Mounted> {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root = createRoot(container);
+    const mounted = { container, root };
+    mountedHeaders.add(mounted);
+    await act(async () => {
+        root.render(<AppHeader />);
+    });
+    return mounted;
+}
+
+function buttonByText(mounted: Mounted, label: string): HTMLButtonElement {
+    const button = Array.from(mounted.container.querySelectorAll<HTMLButtonElement>('button'))
+        .find(element => element.textContent?.trim() === label);
+    if (!button) throw new Error(`${label} ボタンがありません`);
+    return button;
+}
+
+async function click(element: HTMLElement): Promise<void> {
+    await act(async () => {
+        element.click();
+        await Promise.resolve();
+    });
+}
+
+/** ガード中の画面の代わりに、意図イベントを止める側を立てる */
+function installBlockingGuard(): { proceeds: Array<() => void>; remove: () => void } {
+    const proceeds: Array<() => void> = [];
+    const listener = (event: Event) => {
+        event.preventDefault();
+        proceeds.push((event as CustomEvent<{ proceed: () => void }>).detail.proceed);
+    };
+    window.addEventListener(NAVIGATION_INTENT_EVENT, listener);
+    return { proceeds, remove: () => window.removeEventListener(NAVIGATION_INTENT_EVENT, listener) };
+}
+
+describe('requestGuardedAction', () => {
+    it('止める側が居なければその場で実行する', () => {
+        const proceed = vi.fn();
+        requestGuardedAction('signout', proceed);
+        expect(proceed).toHaveBeenCalledTimes(1);
+    });
+
+    it('止める側が preventDefault したら実行せず、承認で渡した proceed を呼ぶ', () => {
+        const guard = installBlockingGuard();
+        try {
+            const proceed = vi.fn();
+            requestGuardedAction('signin', proceed);
+            expect(proceed).not.toHaveBeenCalled();
+            expect(guard.proceeds).toHaveLength(1);
+
+            guard.proceeds[0]();
+            expect(proceed).toHaveBeenCalledTimes(1);
+        } finally {
+            guard.remove();
+        }
+    });
+});
+
+describe('AppHeader の認証操作は離脱ガードを通す (S2-2)', () => {
+    beforeEach(() => {
+        state.user = { uid: 'u1', email: 'a@example.com', displayName: '東野', providerData: [{ providerId: 'password' }] };
+        state.signOutNow.mockReset().mockResolvedValue(undefined);
+        state.beginAccountDeletion.mockReset().mockResolvedValue(undefined);
+        state.authModalOpen = [];
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            value: vi.fn(() => ({
+                matches: false,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            })),
+        });
+        Object.defineProperty(window, 'requestAnimationFrame', {
+            configurable: true,
+            value: vi.fn((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            }),
+        });
+    });
+
+    afterEach(async () => {
+        for (const mounted of [...mountedHeaders]) {
+            mountedHeaders.delete(mounted);
+            await act(async () => {
+                mounted.root.unmount();
+            });
+            mounted.container.remove();
+        }
+        document.body.replaceChildren();
+        vi.restoreAllMocks();
+    });
+
+    it('ログアウトは、止める側が居なければそのまま実行する', async () => {
+        const mounted = await mountHeader();
+        await click(buttonByText(mounted, '東野'));
+        await click(buttonByText(mounted, 'ログアウト'));
+
+        expect(state.signOutNow).toHaveBeenCalledTimes(1);
+    });
+
+    it('ログアウトは、処理中の画面が止めたら承認まで実行しない', async () => {
+        const guard = installBlockingGuard();
+        try {
+            const mounted = await mountHeader();
+            await click(buttonByText(mounted, '東野'));
+            await click(buttonByText(mounted, 'ログアウト'));
+
+            expect(state.signOutNow).not.toHaveBeenCalled();
+            expect(guard.proceeds).toHaveLength(1);
+
+            guard.proceeds[0]();
+            expect(state.signOutNow).toHaveBeenCalledTimes(1);
+        } finally {
+            guard.remove();
+        }
+    });
+
+    it('ログインの開始も同じ問い合わせを通す', async () => {
+        state.user = null;
+        const guard = installBlockingGuard();
+        try {
+            const mounted = await mountHeader();
+            const signInButton = Array.from(mounted.container.querySelectorAll<HTMLButtonElement>('button'))
+                .find(element => element.textContent?.trim() === SIGN_IN_LABEL);
+            expect(signInButton).toBeDefined();
+
+            await click(signInButton!);
+            expect(state.authModalOpen.at(-1)).toBe(false);
+            expect(guard.proceeds).toHaveLength(1);
+
+            await act(async () => {
+                guard.proceeds[0]();
+            });
+            expect(state.authModalOpen.at(-1)).toBe(true);
+        } finally {
+            guard.remove();
+        }
+    });
+
+    it('アカウント削除の開始も同じ問い合わせを通す', async () => {
+        const guard = installBlockingGuard();
+        try {
+            const mounted = await mountHeader();
+            await click(buttonByText(mounted, '東野'));
+            await click(buttonByText(mounted, 'アカウントを削除'));
+
+            expect(state.beginAccountDeletion).not.toHaveBeenCalled();
+            guard.proceeds[0]();
+            expect(state.beginAccountDeletion).toHaveBeenCalledTimes(1);
+        } finally {
+            guard.remove();
+        }
+    });
+});

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useAdmin } from '@/hooks/useAdmin';
 import { Music, Shield, Home, FileText, Users, ChevronDown, LogOut, Key, Trash2, User, Edit3, Bell, Menu, X } from 'lucide-react';
 import { signOutNow } from '@/lib/auth';
+import { requestGuardedAction } from '@/hooks/useNavigationGuard';
 import { createLogger } from '@/lib/logger';
 import AuthModal from './AuthModal';
 import PasswordChangeModal from './PasswordChangeModal';
@@ -192,10 +193,18 @@ export const AppHeader: React.FC = () => {
         setShowMobileTeamMenu(false);
     };
 
-    const handleLogout = async () => {
+    // S2-2: 認証の変更は処理中のジョブを中止して課金済みの結果を消す。
+    // 処理中の画面 (ホーム) が居れば問い合わせ、承認されてから実行する。
+    const handleLogout = () => {
         setShowDropdown(false);
         closeMobileMenu();
-        await signOutNow();
+        requestGuardedAction('signout', () => {
+            void signOutNow();
+        });
+    };
+
+    const openAuthModal = () => {
+        requestGuardedAction('signin', () => setShowAuthModal(true));
     };
 
     const handlePasswordChange = () => {
@@ -207,7 +216,9 @@ export const AppHeader: React.FC = () => {
     const handleDeleteAccount = () => {
         setShowDropdown(false);
         closeMobileMenu();
-        void beginAccountDeletion();
+        requestGuardedAction('account-deletion', () => {
+            void beginAccountDeletion();
+        });
     };
 
     const isEmailProvider = user?.providerData.some(p => p.providerId === 'password') || false;
@@ -433,7 +444,7 @@ export const AppHeader: React.FC = () => {
                                     )}
                                 </div>
                             ) : (
-                                <Button onClick={() => setShowAuthModal(true)}>{SIGN_IN_LABEL}</Button>
+                                <Button onClick={openAuthModal}>{SIGN_IN_LABEL}</Button>
                             )}
                         </div>
 
@@ -626,7 +637,7 @@ export const AppHeader: React.FC = () => {
                                                 className="w-full"
                                                 onClick={() => {
                                                     closeMobileMenu();
-                                                    setShowAuthModal(true);
+                                                    openAuthModal();
                                                 }}
                                             >
                                                 {SIGN_IN_LABEL}

--- a/src/components/ConversionSettings.test.tsx
+++ b/src/components/ConversionSettings.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+    AUDIO_BITRATE_OPTIONS,
+    ConversionSettings,
+    DEFAULT_AUDIO_BITRATE,
+} from './ConversionSettings';
+
+const render = (bitrate: string, disabled = false) =>
+    renderToStaticMarkup(
+        <ConversionSettings bitrate={bitrate} onBitrateChange={vi.fn()} disabled={disabled} />,
+    );
+
+const radios = (markup: string): string[] =>
+    [...markup.matchAll(/<input\b[^>]*type="radio"[^>]*>/g)].map(match => match[0]);
+
+describe('ConversionSettings (S2-1: ビットレート選択)', () => {
+    it('既定は安全側の 128k (192k だと約 10 分で送れなくなる)', () => {
+        expect(DEFAULT_AUDIO_BITRATE).toBe('128k');
+        expect(AUDIO_BITRATE_OPTIONS.map(option => option.value)).toContain(DEFAULT_AUDIO_BITRATE);
+    });
+
+    it('64 / 96 / 128 / 192 kbps を選べる', () => {
+        expect(AUDIO_BITRATE_OPTIONS.map(option => option.value)).toEqual(['64k', '96k', '128k', '192k']);
+        expect(radios(render('128k'))).toHaveLength(4);
+    });
+
+    it('現在値のラジオだけが checked', () => {
+        const checked = radios(render('64k')).filter(tag => tag.includes('checked'));
+        expect(checked).toHaveLength(1);
+        expect(checked[0]).toContain('value="64k"');
+    });
+
+    it('各選択肢に「そのまま送れる目安」の分数を出す', () => {
+        const markup = render('128k');
+        expect(markup).toContain('約26分');
+        expect(markup).toContain('約17分');
+        expect(markup).toContain('約13分');
+        expect(markup).toContain('約8分');
+    });
+
+    it('処理中は fieldset ごと無効になる', () => {
+        expect(render('128k', true)).toMatch(/<fieldset[^>]*\bdisabled\b/);
+        expect(render('128k', false)).not.toMatch(/<fieldset[^>]*\bdisabled\b/);
+    });
+});

--- a/src/components/ConversionSettings.tsx
+++ b/src/components/ConversionSettings.tsx
@@ -1,116 +1,67 @@
 'use client';
 
 import React from 'react';
+import { estimateInlineLimitMinutes } from '@/lib/inlineMediaBudget';
+
+/**
+ * S2-1: 既定は 128k。192k だと約 10 分でそのまま送れる上限に達し、長い商談録音が全滅していた。
+ * 音声認識の用途では 128k で十分で、そのまま送れる長さが 1.5 倍に伸びる。
+ */
+export const DEFAULT_AUDIO_BITRATE = '128k';
+
+export const AUDIO_BITRATE_OPTIONS = [
+    { value: '64k', label: '64 kbps', description: '長い録音向け（音質は低め）' },
+    { value: '96k', label: '96 kbps', description: '長めの録音向け' },
+    { value: '128k', label: '128 kbps', description: '標準（推奨）' },
+    { value: '192k', label: '192 kbps', description: '高音質（短い録音向け）' },
+] as const;
 
 interface ConversionSettingsProps {
     bitrate: string;
-    sampleRate: number;
     onBitrateChange: (bitrate: string) => void;
-    onSampleRateChange: (sampleRate: number) => void;
+    disabled?: boolean;
 }
 
 export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
     bitrate,
-    sampleRate,
     onBitrateChange,
-    onSampleRateChange,
-}) => {
-    const bitrateOptions = [
-        { value: '128k', label: '128 kbps (標準品質)' },
-        { value: '192k', label: '192 kbps (高品質)' },
-        { value: '256k', label: '256 kbps (最高品質)' },
-        { value: '320k', label: '320 kbps (無損品質)' },
-    ];
-
-    const sampleRateOptions = [
-        { value: 44100, label: '44.1 kHz (CD品質)' },
-        { value: 48000, label: '48 kHz (DVD品質)' },
-        { value: 96000, label: '96 kHz (高解像度)' },
-    ];
-
-    return (
-        <div className="bg-gray-50 rounded-lg p-6">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">
-                変換設定
-            </h3>
-
-            <div className="space-y-6">
-                {/* ビットレート設定 */}
-                <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                        ビットレート
+    disabled = false,
+}) => (
+    <fieldset className="rounded-lg border border-gray-200 bg-gray-50 p-4" disabled={disabled}>
+        <legend className="px-1 text-sm font-medium text-gray-900">音声のビットレート</legend>
+        <p className="mt-1 text-[13px] text-gray-700">
+            低いほど長い録音をそのまま送れます。目安を超える長さは大きなファイル用の送信方式に自動で切り替えます。うまくいかない場合はビットレートを下げるか、ファイルを分割してください。
+        </p>
+        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {AUDIO_BITRATE_OPTIONS.map(option => {
+                const minutes = estimateInlineLimitMinutes(option.value);
+                return (
+                    <label
+                        key={option.value}
+                        className="flex min-h-11 cursor-pointer items-center rounded-lg border border-gray-200 bg-white p-3 transition-colors hover:bg-gray-100 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50"
+                    >
+                        <input
+                            type="radio"
+                            name="audio-bitrate"
+                            value={option.value}
+                            checked={bitrate === option.value}
+                            onChange={event => onBitrateChange(event.target.value)}
+                            className="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+                        />
+                        <span className="ml-3 min-w-0">
+                            <span className="block text-sm font-medium text-gray-900">
+                                {option.label}
+                                <span className="ml-2 font-normal text-gray-600">{option.description}</span>
+                            </span>
+                            {minutes !== null && (
+                                <span className="block text-xs text-gray-600">
+                                    そのまま送れる目安: 約{minutes}分
+                                </span>
+                            )}
+                        </span>
                     </label>
-                    <div className="grid grid-cols-2 gap-2">
-                        {bitrateOptions.map((option) => (
-                            <label
-                                key={option.value}
-                                className="flex items-center p-3 border rounded-lg cursor-pointer hover:bg-gray-100 transition-colors"
-                            >
-                                <input
-                                    type="radio"
-                                    name="bitrate"
-                                    value={option.value}
-                                    checked={bitrate === option.value}
-                                    onChange={(e) => onBitrateChange(e.target.value)}
-                                    className="mr-3"
-                                />
-                                <div>
-                                    <div className="text-sm font-medium text-gray-900">
-                                        {option.value}
-                                    </div>
-                                    <div className="text-xs text-gray-500">
-                                        {option.label}
-                                    </div>
-                                </div>
-                            </label>
-                        ))}
-                    </div>
-                </div>
-
-                {/* サンプルレート設定 */}
-                <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                        サンプルレート
-                    </label>
-                    <div className="space-y-2">
-                        {sampleRateOptions.map((option) => (
-                            <label
-                                key={option.value}
-                                className="flex items-center p-3 border rounded-lg cursor-pointer hover:bg-gray-100 transition-colors"
-                            >
-                                <input
-                                    type="radio"
-                                    name="sampleRate"
-                                    value={option.value}
-                                    checked={sampleRate === option.value}
-                                    onChange={(e) => onSampleRateChange(Number(e.target.value))}
-                                    className="mr-3"
-                                />
-                                <div>
-                                    <div className="text-sm font-medium text-gray-900">
-                                        {option.value.toLocaleString()} Hz
-                                    </div>
-                                    <div className="text-xs text-gray-500">
-                                        {option.label}
-                                    </div>
-                                </div>
-                            </label>
-                        ))}
-                    </div>
-                </div>
-
-                {/* 設定の説明 */}
-                <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                    <h4 className="text-sm font-medium text-blue-900 mb-2">
-                        設定について
-                    </h4>
-                    <ul className="text-xs text-blue-800 space-y-1">
-                        <li>• ビットレートが高いほど音質は向上しますが、ファイルサイズも大きくなります</li>
-                        <li>• サンプルレートは音の周波数範囲を決定します</li>
-                        <li>• 一般的な用途では192kbps/44.1kHzが推奨されます</li>
-                    </ul>
-                </div>
-            </div>
+                );
+            })}
         </div>
-    );
-};
+    </fieldset>
+);

--- a/src/components/DocumentListSidebar.rename.test.tsx
+++ b/src/components/DocumentListSidebar.rename.test.tsx
@@ -7,7 +7,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Transcription } from '@/lib/firestore';
-import { DocumentListSidebar } from './DocumentListSidebar';
+import { DOCUMENT_LIST_POLL_INTERVAL_MS, DocumentListSidebar } from './DocumentListSidebar';
 
 const mocks = vi.hoisted(() => ({
   getTranscriptions: vi.fn(),
@@ -134,10 +134,14 @@ describe('DocumentListSidebar 改名の楽観的並行性制御', () => {
   }
 
   async function pollAdvancesToOtherWriter(): Promise<void> {
+    const fetchCallsBeforePoll = mocks.getTranscriptions.mock.calls.length;
     mocks.getTranscriptions.mockResolvedValueOnce([documentAfterPoll]);
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5000);
+      await vi.advanceTimersByTimeAsync(DOCUMENT_LIST_POLL_INTERVAL_MS);
     });
+    // 定期取得が実際に着弾した証人。間隔が伸びて空振りすると、以降の
+    // 「版が前進しても」の検査が何も前進していない状態で緑になる。
+    expect(mocks.getTranscriptions.mock.calls.length).toBe(fetchCallsBeforePoll + 1);
   }
 
   async function typeTitleAndSave(nextTitle: string): Promise<void> {

--- a/src/components/DocumentListSidebar.test.tsx
+++ b/src/components/DocumentListSidebar.test.tsx
@@ -46,10 +46,36 @@ vi.mock('@/lib/logger', () => ({
 }));
 
 import {
+    DOCUMENT_LIST_POLL_INTERVAL_MS,
     DocumentListSidebar,
     DocumentListStatus,
 } from './DocumentListSidebar';
 import type { Transcription } from '@/lib/firestore';
+
+interface DocumentStub {
+    hidden: boolean;
+    addEventListener: ReturnType<typeof vi.fn>;
+    removeEventListener: ReturnType<typeof vi.fn>;
+}
+
+// node環境にはdocumentが無い。一覧effectが読むのは可視性(hidden)と
+// visibilitychangeの登録/解除だけなので、その最小面だけを立てる。
+function createDocumentStub(hidden: boolean): DocumentStub {
+    return {
+        hidden,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    };
+}
+
+function getVisibilityChangeHandler(documentStub: DocumentStub): () => void {
+    const registration = documentStub.addEventListener.mock.calls
+        .find(call => call[0] === 'visibilitychange');
+    if (typeof registration?.[1] !== 'function') {
+        throw new Error('visibilitychange ハンドラが登録されていません');
+    }
+    return registration[1] as () => void;
+}
 
 interface TestCollectionState {
     subjectKey: string | null;
@@ -272,6 +298,7 @@ describe('DocumentListSidebar', () => {
                 return 1;
             }),
         });
+        vi.stubGlobal('document', createDocumentStub(false));
     });
 
     afterEach(() => {
@@ -472,6 +499,72 @@ describe('DocumentListSidebar', () => {
                 ownerType: 'user',
             });
         });
+    });
+
+    it('表示中のタブは初回取得の後、30秒以上の間隔で定期取得を登録する', () => {
+        configureHookState({
+            subjectKey: userSubjectKey,
+            status: 'loading',
+            documents: [],
+        });
+        renderSidebar();
+
+        layoutEffects[0]();
+
+        expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+        const setIntervalMock = window.setInterval as unknown as ReturnType<typeof vi.fn>;
+        expect(setIntervalMock).toHaveBeenCalledTimes(1);
+        const [, delay] = setIntervalMock.mock.calls[0] as [() => void, number];
+        expect(delay).toBe(DOCUMENT_LIST_POLL_INTERVAL_MS);
+        expect(delay).toBeGreaterThanOrEqual(30_000);
+    });
+
+    it('非表示タブでは初回取得も定期取得も発生させず、表示に戻った時だけ即時1回取り直して周期を再開する', () => {
+        const documentStub = createDocumentStub(true);
+        vi.stubGlobal('document', documentStub);
+        configureHookState({
+            subjectKey: userSubjectKey,
+            status: 'loading',
+            documents: [],
+        });
+        const onListStateChange = vi.fn();
+        renderSidebar({ onListStateChange });
+        const setIntervalMock = window.setInterval as unknown as ReturnType<typeof vi.fn>;
+        const clearIntervalMock = window.clearInterval as unknown as ReturnType<typeof vi.fn>;
+
+        const cleanup = layoutEffects[0]();
+
+        // 非表示中は一覧の読取を一切発生させない(初回取得も定期取得の登録も無し)。
+        expect(mocks.getTranscriptions).not.toHaveBeenCalled();
+        expect(setIntervalMock).not.toHaveBeenCalled();
+        expect(onListStateChange).toHaveBeenLastCalledWith({ status: 'loading' });
+        const handleVisibilityChange = getVisibilityChangeHandler(documentStub);
+
+        // 非表示のままのvisibilitychangeでは取得しない。
+        handleVisibilityChange();
+        expect(mocks.getTranscriptions).not.toHaveBeenCalled();
+
+        // 表示に戻った時に即時1回取り直し、定期取得を開始する。
+        documentStub.hidden = false;
+        handleVisibilityChange();
+        expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+        expect(mocks.getTranscriptions).toHaveBeenCalledWith(100, {
+            ownerId: 'user-a',
+            ownerType: 'user',
+        });
+        expect(setIntervalMock).toHaveBeenCalledTimes(1);
+        expect(setIntervalMock.mock.calls[0][1]).toBeGreaterThanOrEqual(30_000);
+
+        // 再び非表示になったら定期取得を止める(取得は増えない)。
+        documentStub.hidden = true;
+        handleVisibilityChange();
+        expect(clearIntervalMock).toHaveBeenCalledWith(1);
+        expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+
+        // unmountでvisibilitychangeの購読を解除する。
+        cleanup?.();
+        expect(documentStub.removeEventListener)
+            .toHaveBeenCalledWith('visibilitychange', handleVisibilityChange);
     });
 
     it('ポーリング結果のIDとupdatedAtが同じなら文書参照を維持する', async () => {

--- a/src/components/DocumentListSidebar.tsx
+++ b/src/components/DocumentListSidebar.tsx
@@ -31,6 +31,10 @@ import { createLogger } from '@/lib/logger';
 
 const documentListLogger = createLogger('DocumentListSidebar');
 
+// 一覧の定期取り直し間隔。本文つき最大100件を毎回転送するため、5秒では
+// 待機中のタブだけで読取量が膨らむ(#9)。表示中のタブでも30秒未満にしない。
+export const DOCUMENT_LIST_POLL_INTERVAL_MS = 30_000;
+
 export type DocumentListStatus = 'loading' | 'success' | 'error';
 
 export interface DocumentListStateChange {
@@ -91,7 +95,7 @@ const getTimestampKey = (timestamp: ComparableTimestamp | undefined): string | n
 };
 
 const hashText = (value: string): string => {
-    // 5秒ポーリングで長い本文を比較するため、本文そのものではなく安定した指紋を使う。
+    // 定期取り直しで長い本文を比較するため、本文そのものではなく安定した指紋を使う。
     let hash = 2166136261;
     for (let index = 0; index < value.length; index += 1) {
         hash ^= value.charCodeAt(index);
@@ -341,14 +345,42 @@ export const DocumentListSidebar: React.FC<DocumentListSidebarProps> = ({
 
         if (subjectKey === null) return;
 
-        void loadTranscriptionsForSubject(subjectKey, ownerId, ownerType, generation, true);
-        const interval = window.setInterval(() => {
-            if (activeFetchRequestRef.current !== null) return;
-            void loadTranscriptionsForSubject(subjectKey, ownerId, ownerType, generation, false);
-        }, 5000);
+        // 非表示タブでは一覧の読取(本文つき最大100件)を一切発生させない。初回取得も
+        // 表示されるまで保留し、表示中だけ DOCUMENT_LIST_POLL_INTERVAL_MS ごとに静かに
+        // 取り直す。非表示→表示の復帰時は即時に1回取り直してから周期を仕切り直す。
+        let pollTimer: number | null = null;
+        const stopPolling = () => {
+            if (pollTimer === null) return;
+            window.clearInterval(pollTimer);
+            pollTimer = null;
+        };
+        const startPolling = () => {
+            stopPolling();
+            pollTimer = window.setInterval(() => {
+                if (activeFetchRequestRef.current !== null) return;
+                void loadTranscriptionsForSubject(subjectKey, ownerId, ownerType, generation, false);
+            }, DOCUMENT_LIST_POLL_INTERVAL_MS);
+        };
+        const handleVisibilityChange = () => {
+            if (document.hidden) {
+                stopPolling();
+                return;
+            }
+            if (activeFetchRequestRef.current === null) {
+                void loadTranscriptionsForSubject(subjectKey, ownerId, ownerType, generation, false);
+            }
+            startPolling();
+        };
+
+        if (!document.hidden) {
+            void loadTranscriptionsForSubject(subjectKey, ownerId, ownerType, generation, true);
+            startPolling();
+        }
+        document.addEventListener('visibilitychange', handleVisibilityChange);
 
         return () => {
-            window.clearInterval(interval);
+            stopPolling();
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
             invalidatePendingRequests();
         };
     }, [invalidatePendingRequests, loadTranscriptionsForSubject, ownerId, ownerType, subjectKey]);

--- a/src/components/DocumentListSidebar.visibility.test.tsx
+++ b/src/components/DocumentListSidebar.visibility.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+// 文書一覧の定期取得(本文つき最大100件)の負荷制御(#9)を実レンダリングで検証する。
+// 非表示タブでは読取をゼロにし、表示中は30秒間隔、復帰時に即時1回取り直す。
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Transcription } from '@/lib/firestore';
+import { DOCUMENT_LIST_POLL_INTERVAL_MS, DocumentListSidebar } from './DocumentListSidebar';
+
+const mocks = vi.hoisted(() => ({
+  getTranscriptions: vi.fn(),
+  deleteTranscription: vi.fn(),
+  updateTranscription: vi.fn(),
+}));
+
+vi.mock('@/lib/firestore', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/firestore')>();
+  return {
+    ...actual,
+    getTranscriptions: mocks.getTranscriptions,
+    deleteTranscription: mocks.deleteTranscription,
+    updateTranscription: mocks.updateTranscription,
+  };
+});
+
+vi.mock('@/lib/firebase', () => ({
+  db: { name: 'mock-firestore' },
+  auth: { currentUser: null },
+  storage: { name: 'mock-storage' },
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { uid: 'user-a' }, loading: false }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ error: vi.fn(), info: vi.fn() }),
+}));
+
+const documentFixture: Transcription = {
+  id: 'document-a',
+  title: '文書A',
+  fileName: 'recording.wav',
+  text: '本文',
+  promptName: '議事録',
+  createdAt: new Date('2026-09-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-09-01T01:00:00.000Z'),
+};
+
+const expectedOwnerScope = { ownerId: 'user-a', ownerType: 'user' };
+
+function setDocumentHidden(hidden: boolean): void {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => (hidden ? 'hidden' : 'visible'),
+  });
+}
+
+function resetDocumentVisibility(): void {
+  delete (document as { hidden?: boolean }).hidden;
+  delete (document as { visibilityState?: string }).visibilityState;
+}
+
+async function changeVisibility(hidden: boolean): Promise<void> {
+  setDocumentHidden(hidden);
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+  });
+}
+
+async function advanceBy(milliseconds: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(milliseconds);
+  });
+}
+
+describe('DocumentListSidebar 一覧取得の可視性制御', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onListStateChange: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+      .IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    mocks.getTranscriptions.mockReset();
+    mocks.getTranscriptions.mockResolvedValue([documentFixture]);
+    onListStateChange = vi.fn();
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: vi.fn((callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      }),
+    });
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    resetDocumentVisibility();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function mount(): Promise<void> {
+    await act(async () => {
+      root.render(
+        <DocumentListSidebar
+          onDocumentClick={vi.fn()}
+          onListStateChange={onListStateChange}
+        />,
+      );
+    });
+  }
+
+  it('非表示タブでは初回取得も定期取得も発生させず、表示に戻った時に1回だけ取り直す', async () => {
+    setDocumentHidden(true);
+    await mount();
+    await advanceBy(DOCUMENT_LIST_POLL_INTERVAL_MS * 3);
+
+    // 非表示の間は本文つき一覧の読取がゼロ(初回取得も表示まで保留)。
+    expect(mocks.getTranscriptions).not.toHaveBeenCalled();
+    expect(container.querySelector('[aria-label="文書一覧を読み込み中"]')).not.toBeNull();
+    expect(onListStateChange).toHaveBeenLastCalledWith({ status: 'loading' });
+
+    await changeVisibility(false);
+
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+    expect(mocks.getTranscriptions).toHaveBeenCalledWith(100, expectedOwnerScope);
+    expect(container.querySelector('button[aria-label="「文書A」を選択"]')).not.toBeNull();
+    expect(onListStateChange).toHaveBeenLastCalledWith({ status: 'success', count: 1 });
+
+    // 表示に戻った後は通常の周期で取り直す。
+    await advanceBy(DOCUMENT_LIST_POLL_INTERVAL_MS);
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(2);
+  });
+
+  it('表示中は30秒間隔で取り直し、非表示になった瞬間に止まり、復帰時に即時1回取り直して周期を仕切り直す', async () => {
+    await mount();
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+
+    // 間隔の境界: 30秒未満では取り直さず、30秒でちょうど1回。
+    await advanceBy(DOCUMENT_LIST_POLL_INTERVAL_MS - 1);
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+    await advanceBy(1);
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(2);
+    expect(DOCUMENT_LIST_POLL_INTERVAL_MS).toBeGreaterThanOrEqual(30_000);
+
+    // 非表示になったら、どれだけ時間が経っても読取は増えない。
+    await changeVisibility(true);
+    await advanceBy(DOCUMENT_LIST_POLL_INTERVAL_MS * 5);
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(2);
+
+    // 復帰時は即時に1回取り直し、その時点から周期を数え直す。
+    await changeVisibility(false);
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(3);
+    await advanceBy(DOCUMENT_LIST_POLL_INTERVAL_MS - 1);
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(3);
+    await advanceBy(1);
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(4);
+  });
+
+  it('復帰時に取得が飛行中なら重ねて取り直さず、飛行中の結果を待つ', async () => {
+    let resolveInitialFetch!: (documents: Transcription[]) => void;
+    mocks.getTranscriptions.mockReturnValueOnce(new Promise(resolve => {
+      resolveInitialFetch = resolve;
+    }));
+    await mount();
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+
+    await changeVisibility(true);
+    await changeVisibility(false);
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveInitialFetch([documentFixture]);
+      await Promise.resolve();
+    });
+    expect(onListStateChange).toHaveBeenLastCalledWith({ status: 'success', count: 1 });
+    await advanceBy(DOCUMENT_LIST_POLL_INTERVAL_MS);
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(2);
+  });
+
+  it('unmount後はvisibilitychangeでも周期でも取り直さない', async () => {
+    await mount();
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+    await changeVisibility(true);
+    await changeVisibility(false);
+    await advanceBy(DOCUMENT_LIST_POLL_INTERVAL_MS * 3);
+
+    expect(mocks.getTranscriptions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useNavigationGuard.ts
+++ b/src/hooks/useNavigationGuard.ts
@@ -1,0 +1,493 @@
+'use client';
+
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+/**
+ * S2-2: 処理中の画面から離脱するときに確認を挟む。
+ * `documents/page.tsx` の未保存ガード (beforeunload + SPA内クリック監視 + popstate の sentinel 保留) を
+ * 汎用化して移したもの。加えて、画面遷移ではない離脱 (ログイン/ログアウト/退会) を
+ * requestGuardedAction 経由で問い合わせられるようにしている。
+ */
+
+export const NAVIGATION_INTENT_EVENT = 'app:navigation-intent';
+
+export type GuardedActionKind = 'signin' | 'signout' | 'account-deletion';
+
+export interface NavigationIntentDetail {
+    kind: GuardedActionKind;
+    proceed: () => void;
+}
+
+/**
+ * 画面遷移ではない離脱 (認証の変更など) を、ガード中の画面に問い合わせてから実行する。
+ * 誰も preventDefault しなければその場で proceed する。ガード中の画面が止めたときは、
+ * 利用者が承認した時点でその画面が proceed を呼ぶ。
+ */
+export function requestGuardedAction(kind: GuardedActionKind, proceed: () => void): void {
+    if (typeof window === 'undefined') {
+        proceed();
+        return;
+    }
+    const event = new CustomEvent<NavigationIntentDetail>(NAVIGATION_INTENT_EVENT, {
+        cancelable: true,
+        detail: { kind, proceed },
+    });
+    if (window.dispatchEvent(event)) proceed();
+}
+
+type HistoryGuardRole = 'base' | 'sentinel';
+
+type HistoryGuardSession = {
+    id: string;
+    originalState: unknown;
+    url: string;
+};
+
+type HistoryExitApproval = 'none' | 'history' | 'router';
+
+export type LeaveConfirmationRequest =
+    | { kind: 'history' }
+    | { kind: 'router'; target: HTMLElement }
+    | { kind: 'action'; detail: NavigationIntentDetail };
+
+type LeaveConfirmationActions = {
+    approve: () => void;
+    deny: () => void;
+};
+
+export interface UseNavigationGuardOptions {
+    /** true の間だけ離脱を確認する。false になった時点で保留中の確認も閉じる */
+    active: boolean;
+    /** history.state に埋める印のキー。画面ごとに固有の名前にする */
+    stateKey: string;
+}
+
+export interface NavigationGuardHandle {
+    leaveConfirmation: LeaveConfirmationRequest | null;
+    approveLeave: () => void;
+    denyLeave: () => void;
+}
+
+export function useNavigationGuard({ active, stateKey }: UseNavigationGuardOptions): NavigationGuardHandle {
+    const pathname = usePathname();
+    const historyGuardId = useId();
+    const [leaveConfirmation, setLeaveConfirmation] = useState<LeaveConfirmationRequest | null>(null);
+    const leaveConfirmationActionsRef = useRef<LeaveConfirmationActions | null>(null);
+    const historyGuardSessionRef = useRef<HistoryGuardSession | null>(null);
+    const historyExitApprovalRef = useRef<HistoryExitApproval>('none');
+    const routerExitStartPathnameRef = useRef<string | null>(null);
+    const componentMountedRef = useRef(false);
+    const activeRef = useRef(active);
+
+    useLayoutEffect(() => {
+        activeRef.current = active;
+    }, [active]);
+
+    useEffect(() => {
+        componentMountedRef.current = true;
+        return () => {
+            componentMountedRef.current = false;
+            routerExitStartPathnameRef.current = null;
+        };
+    }, []);
+
+    useEffect(() => {
+        const navigationStartPathname = routerExitStartPathnameRef.current;
+        if (navigationStartPathname === null || pathname === navigationStartPathname) return;
+
+        routerExitStartPathnameRef.current = null;
+        historyExitApprovalRef.current = 'none';
+    }, [pathname]);
+
+    useEffect(() => {
+        if (!active) return;
+
+        const guardId = historyGuardId;
+        const readGuardRole = (state: unknown): HistoryGuardRole | null => {
+            if (!state || typeof state !== 'object') return null;
+            const marker = (state as Record<string, unknown>)[stateKey];
+            if (!marker || typeof marker !== 'object') return null;
+            const markerRecord = marker as Record<string, unknown>;
+            if (markerRecord.id !== guardId) return null;
+            return markerRecord.role === 'base' || markerRecord.role === 'sentinel'
+                ? markerRecord.role
+                : null;
+        };
+        const createGuardedState = (
+            originalState: unknown,
+            role: HistoryGuardRole,
+        ): Record<string, unknown> => ({
+            ...(originalState && typeof originalState === 'object' ? originalState : {}),
+            [stateKey]: { id: guardId, role },
+        });
+
+        const installGuardSession = (): HistoryGuardSession | null => {
+            const currentSession = historyGuardSessionRef.current;
+            const existingRole = readGuardRole(window.history.state);
+            if (currentSession?.id === guardId && existingRole) return currentSession;
+
+            const originalState: unknown = window.history.state;
+            const url = window.location.href;
+            const nextSession = { id: guardId, originalState, url };
+            try {
+                window.history.replaceState(createGuardedState(originalState, 'base'), '', url);
+                window.history.pushState(createGuardedState(originalState, 'sentinel'), '', url);
+                historyGuardSessionRef.current = nextSession;
+                return nextSession;
+            } catch {
+                historyGuardSessionRef.current = null;
+                try {
+                    window.history.replaceState(originalState, '', url);
+                } catch {
+                    // 履歴を変更できない環境でもbeforeunloadとクリック監視は有効にする。
+                }
+                return null;
+            }
+        };
+
+        const restoreBaseState = (session: HistoryGuardSession): void => {
+            try {
+                window.history.replaceState(session.originalState, '', session.url);
+            } finally {
+                if (historyGuardSessionRef.current === session) {
+                    historyGuardSessionRef.current = null;
+                }
+            }
+        };
+
+        const cleanupGuardSession = (session: HistoryGuardSession): void => {
+            const currentRole = readGuardRole(window.history.state);
+            if (currentRole === 'base') {
+                restoreBaseState(session);
+                return;
+            }
+            if (currentRole !== 'sentinel') {
+                if (historyGuardSessionRef.current === session) {
+                    historyGuardSessionRef.current = null;
+                }
+                return;
+            }
+
+            const handleSentinelCleanup = (event: PopStateEvent): void => {
+                if (readGuardRole(event.state) !== 'base') return;
+                window.removeEventListener('popstate', handleSentinelCleanup);
+                restoreBaseState(session);
+            };
+            window.addEventListener('popstate', handleSentinelCleanup);
+            window.history.back();
+        };
+
+        installGuardSession();
+        historyExitApprovalRef.current = 'none';
+        let isRecoveringToSentinel = false;
+        let historyExitTraversalObserved = false;
+        let bypassNextRouterClick = false;
+        let pendingRouterTarget: HTMLElement | null = null;
+        let historyExitFallbackTimer: number | null = null;
+        let pendingLeaveRequest: LeaveConfirmationRequest | null = null;
+        let pendingHistoryExitDelta = 0;
+        let approveHistoryExitAfterRecovery = false;
+
+        // タブを閉じる・リロードする離脱は、ページ破棄前に出せるUIがブラウザ標準の
+        // 確認ダイアログしか存在しない（カスタムUIは描画される前に破棄される）ため、
+        // beforeunloadだけはネイティブ挙動を温存する。
+        // 承認状態では免除しない: 承認されたのはSPA内遷移であってリロード/クローズ
+        // ではなく、遷移が完了すればunmountでこのlistenerごと消える。時間ではなく
+        // 「activeでmountされている」という状態だけで判定する。
+        const handleBeforeUnload = (event: BeforeUnloadEvent): void => {
+            event.preventDefault();
+            (event as unknown as { returnValue: boolean }).returnValue = true;
+        };
+
+        const requestLeaveConfirmation = (request: LeaveConfirmationRequest): void => {
+            pendingLeaveRequest = request;
+            setLeaveConfirmation(request);
+        };
+
+        const closeLeaveConfirmation = (): void => {
+            pendingLeaveRequest = null;
+            setLeaveConfirmation(null);
+        };
+
+        const scheduleFailedHistoryExitRecovery = (session: HistoryGuardSession): void => {
+            if (historyExitFallbackTimer !== null) {
+                window.clearTimeout(historyExitFallbackTimer);
+            }
+            historyExitFallbackTimer = window.setTimeout(() => {
+                historyExitFallbackTimer = null;
+                if (
+                    !componentMountedRef.current
+                    || !activeRef.current
+                    || historyExitApprovalRef.current !== 'history'
+                ) {
+                    return;
+                }
+
+                if (historyExitTraversalObserved) {
+                    // 遷移は観測されたがcomponentが残っている。ただし着地先が別pathnameなら
+                    // 旧pageのunmountが遅れているだけであり、そこへ再武装するとpushStateが
+                    // Forward側の履歴を切り落として他routeのentryを汚染する。再武装は
+                    // query/hash違いの同一route着地（unmountが来ない=承認が恒久残留する
+                    // ケース）に限る。trailing slashの揺れは同一routeとして比較する。
+                    const normalizePathname = (value: string): string =>
+                        value.replace(/\/+$/, '') || '/';
+                    let guardedPathname: string | null = null;
+                    try {
+                        guardedPathname = normalizePathname(new URL(session.url).pathname);
+                    } catch {
+                        guardedPathname = null;
+                    }
+                    if (normalizePathname(window.location.pathname) !== guardedPathname) return;
+
+                    historyExitApprovalRef.current = 'none';
+                    installGuardSession();
+                    return;
+                }
+
+                if (
+                    window.location.href === session.url
+                    && readGuardRole(window.history.state) === 'sentinel'
+                ) {
+                    // 履歴前項目が足りずgo()が何も遷移しなかった場合。承認前にsentinelへ
+                    // 復帰済みなので、承認状態だけを解除してガードを再武装する。
+                    historyExitApprovalRef.current = 'none';
+                }
+            }, 250);
+        };
+
+        const replayRouterNavigation = (
+            session: HistoryGuardSession | null,
+            target: HTMLElement,
+        ): void => {
+            pendingRouterTarget = null;
+            if (session && readGuardRole(window.history.state) === 'base') {
+                restoreBaseState(session);
+            } else if (session && historyGuardSessionRef.current === session) {
+                historyGuardSessionRef.current = null;
+            }
+
+            window.queueMicrotask(() => {
+                if (!componentMountedRef.current) {
+                    historyExitApprovalRef.current = 'none';
+                    return;
+                }
+                if (!target.isConnected) {
+                    // replay対象が再描画で消えた。遷移は起こせないので、承認を残して
+                    // beforeunloadと以後のBackが恒久的に確認を迂回する状態にせず、
+                    // その場でガードを再武装して留まる。
+                    historyExitApprovalRef.current = 'none';
+                    if (activeRef.current) installGuardSession();
+                    return;
+                }
+                bypassNextRouterClick = true;
+                routerExitStartPathnameRef.current = window.location.pathname;
+                target.click();
+                // 遷移の完了は時間でなく状態で観測する: pathnameが変われば上のeffectが
+                // 承認を解除し、unmountすれば承認はrefごと消える。
+            });
+        };
+
+        const performApprovedHistoryExit = (): void => {
+            const session = historyGuardSessionRef.current;
+            historyExitApprovalRef.current = 'history';
+            historyExitTraversalObserved = false;
+            window.history.go(pendingHistoryExitDelta);
+            if (session) scheduleFailedHistoryExitRecovery(session);
+        };
+
+        const handlePopState = (event: PopStateEvent): void => {
+            const role = readGuardRole(event.state);
+
+            if (historyExitApprovalRef.current === 'router' && pendingRouterTarget) {
+                if (role === 'base') {
+                    replayRouterNavigation(historyGuardSessionRef.current, pendingRouterTarget);
+                    return;
+                }
+                // replayの往路以外のtraversalが来た(承認直後のBack等)。承認を解除して
+                // このtraversalは素通しする(sentinelは承認時に消費済みで保留できない)。
+                historyExitApprovalRef.current = 'none';
+                pendingRouterTarget = null;
+                return;
+            }
+
+            if (isRecoveringToSentinel) {
+                if (role === 'sentinel') {
+                    isRecoveringToSentinel = false;
+                    if (approveHistoryExitAfterRecovery) {
+                        // 復帰完了前に押された「移動する」をここで実行する
+                        approveHistoryExitAfterRecovery = false;
+                        performApprovedHistoryExit();
+                    }
+                } else {
+                    // sentinelへ戻る一段ごとに、承認時へ引き継ぐ離脱の深さを積む。
+                    pendingHistoryExitDelta -= 1;
+                    window.history.forward();
+                }
+                return;
+            }
+
+            if (historyExitApprovalRef.current === 'history') {
+                historyExitTraversalObserved = true;
+                return;
+            }
+            if (role === 'sentinel') return;
+
+            // sentinelを設置できなかった環境では遷移を保留できない。
+            // popstate経由の離脱は素通しし、beforeunloadとクリック監視だけで守る。
+            if (!historyGuardSessionRef.current) return;
+
+            // 画面内ダイアログは非同期なので、先に同期でsentinelへの復帰を開始して遷移を
+            // 保留し、意思確認をダイアログへ委ねる。承認時は保留中に積んだ深さぶんだけ
+            // history.go()で本来の離脱をやり直す（baseは同一URLの人工entryなので+1深い）。
+            //
+            // 【既知制約】複数entryを飛び越えるBackで、routerのpopstate listenerが別routeの
+            // commitを先に完了させると、この保留は挟めずunmountで確認なしに離脱する。
+            pendingHistoryExitDelta = role === 'base' ? -2 : -1;
+            isRecoveringToSentinel = true;
+            approveHistoryExitAfterRecovery = false;
+            window.history.forward();
+            requestLeaveConfirmation({ kind: 'history' });
+        };
+
+        const handleRouterNavigation = (event: MouseEvent): void => {
+            if (bypassNextRouterClick) {
+                bypassNextRouterClick = false;
+                return;
+            }
+            if (
+                event.defaultPrevented
+                || event.button !== 0
+                || event.metaKey
+                || event.ctrlKey
+                || event.shiftKey
+                || event.altKey
+            ) {
+                return;
+            }
+
+            const target = event.target instanceof Element ? event.target : null;
+            if (!target) return;
+
+            const anchor = target.closest<HTMLAnchorElement>('a[href]');
+            if (
+                !anchor
+                || anchor.hasAttribute('download')
+                || (anchor.target && anchor.target !== '_self')
+            ) {
+                return;
+            }
+
+            let isInternalNavigation = false;
+            try {
+                const destination = new URL(anchor.href, window.location.href);
+                isInternalNavigation = destination.origin === window.location.origin
+                    && destination.href !== window.location.href;
+            } catch {
+                isInternalNavigation = false;
+            }
+            if (!isInternalNavigation) return;
+
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+
+            // クリックは既に握り潰してあるので履歴は動いていない。承認されたときだけ
+            // approve側でclickをreplayする。
+            requestLeaveConfirmation({ kind: 'router', target: anchor });
+        };
+
+        // ログイン/ログアウト/退会のように遷移を伴わない離脱は、AppHeader が
+        // requestGuardedAction で問い合わせてくる。止めたら承認時にこちらが proceed する。
+        const handleNavigationIntent = (event: Event): void => {
+            const detail = (event as CustomEvent<NavigationIntentDetail>).detail;
+            if (!detail || typeof detail.proceed !== 'function') return;
+            event.preventDefault();
+            requestLeaveConfirmation({ kind: 'action', detail });
+        };
+
+        leaveConfirmationActionsRef.current = {
+            approve: () => {
+                const request = pendingLeaveRequest;
+                if (!request) return;
+
+                if (request.kind === 'history') {
+                    closeLeaveConfirmation();
+                    // sentinelへの復帰走行が終わるまで離脱の深さが確定しない。完了前の承認は
+                    // 捨てずに予約し、復帰完了(popstateのsentinel到達)で実行する。
+                    if (isRecoveringToSentinel) {
+                        approveHistoryExitAfterRecovery = true;
+                        return;
+                    }
+                    performApprovedHistoryExit();
+                    return;
+                }
+
+                if (request.kind === 'action') {
+                    closeLeaveConfirmation();
+                    request.detail.proceed();
+                    return;
+                }
+
+                closeLeaveConfirmation();
+                historyExitApprovalRef.current = 'router';
+                pendingRouterTarget = request.target;
+                const session = historyGuardSessionRef.current;
+                if (session && readGuardRole(window.history.state) === 'sentinel') {
+                    window.history.back();
+                } else {
+                    replayRouterNavigation(session, request.target);
+                }
+            },
+            deny: () => {
+                // 履歴経由の離脱は既にsentinelへ復帰済み、クリック経由は握り潰し済み、
+                // action は proceed を呼ばなければ何も起きない。閉じるだけで「残る」が成立する。
+                closeLeaveConfirmation();
+            },
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        window.addEventListener('popstate', handlePopState);
+        window.addEventListener(NAVIGATION_INTENT_EVENT, handleNavigationIntent);
+        window.document.addEventListener('click', handleRouterNavigation, true);
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+            window.removeEventListener('popstate', handlePopState);
+            window.removeEventListener(NAVIGATION_INTENT_EVENT, handleNavigationIntent);
+            window.document.removeEventListener('click', handleRouterNavigation, true);
+            leaveConfirmationActionsRef.current = null;
+            setLeaveConfirmation(null);
+            if (historyExitFallbackTimer !== null) {
+                window.clearTimeout(historyExitFallbackTimer);
+            }
+            routerExitStartPathnameRef.current = null;
+
+            const activeSession = historyGuardSessionRef.current;
+            if (!activeSession || activeSession.id !== guardId) return;
+
+            if (activeRef.current) {
+                // Strict Modeのeffect再実行では直後にmountedへ戻る。実unmount時だけ
+                // 次taskでmarkerを除去し、router承認後の履歴を汚染させない。
+                window.setTimeout(() => {
+                    if (!componentMountedRef.current) cleanupGuardSession(activeSession);
+                }, 0);
+                return;
+            }
+
+            historyExitApprovalRef.current = 'none';
+            cleanupGuardSession(activeSession);
+        };
+    }, [active, historyGuardId, stateKey]);
+
+    const approveLeave = useCallback(() => {
+        leaveConfirmationActionsRef.current?.approve();
+    }, []);
+
+    const denyLeave = useCallback(() => {
+        leaveConfirmationActionsRef.current?.deny();
+        // ガードeffect解体後に閉じ損ねたダイアログも、表示だけは確実に畳む。
+        setLeaveConfirmation(null);
+    }, []);
+
+    return { leaveConfirmation, approveLeave, denyLeave };
+}

--- a/src/hooks/usePromptManagement.test.ts
+++ b/src/hooks/usePromptManagement.test.ts
@@ -113,3 +113,46 @@ describe('usePromptManagement failure handling (V5/H10)', () => {
         expect((reactHarness.stateValues[0] as { status: string }).status).toBe('success');
     });
 });
+
+describe('usePromptManagement default selection (S2-6)', () => {
+    const selectedIds = () => reactHarness.stateValues[1] as string[];
+
+    it('auto-selects the first admin template prompt (isDefault) instead of the newest prompt', async () => {
+        // 一覧は作成日時の新しい順。先頭はゲストが最後に作った任意のプロンプト
+        serviceMocks.getPrompts.mockResolvedValue([
+            createPrompt('newest-guest-prompt'),
+            { ...createPrompt('default-1'), isDefault: true },
+            { ...createPrompt('default-2'), isDefault: true },
+        ]);
+
+        const hook = usePromptManagement();
+        await hook.retry();
+
+        expect(selectedIds()).toEqual(['default-1']);
+    });
+
+    it('leaves the selection empty when there is no admin template prompt', async () => {
+        serviceMocks.getPrompts.mockResolvedValue([
+            createPrompt('guest-a'),
+            createPrompt('guest-b'),
+        ]);
+
+        const hook = usePromptManagement();
+        await hook.retry();
+
+        expect(selectedIds()).toEqual([]);
+    });
+
+    it('keeps a selection the user already made', async () => {
+        serviceMocks.getPrompts.mockResolvedValue([
+            { ...createPrompt('default-1'), isDefault: true },
+            createPrompt('guest-a'),
+        ]);
+
+        const hook = usePromptManagement();
+        hook.toggleBulkPrompt('guest-a');
+        await hook.retry();
+
+        expect(selectedIds()).toEqual(['guest-a']);
+    });
+});

--- a/src/hooks/usePromptManagement.ts
+++ b/src/hooks/usePromptManagement.ts
@@ -88,8 +88,13 @@ export const usePromptManagement = () => {
             const validIds = new Set(prompts.flatMap(prompt => (prompt.id ? [prompt.id] : [])));
             const nextIds = previousIds.filter(id => validIds.has(id));
 
-            if (nextIds.length === 0 && !selectionTouchedForAuthRef.current && prompts[0]?.id) {
-                return [prompts[0].id];
+            // 既定で選ぶのは管理テンプレート由来 (isDefault) の先頭だけ。
+            // 一覧は作成日時の新しい順なので、先頭 (prompts[0]) を選ぶと
+            // ゲストが最後に作った任意のプロンプトが全員の既定になってしまう。
+            // isDefault が 1 つも無ければ勝手に選ばず未選択のままにする。
+            const defaultPromptId = prompts.find(prompt => prompt.isDefault && prompt.id)?.id;
+            if (nextIds.length === 0 && !selectionTouchedForAuthRef.current && defaultPromptId) {
+                return [defaultPromptId];
             }
 
             return nextIds;

--- a/src/hooks/useVideoProcessing.test.ts
+++ b/src/hooks/useVideoProcessing.test.ts
@@ -926,3 +926,117 @@ describe('savePendingPromptIds has a single writer (G2 invariant)', () => {
         expect(violating.match(/promptStates: \{/g) ?? []).toHaveLength(1);
     });
 });
+
+describe('useVideoProcessing Files API 迂回 (S2-1)', () => {
+    const geminiDoubles = {
+        uploadMedia: vi.fn(),
+        deleteUploadedMedia: vi.fn(),
+        transcribeWithFileUri: vi.fn(),
+    };
+    /** inline 予算 (Base64 + プロンプト ≦ 16MiB) を確実に超えるサイズ。中身は読まないので size だけ持つ */
+    const largeBlob = { size: 13 * 1024 * 1024, type: 'audio/mpeg' } as Blob;
+    const smallBlob = new Blob(['audio'], { type: 'audio/mpeg' });
+
+    const DEBUG_OFF = { ffmpegError: false, geminiError: false, errorAtFileIndex: 0, errorAtSegmentIndex: 0 };
+    /** フック本体は各テスト内で呼ぶ (rules-of-hooks)。ここは戻り値に test double を差すだけ */
+    const attachDoubles = (hook: ReturnType<typeof useVideoProcessing>, promptCount: number) => {
+        hook.setProcessingStatuses([createStatus(promptCount)]);
+        hook.geminiClientRef.current = {
+            getBase64: serviceMocks.getBase64,
+            transcribeWithBase64: serviceMocks.transcribeWithBase64,
+            ...geminiDoubles,
+        } as never;
+        return hook;
+    };
+
+    beforeEach(() => {
+        geminiDoubles.uploadMedia.mockReset().mockResolvedValue({
+            name: 'files/abc',
+            fileUri: 'https://files/abc',
+            mimeType: 'audio/mpeg',
+        });
+        geminiDoubles.deleteUploadedMedia.mockReset().mockResolvedValue(undefined);
+        geminiDoubles.transcribeWithFileUri.mockReset().mockResolvedValue({ success: true, text: 'generated' });
+        serviceMocks.transcribeWithBase64.mockResolvedValue({ success: true, text: 'generated' });
+    });
+
+    it('inline 予算を超える音声は getBase64 ではなく uploadMedia で上げ、fileUri で生成する', async () => {
+        const prompt = createPrompt('prompt-a', 'Prompt A');
+        const hook = attachDoubles(useVideoProcessing([prompt], DEBUG_OFF, vi.fn()), 1);
+        const file = createFile([prompt.id!]);
+
+        await hook.processTranscription(createJob(file), largeBlob, '128k', 44100);
+
+        expect(serviceMocks.getBase64).not.toHaveBeenCalled();
+        expect(serviceMocks.transcribeWithBase64).not.toHaveBeenCalled();
+        expect(geminiDoubles.uploadMedia).toHaveBeenCalledTimes(1);
+        expect(geminiDoubles.uploadMedia).toHaveBeenCalledWith(
+            largeBlob,
+            'sample.mp3',
+            expect.objectContaining({ signal: expect.any(AbortSignal) })
+        );
+        expect(geminiDoubles.transcribeWithFileUri).toHaveBeenCalledWith(
+            'https://files/abc',
+            'audio/mpeg',
+            'sample.mp3',
+            'Prompt A content',
+            'gemini-test',
+            undefined
+        );
+        expect(getCurrentStatus()).toMatchObject({ status: 'completed', transcriptionCount: 1 });
+        // 生成が決着したら Files API 上のファイルは消す
+        expect(geminiDoubles.deleteUploadedMedia).toHaveBeenCalledWith('files/abc');
+    });
+
+    it('予算内の音声は従来どおり Base64 で送り、Files API を使わない', async () => {
+        const prompt = createPrompt('prompt-a', 'Prompt A');
+        const hook = attachDoubles(useVideoProcessing([prompt], DEBUG_OFF, vi.fn()), 1);
+        const file = createFile([prompt.id!]);
+
+        await hook.processTranscription(createJob(file), smallBlob, '128k', 44100);
+
+        expect(geminiDoubles.uploadMedia).not.toHaveBeenCalled();
+        expect(geminiDoubles.transcribeWithFileUri).not.toHaveBeenCalled();
+        expect(serviceMocks.getBase64).toHaveBeenCalledTimes(1);
+        // 予算超過の文言を「約N分」で出せるよう、ビットレートも渡す
+        expect(serviceMocks.transcribeWithBase64).toHaveBeenCalledWith(
+            'base64-data',
+            'audio/mpeg',
+            'sample.mp3',
+            'Prompt A content',
+            'gemini-test',
+            undefined,
+            '128k'
+        );
+        expect(geminiDoubles.deleteUploadedMedia).not.toHaveBeenCalled();
+        expect(getCurrentStatus()).toMatchObject({ status: 'completed' });
+    });
+
+    it('複数プロンプトでもアップロードは 1 回で、参照を共有する', async () => {
+        const prompts = [createPrompt('prompt-a', 'Prompt A'), createPrompt('prompt-b', 'Prompt B')];
+        const hook = attachDoubles(useVideoProcessing(prompts, DEBUG_OFF, vi.fn()), prompts.length);
+        const file = createFile(prompts.map(prompt => prompt.id!));
+
+        await hook.processTranscription(createJob(file), largeBlob, '128k', 44100);
+
+        expect(geminiDoubles.uploadMedia).toHaveBeenCalledTimes(1);
+        expect(geminiDoubles.transcribeWithFileUri).toHaveBeenCalledTimes(2);
+        expect(geminiDoubles.deleteUploadedMedia).toHaveBeenCalledTimes(1);
+        expect(getCurrentStatus()).toMatchObject({ status: 'completed', transcriptionCount: 2 });
+    });
+
+    it('Files API のアップロードに失敗したら upload フェーズで止め、ビットレートの目安を示す', async () => {
+        const prompt = createPrompt('prompt-a', 'Prompt A');
+        geminiDoubles.uploadMedia.mockRejectedValue(new Error('CORS blocked'));
+        const hook = attachDoubles(useVideoProcessing([prompt], DEBUG_OFF, vi.fn()), 1);
+        const file = createFile([prompt.id!]);
+
+        await hook.processTranscription(createJob(file), largeBlob, '128k', 44100);
+
+        expect(getCurrentStatus()).toMatchObject({ status: 'error', failedPhase: 'upload' });
+        expect(getCurrentStatus().error).toContain('Gemini Files API アップロード: CORS blocked');
+        expect(getCurrentStatus().error).toContain('ビットレート 128k では約13分を超えると失敗します');
+        expect(geminiDoubles.transcribeWithFileUri).not.toHaveBeenCalled();
+        expect(geminiDoubles.deleteUploadedMedia).not.toHaveBeenCalled();
+    });
+});

--- a/src/hooks/useVideoProcessing.ts
+++ b/src/hooks/useVideoProcessing.ts
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { VideoConverter } from '@/lib/ffmpeg';
 import { GeminiClient } from '@/lib/gemini';
+import {
+    base64LengthForBytes,
+    describeInlineBudgetExceeded,
+    selectMediaTransport,
+    utf8ByteLength,
+} from '@/lib/inlineMediaBudget';
 import { saveTranscription } from '@/lib/firestore';
 import { uploadAudioToStorage } from '@/lib/storage';
 import {
@@ -50,6 +56,11 @@ interface GeneratedDraft {
     bitrate: string;
     sampleRate: number;
 }
+
+/** S2-1: 生成に使うメディアの持ち方。inline は Base64 文字列、file は Files API 上の参照 */
+type PreparedMedia =
+    | { kind: 'inline'; base64Data: string; mimeType: string }
+    | { kind: 'file'; name: string; fileUri: string; mimeType: string };
 
 export interface JobClaim {
     signal: AbortSignal;
@@ -376,6 +387,8 @@ export const useVideoProcessing = (
         const savedPromptIds = [...alreadyCompletedPromptIds];
         const failures: string[] = [];
         let failedPhase: ProcessingFailedPhase = 'text_generation';
+        // S2-1: Files API へ上げたファイルは、ジョブがどう終わっても finally で消す
+        let uploadedMediaName: string | null = null;
 
         const failJob = (phase: ProcessingFailedPhase, messages: string[]) => {
             updateStatus(fileId, status => ({
@@ -506,9 +519,8 @@ export const useVideoProcessing = (
                 totalTranscriptions: plannedTotal,
             }));
 
-            let base64Data = '';
+            let preparedMedia: PreparedMedia | null = null;
             let audioStoragePath: string | null = null;
-            let mimeType = 'audio/mpeg';
 
             if (needsGeneration) {
                 if (!audioBlob) {
@@ -516,12 +528,38 @@ export const useVideoProcessing = (
                     return;
                 }
 
-                mimeType = audioBlob.type || 'audio/mpeg';
+                const mimeType = audioBlob.type || 'audio/mpeg';
 
-                // 同一Blobを複数FileReaderで同時読みすると大容量で空になることがあるため、
-                // Base64は1回だけ取得し、全プロンプトで共有する
-                const [base64Settled, uploadSettled] = await Promise.allSettled([
-                    geminiClientRef.current!.getBase64(audioBlob),
+                // S2-1: inline (Base64) で送れる量には上限がある。generateContent を呼ぶ前にサイズで経路を決め、
+                // 超える分は Files API へ迂回する。経路はファイル単位で 1 つなので、プロンプトは残り全件の最長で見積もる
+                const promptBytes = remainingPrompts.reduce(
+                    (max, prompt) => Math.max(max, utf8ByteLength(prompt.content)),
+                    0
+                );
+                const transport = selectMediaTransport(base64LengthForBytes(audioBlob.size), promptBytes);
+                videoProcessingLogger.info('Gemini への送信経路を決定', {
+                    fileId,
+                    fileIndex,
+                    transport,
+                    blobSizeBytes: audioBlob.size,
+                    promptBytes,
+                    bitrate,
+                });
+
+                const prepareMedia = async (): Promise<PreparedMedia> => {
+                    if (transport === 'inline') {
+                        // 同一Blobを複数FileReaderで同時読みすると大容量で空になることがあるため、
+                        // Base64は1回だけ取得し、全プロンプトで共有する
+                        const base64Data = await geminiClientRef.current!.getBase64(audioBlob);
+                        return { kind: 'inline', base64Data, mimeType };
+                    }
+                    // Files API も 1 ファイルにつき 1 回だけ上げ、全プロンプトで参照を共有する
+                    const uploaded = await geminiClientRef.current!.uploadMedia(audioBlob, file.file.name, { signal });
+                    return { kind: 'file', ...uploaded };
+                };
+
+                const [mediaSettled, uploadSettled] = await Promise.allSettled([
+                    prepareMedia(),
                     uploadAudioToStorage(audioBlob, file.file.name, {
                         originalFileName: file.file.name,
                         originalFileType,
@@ -530,17 +568,28 @@ export const useVideoProcessing = (
                     }),
                 ]);
 
+                if (mediaSettled.status === 'fulfilled' && mediaSettled.value.kind === 'file') {
+                    uploadedMediaName = mediaSettled.value.name;
+                }
+
                 throwIfAborted();
 
                 // H7: 準備段階の失敗はアップロード失敗として、両方の理由をまとめて報告する
                 const preparationFailures: string[] = [];
-                if (base64Settled.status === 'fulfilled') {
-                    base64Data = base64Settled.value;
-                    if (!base64Data || base64Data.length === 0) {
+                if (mediaSettled.status === 'fulfilled') {
+                    preparedMedia = mediaSettled.value;
+                    if (preparedMedia.kind === 'inline' && preparedMedia.base64Data.length === 0) {
+                        preparedMedia = null;
                         preparationFailures.push('Base64変換: 音声/動画データの読み取り結果が空でした。');
                     }
+                } else if (transport === 'inline') {
+                    preparationFailures.push(`Base64変換: ${describeError(mediaSettled.reason)}`);
                 } else {
-                    preparationFailures.push(`Base64変換: ${describeError(base64Settled.reason)}`);
+                    // S2-1: 迂回経路も失敗したときだけ、利用者が自分で打てる手 (ビットレート/分割) を示す
+                    preparationFailures.push(
+                        `Gemini Files API アップロード: ${describeError(mediaSettled.reason)}`,
+                        describeInlineBudgetExceeded(bitrate)
+                    );
                 }
 
                 if (uploadSettled.status === 'fulfilled') {
@@ -569,16 +618,34 @@ export const useVideoProcessing = (
 
                 if (!draft) {
                     throwIfAborted();
+                    const media = preparedMedia;
+                    if (!media) {
+                        throw new PromptPhaseError(
+                            'upload',
+                            '送信用の音声/動画データが準備されていません。音声変換からやり直してください。'
+                        );
+                    }
                     markPromptState(fileId, promptId, 'generating');
 
-                    const transcriptionResult = await geminiClientRef.current!.transcribeWithBase64(
-                        base64Data,
-                        mimeType,
-                        file.file.name,
-                        prompt.content,
-                        prompt.model,
-                        prompt.thinkingLevel,
-                    );
+                    const client = geminiClientRef.current!;
+                    const transcriptionResult = media.kind === 'file'
+                        ? await client.transcribeWithFileUri(
+                            media.fileUri,
+                            media.mimeType,
+                            file.file.name,
+                            prompt.content,
+                            prompt.model,
+                            prompt.thinkingLevel,
+                        )
+                        : await client.transcribeWithBase64(
+                            media.base64Data,
+                            media.mimeType,
+                            file.file.name,
+                            prompt.content,
+                            prompt.model,
+                            prompt.thinkingLevel,
+                            bitrate,
+                        );
 
                     if (!transcriptionResult.success) {
                         throw new PromptPhaseError(
@@ -738,6 +805,11 @@ export const useVideoProcessing = (
                 [describeError(error)]
             );
         } finally {
+            if (uploadedMediaName) {
+                // S2-1: Files API 上のファイルは 48 時間で自動削除されるが、生成が決着したら待たずに消す
+                // (失敗しても続行。再開で生成が要るときは上げ直す)
+                void geminiClientRef.current?.deleteUploadedMedia(uploadedMediaName);
+            }
             claim.release();
         }
     }, [availablePrompts, claimJob, debugErrorMode, markPromptState, onDocumentSaved, updateStatus, withPromptStates]);

--- a/src/lib/adminSettings.test.ts
+++ b/src/lib/adminSettings.test.ts
@@ -264,8 +264,9 @@ describe('adminSettings', () => {
             });
 
         expect(promptsObservedBySync).toEqual(savedPrompts);
-        // 同期用snapshotを一度だけ直接受け渡すため、fail-openのruntime readへ到達しない。
-        expect(mocks.getDoc).not.toHaveBeenCalled();
+        // 1 回だけの read は保存前の同期要否判定 (失敗→安全側で同期)。同期用snapshotは
+        // 直接受け渡すため、同期自体は fail-open の runtime read へ到達しない。
+        expect(mocks.getDoc).toHaveBeenCalledTimes(1);
     });
 
     it('再同期はpending化前の管理者readで確定したprompt snapshotを使用する', async () => {
@@ -539,6 +540,162 @@ describe('adminSettings', () => {
             defaultPrompts: [{ name: '議事録', content: '議事録を作成してください。' }],
         }, 'admin-1')).rejects.toThrow('管理者設定の更新に失敗しました');
 
+        expect(mocks.syncGuestDefaultPrompts).not.toHaveBeenCalled();
+    });
+});
+
+describe('adminSettings ゲスト同期の要否 (S2-5)', () => {
+    const storedPrompts = [
+        { name: '打ち合わせの流れ', content: '流れ', model: 'default', thinkingLevel: 'default' as const },
+        { name: '希望条件', content: '希望条件を整理', model: 'gemini-3.7-flash', thinkingLevel: 'high' as const },
+    ];
+
+    function arrangeStoredConfig(overrides: Record<string, unknown> = {}) {
+        mocks.getDoc.mockResolvedValue({
+            exists: () => true,
+            data: () => ({
+                maxPromptSize: 50000,
+                maxDocumentSize: 500000,
+                defaultPrompts: storedPrompts,
+                lastGuestSyncStatus: 'succeeded',
+                ...overrides,
+            }),
+        });
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.getDoc.mockReset();
+        for (const key of Object.keys(mocks.persistedData)) delete mocks.persistedData[key];
+        // 同期完了 status の finalize transaction が setDoc で書いた operationId を読めるよう、
+        // 上の describe と同じく保存内容を persistedData へ通す
+        mocks.setDoc.mockReset().mockImplementation(async (
+            _reference: unknown,
+            data: Record<string, unknown>,
+        ) => {
+            Object.assign(mocks.persistedData, data);
+        });
+        mocks.syncGuestDefaultPrompts.mockReset().mockResolvedValue(undefined);
+        mocks.transactionGet.mockReset().mockImplementation(async () => ({
+            exists: () => true,
+            data: () => ({ ...mocks.persistedData }),
+        }));
+        mocks.transactionSet.mockReset().mockImplementation((
+            _reference: unknown,
+            data: Record<string, unknown>,
+        ) => {
+            Object.assign(mocks.persistedData, data);
+        });
+    });
+
+    it('保存前と同じdefaultPromptsの保存ではゲスト同期を要求しない', async () => {
+        arrangeStoredConfig();
+
+        const result = await updateAdminSettings({
+            maxPromptSize: 60000,
+            defaultPrompts: storedPrompts.map(prompt => ({ ...prompt })),
+        }, 'admin-1');
+
+        expect(result).toEqual({ settingsUpdated: true, guestPromptsSync: 'not-requested' });
+        expect(mocks.syncGuestDefaultPrompts).not.toHaveBeenCalled();
+        expect(mocks.setDoc).toHaveBeenCalledTimes(1);
+        const savedData = mocks.setDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(savedData).toEqual(expect.objectContaining({
+            maxPromptSize: 60000,
+            defaultPrompts: storedPrompts,
+            updatedBy: 'admin-1',
+        }));
+        expect(savedData).not.toHaveProperty('lastGuestSyncStatus');
+        expect(savedData).not.toHaveProperty('lastGuestSyncOperationId');
+        expect(mocks.transactionSet).not.toHaveBeenCalled();
+    });
+
+    it('model/thinkingLevel の未設定と既定値の違いだけなら同じとみなす', async () => {
+        arrangeStoredConfig({
+            defaultPrompts: [
+                { name: '打ち合わせの流れ', content: '流れ' },
+                { name: '希望条件', content: '希望条件を整理', model: 'gemini-3.7-flash', thinkingLevel: ' high ' },
+            ],
+        });
+
+        const result = await updateAdminSettings({ defaultPrompts: storedPrompts }, 'admin-1');
+
+        expect(result.guestPromptsSync).toBe('not-requested');
+        expect(mocks.syncGuestDefaultPrompts).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {
+            change: '内容',
+            next: [{ ...storedPrompts[0], content: '新しい流れ' }, storedPrompts[1]],
+        },
+        {
+            change: '名前',
+            next: [{ ...storedPrompts[0], name: '商談の流れ' }, storedPrompts[1]],
+        },
+        {
+            change: 'モデル',
+            next: [{ ...storedPrompts[0], model: 'gemini-3.7-pro' }, storedPrompts[1]],
+        },
+        {
+            change: '思考レベル',
+            next: [{ ...storedPrompts[0], thinkingLevel: 'low' as const }, storedPrompts[1]],
+        },
+        {
+            change: '件数',
+            next: [storedPrompts[0]],
+        },
+    ])('defaultPromptsの$changeが変わった保存では同期する', async ({ next }) => {
+        arrangeStoredConfig();
+
+        const result = await updateAdminSettings({ defaultPrompts: next }, 'admin-1');
+
+        expect(result.guestPromptsSync).toBe('succeeded');
+        expect(mocks.syncGuestDefaultPrompts).toHaveBeenCalledTimes(1);
+        expect(mocks.setDoc.mock.calls[0][1]).toEqual(expect.objectContaining({
+            lastGuestSyncStatus: 'pending',
+        }));
+    });
+
+    it.each(['failed', 'pending'] as const)(
+        '前回のゲスト同期が%sのままなら同じdefaultPromptsでも同期する',
+        async unresolvedStatus => {
+            arrangeStoredConfig({ lastGuestSyncStatus: unresolvedStatus });
+
+            const result = await updateAdminSettings({ defaultPrompts: storedPrompts }, 'admin-1');
+
+            expect(result.guestPromptsSync).toBe('succeeded');
+            expect(mocks.syncGuestDefaultPrompts).toHaveBeenCalledTimes(1);
+        },
+    );
+
+    it.each([
+        {
+            scenario: 'configが未作成',
+            arrangeRead: () => mocks.getDoc.mockResolvedValue({ exists: () => false }),
+        },
+        {
+            scenario: 'defaultPromptsが未保存',
+            arrangeRead: () => arrangeStoredConfig({ defaultPrompts: undefined }),
+        },
+        {
+            scenario: '保存前の読み取りに失敗',
+            arrangeRead: () => mocks.getDoc.mockRejectedValue(new Error('unavailable')),
+        },
+    ])('$scenarioなら比較できないので安全側で同期する', async ({ arrangeRead }) => {
+        arrangeRead();
+
+        const result = await updateAdminSettings({ defaultPrompts: storedPrompts }, 'admin-1');
+
+        expect(result.guestPromptsSync).toBe('succeeded');
+        expect(mocks.syncGuestDefaultPrompts).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaultPromptsを含まない保存は保存前の読み取りも同期もしない', async () => {
+        const result = await updateAdminSettings({ maxPromptSize: 60000 }, 'admin-1');
+
+        expect(result.guestPromptsSync).toBe('not-requested');
+        expect(mocks.getDoc).not.toHaveBeenCalled();
         expect(mocks.syncGuestDefaultPrompts).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/adminSettings.ts
+++ b/src/lib/adminSettings.ts
@@ -227,6 +227,30 @@ function canonicalizeDefaultPrompts(
     }));
 }
 
+/**
+ * 2つのテンプレートが同じ内容か。name/content は完全一致、model/thinkingLevel は
+ * 正規化して比較する (未設定と既定値の違いは変更とみなさない)。
+ * ゲスト同期の要否判定と、同期時の「変更のあった doc だけ書く」判定の両方で使う。
+ */
+export function isEquivalentDefaultPrompt(
+    left: DefaultPromptTemplate,
+    right: DefaultPromptTemplate,
+): boolean {
+    return left.name === right.name
+        && left.content === right.content
+        && canonicalizeGeminiModel(left.model) === canonicalizeGeminiModel(right.model)
+        && canonicalizeThinkingLevel(left.thinkingLevel)
+            === canonicalizeThinkingLevel(right.thinkingLevel);
+}
+
+export function areEquivalentDefaultPrompts(
+    left: DefaultPromptTemplate[],
+    right: DefaultPromptTemplate[],
+): boolean {
+    return left.length === right.length
+        && left.every((prompt, index) => isEquivalentDefaultPrompt(prompt, right[index]));
+}
+
 function withCanonicalDefaultPrompts(
     settings: AdminSettings,
     prompts: DefaultPromptTemplate[],
@@ -489,6 +513,54 @@ export async function retryGuestDefaultPromptsSync(updatedBy: string): Promise<v
     }
 }
 
+interface GuestSyncBaseline {
+    /** 保存前に config へ入っていた defaultPrompts。未保存なら null */
+    defaultPrompts: DefaultPromptTemplate[] | null;
+    /** 前回のゲスト同期が failed / pending のまま残っているか */
+    syncUnresolved: boolean;
+}
+
+/**
+ * ゲスト同期の要否判定に使う、保存前の config を読む。
+ * 読めなければ null を返し、呼び出し側が安全側 (同期する) に倒す。
+ */
+async function readGuestSyncBaseline(updatedBy: string): Promise<GuestSyncBaseline | null> {
+    try {
+        const snapshot = await getDoc(doc(db, 'adminSettings', 'config'));
+        if (!snapshot.exists()) {
+            return { defaultPrompts: null, syncUnresolved: false };
+        }
+
+        const currentSettings = snapshot.data() as Partial<AdminSettings>;
+        return {
+            defaultPrompts: currentSettings.defaultPrompts == null
+                ? null
+                : canonicalizeDefaultPrompts(currentSettings.defaultPrompts),
+            syncUnresolved: currentSettings.lastGuestSyncStatus === 'failed'
+                || currentSettings.lastGuestSyncStatus === 'pending',
+        };
+    } catch (error) {
+        adminSettingsLogger.error('保存前の管理者設定を読めなかったためゲスト同期を実行', error, {
+            updatedBy,
+        });
+        return null;
+    }
+}
+
+/**
+ * ゲスト共通プロンプトの同期は defaultPrompts が実際に変わった時だけ走らせる。
+ * 保存のたびに全件を作り直すと、途中で切れた時にゲストのプロンプトが 0 件になる窓ができる。
+ * 保存前の値が分からない (未保存・読み取り失敗) 時と前回同期が未解消の時は安全側で同期する。
+ */
+function shouldSyncGuestDefaultPrompts(
+    baseline: GuestSyncBaseline | null,
+    nextDefaultPrompts: DefaultPromptTemplate[],
+): boolean {
+    if (baseline === null || baseline.defaultPrompts === null) return true;
+    if (baseline.syncUnresolved) return true;
+    return !areEquivalentDefaultPrompts(baseline.defaultPrompts, nextDefaultPrompts);
+}
+
 /**
  * 管理者設定を更新（管理者のみ）
  */
@@ -513,7 +585,11 @@ export async function updateAdminSettings(
             canonicalSettings.defaultPrompts = canonicalizeDefaultPrompts(settings.defaultPrompts);
         }
 
-        const guestSyncRequested = canonicalSettings.defaultPrompts != null;
+        const guestSyncRequested = canonicalSettings.defaultPrompts != null
+            && shouldSyncGuestDefaultPrompts(
+                await readGuestSyncBaseline(updatedBy),
+                canonicalSettings.defaultPrompts,
+            );
         const guestSyncOperationId = guestSyncRequested
             ? createGuestSyncOperationId()
             : null;

--- a/src/lib/clientErrorReporter.test.ts
+++ b/src/lib/clientErrorReporter.test.ts
@@ -1,0 +1,378 @@
+// @vitest-environment jsdom
+
+/**
+ * 未捕捉エラー観測 (S2-8) の錠。
+ *  - window の error / unhandledrejection が logger.error へ構造化引数で流れる
+ *  - 二重登録しない
+ *  - Firestore 送信の失敗 (Rules 未配備) がアプリへ伝播しない
+ *  - 同一メッセージの送信は throttle される / ページあたり上限がある
+ *  - ハンドラ自身は決して throw せず、再帰しない
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    database: { name: 'mock-firestore' },
+    addDoc: vi.fn(),
+    collection: vi.fn((...segments: unknown[]) => ({ type: 'collection', segments })),
+    serverTimestamp: vi.fn(() => ({ type: 'serverTimestamp' })),
+    loggerError: vi.fn(),
+    loggerWarn: vi.fn(),
+    loggerInfo: vi.fn(),
+    identity: { userId: 'GUEST', ownerType: 'guest' as 'guest' | 'user' },
+}));
+
+vi.mock('firebase/firestore', () => ({
+    addDoc: mocks.addDoc,
+    collection: mocks.collection,
+    serverTimestamp: mocks.serverTimestamp,
+}));
+
+vi.mock('./firebase', () => ({
+    db: mocks.database,
+}));
+
+vi.mock('./auth', () => ({
+    getCurrentUserId: () => mocks.identity.userId,
+    getOwnerType: () => mocks.identity.ownerType,
+}));
+
+vi.mock('./logger', () => ({
+    createLogger: vi.fn(() => ({
+        error: mocks.loggerError,
+        warn: mocks.loggerWarn,
+        info: mocks.loggerInfo,
+    })),
+}));
+
+import {
+    CLIENT_ERRORS_COLLECTION,
+    MAX_MESSAGE_LENGTH,
+    MAX_STACK_LENGTH,
+    isClientErrorReporterInstalled,
+    setupClientErrorReporter,
+    teardownClientErrorReporter,
+} from './clientErrorReporter';
+
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function fireError(init: ErrorEventInit): void {
+    window.dispatchEvent(new ErrorEvent('error', init));
+}
+
+// jsdom 26 には PromiseRejectionEvent が無いので、同名の素の Event に reason を載せる。
+// ハンドラ側は event.reason しか読まないので実ブラウザと同じ経路を通る。
+function fireRejection(reason: unknown): void {
+    const event = new Event('unhandledrejection');
+    Object.defineProperty(event, 'reason', { value: reason });
+    window.dispatchEvent(event);
+}
+
+/** addDoc は fire-and-forget なので、マイクロタスクを数回流して送信まで待つ */
+async function flush(): Promise<void> {
+    for (let i = 0; i < 4; i += 1) {
+        await Promise.resolve();
+    }
+}
+
+function sentPayload(callIndex = 0): Record<string, unknown> {
+    return mocks.addDoc.mock.calls[callIndex][1] as Record<string, unknown>;
+}
+
+describe('clientErrorReporter (S2-8)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.addDoc.mockResolvedValue({ id: 'doc-1' });
+        mocks.identity.userId = 'GUEST';
+        mocks.identity.ownerType = 'guest';
+    });
+
+    afterEach(() => {
+        teardownClientErrorReporter();
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    describe('logger.error への構造化出力', () => {
+        it('window の error イベントを message/stack/source/url/timestamp 付きで流す', () => {
+            setupClientErrorReporter();
+            const error = new Error('boom');
+
+            fireError({
+                message: 'Uncaught Error: boom',
+                error,
+                filename: 'https://app.example/_next/static/chunks/page.js',
+                lineno: 10,
+                colno: 5,
+            });
+
+            expect(mocks.loggerError).toHaveBeenCalledTimes(1);
+            const [message, rawError, metadata] = mocks.loggerError.mock.calls[0];
+            expect(typeof message).toBe('string');
+            expect(rawError).toBe(error);
+            expect(metadata).toEqual(expect.objectContaining({
+                source: 'window.error',
+                message: 'boom',
+                stack: expect.stringContaining('boom'),
+                url: window.location.href,
+                timestamp: expect.stringMatching(ISO_8601),
+                filename: 'https://app.example/_next/static/chunks/page.js',
+                lineno: 10,
+                colno: 5,
+                userId: 'GUEST',
+                ownerType: 'guest',
+            }));
+        });
+
+        it('Error オブジェクトが無い error イベント (クロスオリジンの "Script error.") でも message を作る', () => {
+            setupClientErrorReporter();
+
+            fireError({ message: 'Script error.' });
+
+            expect(mocks.loggerError).toHaveBeenCalledTimes(1);
+            const metadata = mocks.loggerError.mock.calls[0][2] as Record<string, unknown>;
+            expect(metadata.message).toBe('Script error.');
+            expect(metadata.source).toBe('window.error');
+            expect(metadata.stack).toBeUndefined();
+        });
+
+        it('unhandledrejection (reason が Error) を source=unhandledrejection で流す', () => {
+            setupClientErrorReporter();
+            const reason = new Error('rejected');
+
+            fireRejection(reason);
+
+            expect(mocks.loggerError).toHaveBeenCalledTimes(1);
+            const [, rawError, metadata] = mocks.loggerError.mock.calls[0];
+            expect(rawError).toBe(reason);
+            expect(metadata).toEqual(expect.objectContaining({
+                source: 'unhandledrejection',
+                message: 'rejected',
+                stack: expect.stringContaining('rejected'),
+                url: window.location.href,
+                timestamp: expect.stringMatching(ISO_8601),
+            }));
+        });
+
+        it.each([
+            ['文字列', 'plain string', 'plain string', undefined],
+            ['code 付きオブジェクト', { code: 'permission-denied', message: 'Missing or insufficient permissions.' }, 'Missing or insufficient permissions.', 'permission-denied'],
+            ['message を持たないオブジェクト', { status: 500 }, '{"status":500}', undefined],
+            ['undefined', undefined, '(no reason)', undefined],
+            ['数値', 42, '42', undefined],
+        ])('reason が %s でも message を作る', (_label, reason, expectedMessage, expectedCode) => {
+            setupClientErrorReporter();
+
+            fireRejection(reason);
+
+            const metadata = mocks.loggerError.mock.calls[0][2] as Record<string, unknown>;
+            expect(metadata.message).toBe(expectedMessage);
+            expect(metadata.code).toBe(expectedCode);
+        });
+
+        it('message と stack を上限長で切り詰める', () => {
+            setupClientErrorReporter();
+            const error = new Error('x'.repeat(MAX_MESSAGE_LENGTH * 3));
+            error.stack = 'y'.repeat(MAX_STACK_LENGTH * 3);
+
+            fireError({ error });
+
+            const metadata = mocks.loggerError.mock.calls[0][2] as { message: string; stack: string };
+            expect(metadata.message.length).toBe(MAX_MESSAGE_LENGTH + 1);
+            expect(metadata.message.endsWith('…')).toBe(true);
+            expect(metadata.stack.length).toBe(MAX_STACK_LENGTH + 1);
+        });
+    });
+
+    describe('登録の冪等性', () => {
+        it('2回 setup しても購読は1つ (二重登録しない)', () => {
+            const addListener = vi.spyOn(window, 'addEventListener');
+
+            expect(setupClientErrorReporter()).toBe(true);
+            expect(setupClientErrorReporter()).toBe(false);
+            expect(isClientErrorReporterInstalled()).toBe(true);
+
+            const registered = addListener.mock.calls.map(([type]) => type);
+            expect(registered.filter(type => type === 'error')).toHaveLength(1);
+            expect(registered.filter(type => type === 'unhandledrejection')).toHaveLength(1);
+
+            fireError({ error: new Error('once') });
+            expect(mocks.loggerError).toHaveBeenCalledTimes(1);
+
+            addListener.mockRestore();
+        });
+
+        it('teardown 後は受け取らず、再 setup で再び受け取る', () => {
+            setupClientErrorReporter();
+            teardownClientErrorReporter();
+            expect(isClientErrorReporterInstalled()).toBe(false);
+
+            // vitest の jsdom 環境は「ユーザーの error リスナーが無い状態で error を持つ
+            // ErrorEvent」を未捕捉例外として扱うので、ここは message だけで発火する。
+            fireError({ message: 'after teardown' });
+            expect(mocks.loggerError).not.toHaveBeenCalled();
+
+            expect(setupClientErrorReporter()).toBe(true);
+            fireError({ error: new Error('after re-setup') });
+            expect(mocks.loggerError).toHaveBeenCalledTimes(1);
+        });
+
+        it('window が無い環境 (SSR) では何もせず false を返す', () => {
+            vi.stubGlobal('window', undefined);
+
+            expect(() => setupClientErrorReporter()).not.toThrow();
+            expect(setupClientErrorReporter()).toBe(false);
+            expect(isClientErrorReporterInstalled()).toBe(false);
+        });
+    });
+
+    describe('Firestore への best-effort 送信', () => {
+        it('clientErrors コレクションへ undefined を含まない本文 + createdAt=serverTimestamp で送る', async () => {
+            mocks.identity.userId = 'uid-1';
+            mocks.identity.ownerType = 'user';
+            setupClientErrorReporter();
+
+            // stack / filename / lineno / colno / code が無いケース: undefined のキーが混ざると
+            // addDoc は "Unsupported field value: undefined" で落ちるので、キーごと落ちること。
+            fireError({ message: 'Script error.' });
+            await flush();
+
+            expect(mocks.collection).toHaveBeenCalledWith(mocks.database, CLIENT_ERRORS_COLLECTION);
+            expect(mocks.addDoc).toHaveBeenCalledTimes(1);
+            const payload = sentPayload();
+            expect(Object.values(payload).every(value => value !== undefined)).toBe(true);
+            expect(payload).not.toHaveProperty('stack');
+            expect(payload).not.toHaveProperty('filename');
+            expect(payload).toEqual(expect.objectContaining({
+                message: 'Script error.',
+                source: 'window.error',
+                url: window.location.href,
+                timestamp: expect.stringMatching(ISO_8601),
+                userId: 'uid-1',
+                ownerType: 'user',
+                userAgent: navigator.userAgent,
+                createdAt: { type: 'serverTimestamp' },
+            }));
+        });
+
+        it('addDoc が reject (permission-denied) してもアプリへ伝播せず、警告は1回だけ', async () => {
+            const denied = Object.assign(new Error('Missing or insufficient permissions.'), {
+                code: 'permission-denied',
+            });
+            mocks.addDoc.mockRejectedValue(denied);
+            setupClientErrorReporter();
+
+            expect(() => fireError({ error: new Error('first') })).not.toThrow();
+            await flush();
+            expect(() => fireError({ error: new Error('second') })).not.toThrow();
+            await flush();
+
+            // 未捕捉エラー自体は毎回 console (logger.error) へ出る
+            expect(mocks.loggerError).toHaveBeenCalledTimes(2);
+            expect(mocks.addDoc).toHaveBeenCalledTimes(2);
+            // 送信失敗の警告は1ページ1回に抑制
+            expect(mocks.loggerWarn).toHaveBeenCalledTimes(1);
+            expect(mocks.loggerWarn.mock.calls[0][1]).toEqual(expect.objectContaining({
+                code: 'permission-denied',
+            }));
+        });
+
+        it('addDoc が同期 throw してもアプリへ伝播しない', async () => {
+            mocks.addDoc.mockImplementation(() => {
+                throw new Error('sync failure');
+            });
+            setupClientErrorReporter();
+
+            expect(() => fireError({ error: new Error('boom') })).not.toThrow();
+            await flush();
+
+            expect(mocks.loggerError).toHaveBeenCalledTimes(1);
+            expect(mocks.loggerWarn).toHaveBeenCalledTimes(1);
+        });
+
+        it('collection() が throw してもアプリへ伝播しない', async () => {
+            mocks.collection.mockImplementationOnce(() => {
+                throw new Error('firestore not ready');
+            });
+            setupClientErrorReporter();
+
+            expect(() => fireError({ error: new Error('boom') })).not.toThrow();
+            await flush();
+
+            expect(mocks.addDoc).not.toHaveBeenCalled();
+            expect(mocks.loggerWarn).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('throttle と上限', () => {
+        it('同一メッセージは一定時間に1回だけ送る (console には毎回出る)', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-09-03T00:00:00.000Z'));
+            setupClientErrorReporter({ throttleMs: 60_000 });
+
+            fireError({ error: new Error('same') });
+            fireError({ error: new Error('same') });
+            fireRejection(new Error('same'));
+            await flush();
+            expect(mocks.addDoc).toHaveBeenCalledTimes(1);
+            expect(mocks.loggerError).toHaveBeenCalledTimes(3);
+
+            fireError({ error: new Error('different') });
+            await flush();
+            expect(mocks.addDoc).toHaveBeenCalledTimes(2);
+
+            vi.setSystemTime(new Date('2026-09-03T00:00:59.999Z'));
+            fireError({ error: new Error('same') });
+            await flush();
+            expect(mocks.addDoc).toHaveBeenCalledTimes(2);
+
+            vi.setSystemTime(new Date('2026-09-03T00:01:00.000Z'));
+            fireError({ error: new Error('same') });
+            await flush();
+            expect(mocks.addDoc).toHaveBeenCalledTimes(3);
+        });
+
+        it('1ページあたりの送信上限を超えたら送らない (エラー嵐対策)', async () => {
+            setupClientErrorReporter({ maxReportsPerPage: 3 });
+
+            for (let i = 0; i < 5; i += 1) {
+                fireError({ error: new Error(`distinct ${i}`) });
+            }
+            await flush();
+
+            expect(mocks.loggerError).toHaveBeenCalledTimes(5);
+            expect(mocks.addDoc).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe('ハンドラ自身の堅牢性', () => {
+        it('logger が throw しても伝播しない', () => {
+            mocks.loggerError.mockImplementationOnce(() => {
+                throw new Error('logger broke');
+            });
+            setupClientErrorReporter();
+
+            expect(() => fireError({ error: new Error('boom') })).not.toThrow();
+        });
+
+        it('ハンドラ処理中に発生した error イベントは捨てて再帰しない', () => {
+            mocks.loggerError.mockImplementationOnce(() => {
+                fireError({ error: new Error('nested') });
+            });
+            setupClientErrorReporter();
+
+            fireError({ error: new Error('outer') });
+
+            expect(mocks.loggerError).toHaveBeenCalledTimes(1);
+            const metadata = mocks.loggerError.mock.calls[0][2] as Record<string, unknown>;
+            expect(metadata.message).toBe('outer');
+        });
+
+        it('getCurrentUserId が throw しても伝播しない', () => {
+            setupClientErrorReporter();
+            vi.mocked(mocks.identity).userId = undefined as unknown as string;
+
+            expect(() => fireError({ error: new Error('boom') })).not.toThrow();
+        });
+    });
+});

--- a/src/lib/clientErrorReporter.ts
+++ b/src/lib/clientErrorReporter.ts
@@ -1,0 +1,294 @@
+/**
+ * クライアント側の未捕捉エラー観測 (S2-8 / issue #13)
+ *
+ * window の 'error' / 'unhandledrejection' を1回だけ購読し、
+ *  1. 既存 logger.error へ構造化 (message/stack/source/url/timestamp) で流す (毎回)
+ *  2. Firestore `clientErrors` へ best-effort で送る (失敗は無音・throttle 付き)
+ *
+ * 不変条件:
+ *  - 観測層がアプリ挙動を変えることはない。ハンドラは決して throw しない
+ *    (リスナー内の例外は再び 'error' イベントになり、自分自身へ再帰する)。
+ *  - Firestore 送信の失敗 (Rules 未配備の permission-denied を含む) はアプリへ伝播しない。
+ *  - 二重登録しない (React StrictMode の effect 二重実行・レイアウト再マウントに耐える)。
+ *  - Firestore に undefined 値を渡さない (addDoc が "Unsupported field value" で落ちる)。
+ *
+ * window.onerror への代入ではなく addEventListener を使うのは、Next の dev overlay など
+ * 他のハンドラを上書きしないため。受け取る ErrorEvent は同じ。
+ */
+
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { db } from './firebase';
+import { getCurrentUserId, getOwnerType } from './auth';
+import { createLogger } from './logger';
+
+const reporterLogger = createLogger('clientErrorReporter');
+
+export const CLIENT_ERRORS_COLLECTION = 'clientErrors';
+
+/** message の保存上限 (文字数)。超過分は切り詰めて末尾に … を付ける */
+export const MAX_MESSAGE_LENGTH = 1000;
+/** stack の保存上限 (文字数) */
+export const MAX_STACK_LENGTH = 8000;
+
+const DEFAULT_THROTTLE_MS = 60_000;
+const DEFAULT_MAX_REPORTS_PER_PAGE = 20;
+
+export type ClientErrorSource = 'window.error' | 'unhandledrejection';
+
+/** logger.error のメタデータ兼 Firestore へ送る本文 (undefined のキーは送信前に落とす) */
+export interface ClientErrorReport {
+    message: string;
+    stack?: string;
+    source: ClientErrorSource;
+    /** 発生ページ (location.href) */
+    url: string;
+    /** 発生時刻 (クライアント時計・ISO 8601)。Firestore 側には別途 createdAt=serverTimestamp も付く */
+    timestamp: string;
+    filename?: string;
+    lineno?: number;
+    colno?: number;
+    /** FirebaseError.code など、例外が code を持っていれば載せる */
+    code?: string;
+    userAgent?: string;
+    /** "GUEST" または Auth UID (auditLogs と同じ規約) */
+    userId: string;
+    ownerType: 'user' | 'guest';
+}
+
+export interface ClientErrorReporterOptions {
+    /** 同一メッセージの Firestore 送信を抑制する時間 (ms)。既定 60 秒 */
+    throttleMs?: number;
+    /** 1ページ滞在あたりの Firestore 送信上限 (エラー嵐対策)。既定 20 件。console 出力は制限しない */
+    maxReportsPerPage?: number;
+}
+
+interface ReporterState {
+    throttleMs: number;
+    maxReportsPerPage: number;
+    /** 同一メッセージの最終送信時刻 (epoch ms) */
+    lastSentAt: Map<string, number>;
+    sentCount: number;
+    /** 送信失敗の警告は1ページ1回だけ (Rules 未配備時に console が埋まらないように) */
+    sendFailureWarned: boolean;
+    /** 再入ガード: ハンドラ処理中に発生したイベントは捨てる */
+    handling: boolean;
+    onError: (event: ErrorEvent) => void;
+    onRejection: (event: Event) => void;
+}
+
+let state: ReporterState | null = null;
+
+/**
+ * 未捕捉エラーの購読を開始する。冪等 (2回目以降は何もしない)。
+ * @returns 新規に登録したら true。既に登録済み・window が無い (SSR) なら false。
+ */
+export function setupClientErrorReporter(options: ClientErrorReporterOptions = {}): boolean {
+    if (typeof window === 'undefined') {
+        return false;
+    }
+    if (state) {
+        return false;
+    }
+
+    const current: ReporterState = {
+        throttleMs: options.throttleMs ?? DEFAULT_THROTTLE_MS,
+        maxReportsPerPage: options.maxReportsPerPage ?? DEFAULT_MAX_REPORTS_PER_PAGE,
+        lastSentAt: new Map(),
+        sentCount: 0,
+        sendFailureWarned: false,
+        handling: false,
+        onError: (event) => {
+            report(current, () => buildFromErrorEvent(event), event.error);
+        },
+        onRejection: (event) => {
+            const reason = (event as Partial<PromiseRejectionEvent>).reason;
+            report(current, () => buildFromRejection(reason), reason);
+        },
+    };
+
+    window.addEventListener('error', current.onError);
+    window.addEventListener('unhandledrejection', current.onRejection);
+    state = current;
+    return true;
+}
+
+/**
+ * 購読を解除して状態を捨てる。アプリは呼ばない (リスナーはページ寿命で生かす)。テスト用。
+ */
+export function teardownClientErrorReporter(): void {
+    if (!state) {
+        return;
+    }
+    if (typeof window !== 'undefined') {
+        window.removeEventListener('error', state.onError);
+        window.removeEventListener('unhandledrejection', state.onRejection);
+    }
+    state = null;
+}
+
+export function isClientErrorReporterInstalled(): boolean {
+    return state !== null;
+}
+
+// ---- 内部 ------------------------------------------------------------------
+
+function report(current: ReporterState, build: () => ClientErrorReport, rawError: unknown): void {
+    if (current.handling) {
+        return;
+    }
+    current.handling = true;
+    try {
+        const entry = build();
+        reporterLogger.error('未捕捉エラーを検知', rawError, { ...entry });
+        void sendToFirestore(current, entry);
+    } catch {
+        // 観測層の失敗はアプリに伝播させない (ここで throw すると 'error' イベントへ再帰する)
+    } finally {
+        current.handling = false;
+    }
+}
+
+async function sendToFirestore(current: ReporterState, entry: ClientErrorReport): Promise<void> {
+    try {
+        if (!shouldSend(current, entry)) {
+            return;
+        }
+        await addDoc(collection(db, CLIENT_ERRORS_COLLECTION), {
+            ...withoutUndefined(entry),
+            createdAt: serverTimestamp(),
+        });
+    } catch (error) {
+        // Rules 未配備 (permission-denied) やオフラインを含め、送信失敗は無音。
+        // 警告は1ページ1回だけ出す。
+        if (!current.sendFailureWarned) {
+            current.sendFailureWarned = true;
+            reporterLogger.warn('clientErrors への送信に失敗 (以後この警告は抑制)', {
+                code: readCode(error),
+                reason: describeThrown(error).message,
+            });
+        }
+    }
+}
+
+function shouldSend(current: ReporterState, entry: ClientErrorReport): boolean {
+    if (current.sentCount >= current.maxReportsPerPage) {
+        return false;
+    }
+    const now = Date.now();
+    const last = current.lastSentAt.get(entry.message);
+    if (last !== undefined && now - last < current.throttleMs) {
+        return false;
+    }
+    current.lastSentAt.set(entry.message, now);
+    current.sentCount += 1;
+    return true;
+}
+
+function buildFromErrorEvent(event: ErrorEvent): ClientErrorReport {
+    const thrown = event.error === undefined || event.error === null ? null : describeThrown(event.error);
+    return finalize({
+        source: 'window.error',
+        // Error オブジェクトがあれば素の message ("boom") を優先。無ければ
+        // ErrorEvent.message ("Uncaught Error: boom" / クロスオリジンは "Script error.")
+        message: thrown?.message || event.message || '(no message)',
+        stack: thrown?.stack,
+        code: thrown?.code,
+        filename: event.filename || undefined,
+        lineno: event.lineno || undefined,
+        colno: event.colno || undefined,
+    });
+}
+
+function buildFromRejection(reason: unknown): ClientErrorReport {
+    const thrown = describeThrown(reason);
+    return finalize({
+        source: 'unhandledrejection',
+        message: thrown.message,
+        stack: thrown.stack,
+        code: thrown.code,
+    });
+}
+
+type ReportDraft = Pick<
+    ClientErrorReport,
+    'source' | 'message' | 'stack' | 'code' | 'filename' | 'lineno' | 'colno'
+>;
+
+function finalize(draft: ReportDraft): ClientErrorReport {
+    return {
+        message: truncate(draft.message, MAX_MESSAGE_LENGTH),
+        stack: draft.stack === undefined ? undefined : truncate(draft.stack, MAX_STACK_LENGTH),
+        source: draft.source,
+        url: window.location.href,
+        timestamp: new Date().toISOString(),
+        filename: draft.filename,
+        lineno: draft.lineno,
+        colno: draft.colno,
+        code: draft.code,
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+        userId: getCurrentUserId(),
+        ownerType: getOwnerType(),
+    };
+}
+
+interface ThrownDescription {
+    message: string;
+    stack?: string;
+    code?: string;
+}
+
+/** 例外値 (Error / 文字列 / 任意オブジェクト / プリミティブ) を message/stack/code に正規化 */
+function describeThrown(value: unknown): ThrownDescription {
+    if (value === undefined || value === null) {
+        return { message: '(no reason)' };
+    }
+    if (typeof value === 'string') {
+        return { message: value };
+    }
+    if (typeof value === 'object') {
+        // instanceof Error はクロスレルム (iframe 等) で外れるので、形で判定する
+        const candidate = value as { message?: unknown; stack?: unknown };
+        const message = typeof candidate.message === 'string' && candidate.message !== ''
+            ? candidate.message
+            : safeStringify(value);
+        return {
+            message,
+            stack: typeof candidate.stack === 'string' ? candidate.stack : undefined,
+            code: readCode(value),
+        };
+    }
+    return { message: String(value) };
+}
+
+function readCode(value: unknown): string | undefined {
+    if (value && typeof value === 'object') {
+        const code = (value as { code?: unknown }).code;
+        if (typeof code === 'string') {
+            return code;
+        }
+    }
+    return undefined;
+}
+
+function safeStringify(value: unknown): string {
+    try {
+        const json = JSON.stringify(value);
+        return typeof json === 'string' ? json : Object.prototype.toString.call(value);
+    } catch {
+        return Object.prototype.toString.call(value);
+    }
+}
+
+function truncate(text: string, max: number): string {
+    return text.length <= max ? text : `${text.slice(0, max)}…`;
+}
+
+function withoutUndefined(entry: ClientErrorReport): Record<string, string | number> {
+    const result: Record<string, string | number> = {};
+    for (const [key, value] of Object.entries(entry)) {
+        if (value !== undefined) {
+            result[key] = value;
+        }
+    }
+    return result;
+}

--- a/src/lib/firestoreRules.team.test.ts
+++ b/src/lib/firestoreRules.team.test.ts
@@ -142,7 +142,7 @@ function expectJunction(expression: string, operator: '&&' | '||', expected: str
 }
 
 // ============================================================
-// allow 式の完全一致(prompts / transcriptions / relationships / systemNotifications)
+// allow 式の完全一致(prompts / transcriptions / relationships / systemNotifications / auditLogs)
 // ============================================================
 
 describe('firestore.rules: allow 式の完全一致', () => {
@@ -150,6 +150,7 @@ describe('firestore.rules: allow 式の完全一致', () => {
     const transcriptions = extractAllowExpressions(extractMatchBlock('transcriptions'));
     const relationships = extractAllowExpressions(extractMatchBlock('relationships'));
     const notifications = extractAllowExpressions(extractMatchBlock('systemNotifications'));
+    const auditLogs = extractAllowExpressions(extractMatchBlock('auditLogs'));
 
     it('prompts: get は 存在確認/所有者/承認済み上司、list は canListExisting() のみ', () => {
         expect(prompts.get).toBe(
@@ -213,6 +214,16 @@ describe('firestore.rules: allow 式の完全一致', () => {
         expect(notifications.list).toBe(
             "isSuperuser() || (resource.data.keys().hasAll(['published']) && resource.data.published == true)",
         );
+    });
+
+    it('auditLogs: 作成は「本人 uid」か「未ログインの GUEST」のみ(if true の全開放は不可)、読取は管理者のみ、更新・削除の許可文は無い', () => {
+        // S2-3: 旧ルール `allow create: if true` は未ログインでも他人の uid を名乗る偽ログを書けた。
+        expect(auditLogs.create).toBe(
+            "(isSignedIn() && request.resource.data.userId == request.auth.uid) || (!isSignedIn() && request.resource.data.userId == 'GUEST')",
+        );
+        expect(auditLogs.read).toBe('isSuperuser()');
+        // 監査ログの不変性: create / read 以外の allow 文(update / delete / write)が増えたら錠を落とす。
+        expect(Object.keys(auditLogs).sort()).toEqual(['create', 'read']);
     });
 });
 

--- a/src/lib/gemini.test.ts
+++ b/src/lib/gemini.test.ts
@@ -7,6 +7,9 @@ import type { GeminiThinkingLevel } from '../constants/geminiThinking';
 
 const testDoubles = vi.hoisted(() => ({
     generateContent: vi.fn(),
+    filesUpload: vi.fn(),
+    filesGet: vi.fn(),
+    filesDelete: vi.fn(),
     logger: {
         info: vi.fn(),
         warn: vi.fn(),
@@ -22,6 +25,11 @@ vi.mock('@google/genai', () => ({
     },
     GoogleGenAI: class {
         models = { generateContent: testDoubles.generateContent };
+        files = {
+            upload: testDoubles.filesUpload,
+            get: testDoubles.filesGet,
+            delete: testDoubles.filesDelete,
+        };
     },
 }));
 
@@ -30,6 +38,7 @@ vi.mock('./logger', () => ({
 }));
 
 import { GeminiClient, TranscriptionResult } from './gemini';
+import { INLINE_REQUEST_BUDGET_BYTES } from './inlineMediaBudget';
 
 type InvokeGeminiMethod = (
     client: GeminiClient,
@@ -272,4 +281,252 @@ describe('GeminiClient のモデル解決配線', () => {
             });
         },
     );
+});
+
+describe('GeminiClient inline 予算の事前検査 (S2-1)', () => {
+    beforeEach(() => {
+        vi.stubEnv('NEXT_PUBLIC_GEMINI_API_KEY', 'test-api-key');
+        testDoubles.generateContent.mockReset();
+        testDoubles.generateContent.mockResolvedValue({ text: 'ok' });
+        testDoubles.logger.info.mockReset();
+        testDoubles.logger.warn.mockReset();
+        testDoubles.logger.error.mockReset();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    const oversizedBase64 = () => 'a'.repeat(INLINE_REQUEST_BUDGET_BYTES + 1);
+
+    it('予算を超える Base64 は generateContent を呼ばずに、実行可能な文言で失敗にする', async () => {
+        const result = await new GeminiClient().transcribeWithBase64(
+            oversizedBase64(),
+            'audio/mpeg',
+            'long.mp3',
+            'テスト用プロンプト',
+            'gemini-test',
+            'default',
+            '128k',
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('ビットレート 128k では約13分を超えると失敗します');
+        expect(result.error).toContain('ビットレートを下げる');
+        expect(testDoubles.generateContent).not.toHaveBeenCalled();
+        expect(testDoubles.logger.error).toHaveBeenCalledWith(
+            'inline 予算を超えるため generateContent を呼ばずに中止',
+            undefined,
+            expect.objectContaining({ fileName: 'long.mp3', budgetBytes: INLINE_REQUEST_BUDGET_BYTES }),
+        );
+    });
+
+    it('ビットレート未指定でもサイズの目安つきで失敗にする', async () => {
+        const result = await new GeminiClient().transcribeWithBase64(
+            oversizedBase64(),
+            'audio/mpeg',
+            'long.mp3',
+            'テスト用プロンプト',
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('約12MB');
+        expect(testDoubles.generateContent).not.toHaveBeenCalled();
+    });
+
+    it('予算内の Base64 は従来どおり inlineData で送る', async () => {
+        const result = await new GeminiClient().transcribeWithBase64(
+            'ZmFrZQ==',
+            'audio/mpeg',
+            'short.mp3',
+            'テスト用プロンプト',
+        );
+
+        expect(result.success).toBe(true);
+        const request = testDoubles.generateContent.mock.calls[0][0] as {
+            contents: Array<{ parts: Array<Record<string, unknown>> }>;
+        };
+        expect(request.contents[0].parts[1]).toEqual({
+            inlineData: { mimeType: 'audio/mpeg', data: 'ZmFrZQ==' },
+        });
+    });
+
+    it.each([
+        ['transcribeVideo', (client: GeminiClient) => client.transcribeVideo(new Blob(['v'], { type: 'video/mp4' }), 'v.mp4')],
+        ['transcribeAudio', (client: GeminiClient) => client.transcribeAudio(new Blob(['a'], { type: 'audio/mpeg' }), 'a.mp3')],
+    ] as const)('%s も同じ事前検査を通る', async (_name, invoke) => {
+        const client = new GeminiClient();
+        Object.defineProperty(client, 'blobToBase64', {
+            value: vi.fn().mockResolvedValue(oversizedBase64()),
+        });
+
+        const result = await invoke(client);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('ビットレートを下げる');
+        expect(testDoubles.generateContent).not.toHaveBeenCalled();
+    });
+
+    it('API 側の payload 超過エラーも「大きすぎます」で終わらせず、打てる手を示す', async () => {
+        testDoubles.generateContent.mockRejectedValue(
+            new Error('Request payload size exceeds the limit: 20971520 bytes.'),
+        );
+
+        const result = await new GeminiClient().transcribeWithBase64(
+            'ZmFrZQ==',
+            'audio/mpeg',
+            'short.mp3',
+            'テスト用プロンプト',
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('ビットレートを下げる');
+        expect(result.error).not.toContain('より小さいファイルを使用してください');
+    });
+});
+
+describe('GeminiClient Files API 経路 (S2-1・要ライブ検証)', () => {
+    beforeEach(() => {
+        vi.stubEnv('NEXT_PUBLIC_GEMINI_API_KEY', 'test-api-key');
+        testDoubles.generateContent.mockReset();
+        testDoubles.generateContent.mockResolvedValue({ text: 'ok' });
+        testDoubles.filesUpload.mockReset();
+        testDoubles.filesGet.mockReset();
+        testDoubles.filesDelete.mockReset();
+        testDoubles.logger.info.mockReset();
+        testDoubles.logger.warn.mockReset();
+        testDoubles.logger.error.mockReset();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('transcribeWithFileUri は inlineData ではなく fileData で参照を渡す', async () => {
+        const result = await new GeminiClient().transcribeWithFileUri(
+            'https://generativelanguage.googleapis.com/v1beta/files/abc',
+            'audio/mpeg',
+            'long.mp3',
+            'テスト用プロンプト',
+            'gemini-test',
+        );
+
+        expect(result).toMatchObject({ success: true, text: 'ok' });
+        const request = testDoubles.generateContent.mock.calls[0][0] as {
+            contents: Array<{ parts: Array<Record<string, unknown>> }>;
+        };
+        expect(request.contents[0].parts).toEqual([
+            { text: 'テスト用プロンプト' },
+            {
+                fileData: {
+                    fileUri: 'https://generativelanguage.googleapis.com/v1beta/files/abc',
+                    mimeType: 'audio/mpeg',
+                },
+            },
+        ]);
+    });
+
+    it('uploadMedia は Blob を upload し、ACTIVE になるまで get で待って参照を返す', async () => {
+        const blob = new Blob(['audio'], { type: 'audio/mpeg' });
+        testDoubles.filesUpload.mockResolvedValue({ name: 'files/abc', state: 'PROCESSING' });
+        testDoubles.filesGet
+            .mockResolvedValueOnce({ name: 'files/abc', state: 'PROCESSING' })
+            .mockResolvedValueOnce({
+                name: 'files/abc',
+                uri: 'https://files/abc',
+                mimeType: 'audio/mpeg',
+                state: 'ACTIVE',
+            });
+
+        const ref = await new GeminiClient().uploadMedia(blob, 'long.mp3', { pollIntervalMs: 0 });
+
+        expect(ref).toEqual({ name: 'files/abc', fileUri: 'https://files/abc', mimeType: 'audio/mpeg' });
+        expect(testDoubles.filesUpload).toHaveBeenCalledWith({
+            file: blob,
+            config: { mimeType: 'audio/mpeg', displayName: 'long.mp3' },
+        });
+        expect(testDoubles.filesGet).toHaveBeenCalledTimes(2);
+        expect(testDoubles.filesGet).toHaveBeenCalledWith({ name: 'files/abc' });
+    });
+
+    it('最初から ACTIVE なら get を呼ばない', async () => {
+        testDoubles.filesUpload.mockResolvedValue({
+            name: 'files/abc',
+            uri: 'https://files/abc',
+            mimeType: 'audio/mpeg',
+            state: 'ACTIVE',
+        });
+
+        const ref = await new GeminiClient().uploadMedia(
+            new Blob(['audio'], { type: 'audio/mpeg' }),
+            'long.mp3',
+        );
+
+        expect(ref.fileUri).toBe('https://files/abc');
+        expect(testDoubles.filesGet).not.toHaveBeenCalled();
+    });
+
+    it('FAILED になったら理由つきで投げる', async () => {
+        testDoubles.filesUpload.mockResolvedValue({
+            name: 'files/abc',
+            state: 'FAILED',
+            error: { message: 'unsupported codec' },
+        });
+
+        await expect(
+            new GeminiClient().uploadMedia(new Blob(['audio'], { type: 'audio/mpeg' }), 'long.mp3'),
+        ).rejects.toThrow('Files API でのファイル処理に失敗しました: unsupported codec');
+    });
+
+    it('URI を返さない応答は失敗にする', async () => {
+        testDoubles.filesUpload.mockResolvedValue({ name: 'files/abc', state: 'ACTIVE' });
+
+        await expect(
+            new GeminiClient().uploadMedia(new Blob(['audio'], { type: 'audio/mpeg' }), 'long.mp3'),
+        ).rejects.toThrow('Files API がファイルURIを返しませんでした。');
+    });
+
+    it('中止シグナルを upload に渡し、待機中に中止されたらその理由で投げる', async () => {
+        const controller = new AbortController();
+        testDoubles.filesUpload.mockImplementation(async () => {
+            controller.abort(new Error('画面を離れたため処理を中止しました。'));
+            return { name: 'files/abc', state: 'PROCESSING' };
+        });
+
+        await expect(
+            new GeminiClient().uploadMedia(
+                new Blob(['audio'], { type: 'audio/mpeg' }),
+                'long.mp3',
+                { signal: controller.signal, pollIntervalMs: 0 },
+            ),
+        ).rejects.toThrow('画面を離れたため処理を中止しました。');
+        expect(testDoubles.filesUpload.mock.calls[0][0]).toMatchObject({
+            config: { abortSignal: controller.signal },
+        });
+        expect(testDoubles.filesGet).not.toHaveBeenCalled();
+    });
+
+    it('処理待ちが上限を超えたら投げる', async () => {
+        testDoubles.filesUpload.mockResolvedValue({ name: 'files/abc', state: 'PROCESSING' });
+        testDoubles.filesGet.mockResolvedValue({ name: 'files/abc', state: 'PROCESSING' });
+
+        await expect(
+            new GeminiClient().uploadMedia(
+                new Blob(['audio'], { type: 'audio/mpeg' }),
+                'long.mp3',
+                { pollIntervalMs: 0, timeoutMs: 0 },
+            ),
+        ).rejects.toThrow('時間内に完了しませんでした');
+    });
+
+    it('deleteUploadedMedia は失敗しても投げずに記録だけする', async () => {
+        testDoubles.filesDelete.mockRejectedValue(new Error('gone'));
+
+        await expect(new GeminiClient().deleteUploadedMedia('files/abc')).resolves.toBeUndefined();
+        expect(testDoubles.filesDelete).toHaveBeenCalledWith({ name: 'files/abc' });
+        expect(testDoubles.logger.warn).toHaveBeenCalledWith(
+            'Files API のファイル削除に失敗（48時間で自動削除される）',
+            expect.objectContaining({ name: 'files/abc', error: 'gone' }),
+        );
+    });
 });

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -5,6 +5,12 @@ import {
     type GeminiThinkingLevel,
 } from '../constants/geminiThinking';
 import { createLogger } from './logger';
+import {
+    INLINE_REQUEST_BUDGET_BYTES,
+    describeInlineBudgetExceeded,
+    selectMediaTransport,
+    utf8ByteLength,
+} from './inlineMediaBudget';
 
 const geminiLogger = createLogger('gemini');
 
@@ -16,6 +22,23 @@ export interface TranscriptionResult {
     usedThinkingLevel?: string;
 }
 
+/** S2-1: Files API へアップロード済みのメディア参照。生成後は name で削除する */
+export interface UploadedMediaRef {
+    name: string;
+    fileUri: string;
+    mimeType: string;
+}
+
+export interface UploadMediaOptions {
+    signal?: AbortSignal;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+}
+
+/** Files API のファイルが ACTIVE になるのを待つ間隔と上限 (動画は PROCESSING が長引くことがある) */
+export const FILES_API_ACTIVATION_POLL_MS = 2_000;
+export const FILES_API_ACTIVATION_TIMEOUT_MS = 5 * 60 * 1000;
+
 interface GeminiUsageMetadata {
     promptTokenCount?: number;
     candidatesTokenCount?: number;
@@ -23,11 +46,59 @@ interface GeminiUsageMetadata {
     totalTokenCount?: number;
 }
 
+/** generateContent へ渡すメディアの出所。inline は Base64、file は Files API の URI */
+type MediaSource =
+    | { kind: 'inline'; base64Data: string; mimeType: string }
+    | { kind: 'file'; fileUri: string; mimeType: string };
+
 const THINKING_LEVEL_ENUMS = {
     LOW: ThinkingLevel.LOW,
     MEDIUM: ThinkingLevel.MEDIUM,
     HIGH: ThinkingLevel.HIGH,
 } as const;
+
+const VIDEO_DEFAULT_PROMPT = `
+以下の動画ファイルの内容を分析し、以下の形式でMarkdown文書を作成してください：
+
+# タイトル
+（動画の主題を簡潔に）
+
+## 要約
+（内容の要約を3-5文で）
+
+## 詳細な内容
+（話されている内容を詳しく記述）
+
+## キーポイント
+- （重要なポイント1）
+- （重要なポイント2）
+- （重要なポイント3）
+
+動画が日本語の場合は日本語で、英語の場合は英語で文書を作成してください。
+`.trim();
+
+const AUDIO_DEFAULT_PROMPT = `
+以下の音声ファイルの内容を分析し、以下の形式でMarkdown文書を作成してください：
+
+# タイトル
+（音声の主題を簡潔に）
+
+## 要約
+（内容の要約を3-5文で）
+
+## 詳細な内容
+（話されている内容を詳しく記述）
+
+## キーポイント
+- （重要なポイント1）
+- （重要なポイント2）
+- （重要なポイント3）
+
+音声が日本語の場合は日本語で、英語の場合は英語で文書を作成してください。
+`.trim();
+
+const defaultPromptFor = (mimeType: string): string =>
+    mimeType.startsWith('video/') ? VIDEO_DEFAULT_PROMPT : AUDIO_DEFAULT_PROMPT;
 
 function logGeminiUsage(
     model: string,
@@ -42,6 +113,33 @@ function logGeminiUsage(
         thoughtsTokenCount: usageMetadata?.thoughtsTokenCount,
         totalTokenCount: usageMetadata?.totalTokenCount,
     });
+}
+
+/** API のエラー文を利用者向けの文言に読み替える。該当しなければ元の文をそのまま返す */
+function translateGeminiError(errorMessage: string, targetModel: string): string {
+    if (errorMessage.includes('fetch') ||
+        errorMessage.includes('network') ||
+        errorMessage.includes('Failed to fetch') ||
+        errorMessage.includes('NetworkError') ||
+        errorMessage.toLowerCase().includes('offline')) {
+        return 'ネットワークエラー: インターネット接続を確認してください。';
+    }
+    if (errorMessage.includes('API_KEY_INVALID') || errorMessage.includes('API key not valid')) {
+        return 'Gemini APIキーが無効です。.env.localファイルを確認してください。';
+    }
+    if (errorMessage.includes('not found') || errorMessage.includes('404')) {
+        return `指定されたモデルが見つかりません（${targetModel}）。Gemini APIキーとモデル名を確認してください。`;
+    }
+    if (errorMessage.includes('PERMISSION_DENIED')) {
+        return 'Gemini APIへのアクセスが拒否されました。APIキーの権限を確認してください。';
+    }
+    if (errorMessage.includes('file too large') ||
+        errorMessage.includes('too large') ||
+        errorMessage.includes('payload')) {
+        // S2-1: 「大きすぎます」で終わらせず、利用者が自分で打てる手を示す
+        return describeInlineBudgetExceeded();
+    }
+    return errorMessage;
 }
 
 export class GeminiClient {
@@ -75,129 +173,30 @@ export class GeminiClient {
         thinkingLevel: GeminiThinkingLevel = 'default',
     ): Promise<TranscriptionResult> {
         const targetModel = resolveGeminiModel(modelName ?? this.defaultModel);
-        const resolvedThinkingLevel = resolveThinkingLevelForModel(thinkingLevel, targetModel);
-        const usedThinkingLevel = resolvedThinkingLevel ?? 'unspecified';
+        geminiLogger.info('transcribeVideo 開始', {
+            fileName,
+            mimeType: videoBlob.type,
+            sizeInMB: (videoBlob.size / 1024 / 1024).toFixed(2),
+            modelName: targetModel,
+            hasCustomPrompt: Boolean(customPrompt),
+            customPromptLength: customPrompt?.length,
+        });
 
+        let base64Video: string;
         try {
-            geminiLogger.info('transcribeVideo 開始', {
-                fileName,
-                mimeType: videoBlob.type,
-                sizeInMB: (videoBlob.size / 1024 / 1024).toFixed(2),
-                modelName: targetModel,
-                hasCustomPrompt: Boolean(customPrompt),
-                customPromptLength: customPrompt?.length,
-            });
-
-            // BlobをBase64に変換
-            const base64Video = await this.blobToBase64(videoBlob);
-
-            // プロンプトの作成（カスタムプロンプトがあればそれを使用）
-            const prompt = customPrompt || `
-以下の動画ファイルの内容を分析し、以下の形式でMarkdown文書を作成してください：
-
-# タイトル
-（動画の主題を簡潔に）
-
-## 要約
-（内容の要約を3-5文で）
-
-## 詳細な内容
-（話されている内容を詳しく記述）
-
-## キーポイント
-- （重要なポイント1）
-- （重要なポイント2）
-- （重要なポイント3）
-
-動画が日本語の場合は日本語で、英語の場合は英語で文書を作成してください。
-`.trim();
-
-            // BlobのmimeTypeを取得（デフォルトはvideo/mp4）
-            const mimeType = videoBlob.type || 'video/mp4';
-
-            geminiLogger.info('Gemini API へ動画を送信', {
-                fileName,
-                mimeType,
-                sizeInMB: (videoBlob.size / 1024 / 1024).toFixed(2),
-                modelName: targetModel,
-                promptLength: prompt.length,
-            });
-
-            // Gemini APIにリクエスト
-            const result = await this.genAI.models.generateContent({
-                model: targetModel,
-                ...(resolvedThinkingLevel && {
-                    config: {
-                        thinkingConfig: {
-                            thinkingLevel: THINKING_LEVEL_ENUMS[resolvedThinkingLevel],
-                        },
-                    },
-                }),
-                contents: [
-                    {
-                        role: 'user',
-                        parts: [
-                            { text: prompt },
-                            { inlineData: { mimeType, data: base64Video } },
-                        ],
-                    },
-                ],
-            });
-
-            geminiLogger.info('generateContent のレスポンスを受信', { fileName });
-
-            const text = result.text ?? '';
-
-            logGeminiUsage(targetModel, usedThinkingLevel, result.usageMetadata);
-
-            geminiLogger.info('動画の直接送信による文書生成が成功', {
-                fileName,
-                modelName: targetModel,
-                generatedTextLength: text.length,
-            });
-
-            return {
-                success: true,
-                text,
-                usedModel: targetModel,
-                usedThinkingLevel,
-            };
+            base64Video = await this.blobToBase64(videoBlob);
         } catch (error) {
-            geminiLogger.error('動画の直接送信でエラーが発生', error, {
-                fileName,
-                modelName: targetModel,
-            });
-
-            // より詳細なエラー情報を返す
-            let errorMessage = '不明なエラーが発生しました';
-            if (error instanceof Error) {
-                errorMessage = error.message;
-
-                // ネットワークエラーチェック
-                if (errorMessage.includes('fetch') ||
-                    errorMessage.includes('network') ||
-                    errorMessage.includes('Failed to fetch') ||
-                    errorMessage.includes('NetworkError') ||
-                    errorMessage.toLowerCase().includes('offline')) {
-                    errorMessage = 'ネットワークエラー: インターネット接続を確認してください。';
-                }
-                // APIキーのエラーチェック
-                else if (errorMessage.includes('API_KEY_INVALID') || errorMessage.includes('API key not valid')) {
-                    errorMessage = 'Gemini APIキーが無効です。.env.localファイルを確認してください。';
-                } else if (errorMessage.includes('not found') || errorMessage.includes('404')) {
-                    errorMessage = `指定されたモデルが見つかりません（${targetModel}）。Gemini APIキーとモデル名を確認してください。`;
-                } else if (errorMessage.includes('PERMISSION_DENIED')) {
-                    errorMessage = 'Gemini APIへのアクセスが拒否されました。APIキーの権限を確認してください。';
-                } else if (errorMessage.includes('file too large') || errorMessage.includes('payload')) {
-                    errorMessage = '動画ファイルが大きすぎます。より小さいファイルを使用してください。';
-                }
-            }
-
-            return {
-                success: false,
-                error: errorMessage,
-            };
+            geminiLogger.error('動画の直接送信でエラーが発生', error, { fileName, modelName: targetModel });
+            return { success: false, error: error instanceof Error ? error.message : '不明なエラーが発生しました' };
         }
+
+        return this.generateDocument(
+            { kind: 'inline', base64Data: base64Video, mimeType: videoBlob.type || 'video/mp4' },
+            fileName,
+            customPrompt,
+            modelName,
+            thinkingLevel,
+        );
     }
 
     /**
@@ -213,127 +212,30 @@ export class GeminiClient {
         thinkingLevel: GeminiThinkingLevel = 'default',
     ): Promise<TranscriptionResult> {
         const targetModel = resolveGeminiModel(modelName ?? this.defaultModel);
-        const resolvedThinkingLevel = resolveThinkingLevelForModel(thinkingLevel, targetModel);
-        const usedThinkingLevel = resolvedThinkingLevel ?? 'unspecified';
+        geminiLogger.info('transcribeAudio 開始', {
+            fileName,
+            mimeType: audioBlob.type,
+            sizeInMB: (audioBlob.size / 1024 / 1024).toFixed(2),
+            modelName: targetModel,
+            hasCustomPrompt: Boolean(customPrompt),
+            customPromptLength: customPrompt?.length,
+        });
 
+        let base64Audio: string;
         try {
-            geminiLogger.info('transcribeAudio 開始', {
-                fileName,
-                mimeType: audioBlob.type,
-                sizeInMB: (audioBlob.size / 1024 / 1024).toFixed(2),
-                modelName: targetModel,
-                hasCustomPrompt: Boolean(customPrompt),
-                customPromptLength: customPrompt?.length,
-            });
-
-            // BlobをBase64に変換
-            const base64Audio = await this.blobToBase64(audioBlob);
-
-            // プロンプトの作成（カスタムプロンプトがあればそれを使用）
-            const prompt = customPrompt || `
-以下の音声ファイルの内容を分析し、以下の形式でMarkdown文書を作成してください：
-
-# タイトル
-（音声の主題を簡潔に）
-
-## 要約
-（内容の要約を3-5文で）
-
-## 詳細な内容
-（話されている内容を詳しく記述）
-
-## キーポイント
-- （重要なポイント1）
-- （重要なポイント2）
-- （重要なポイント3）
-
-音声が日本語の場合は日本語で、英語の場合は英語で文書を作成してください。
-`.trim();
-
-            // BlobのmimeTypeを取得（デフォルトはaudio/mp3）
-            const mimeType = audioBlob.type || 'audio/mp3';
-
-            geminiLogger.info('Gemini API へ音声を送信', {
-                fileName,
-                mimeType,
-                sizeInMB: (audioBlob.size / 1024 / 1024).toFixed(2),
-                modelName: targetModel,
-                promptLength: prompt.length,
-            });
-
-            // Gemini APIにリクエスト
-            const result = await this.genAI.models.generateContent({
-                model: targetModel,
-                ...(resolvedThinkingLevel && {
-                    config: {
-                        thinkingConfig: {
-                            thinkingLevel: THINKING_LEVEL_ENUMS[resolvedThinkingLevel],
-                        },
-                    },
-                }),
-                contents: [
-                    {
-                        role: 'user',
-                        parts: [
-                            { text: prompt },
-                            { inlineData: { mimeType, data: base64Audio } },
-                        ],
-                    },
-                ],
-            });
-
-            geminiLogger.info('generateContent のレスポンスを受信', { fileName });
-
-            const text = result.text ?? '';
-
-            logGeminiUsage(targetModel, usedThinkingLevel, result.usageMetadata);
-
-            geminiLogger.info('音声の文書生成が成功', {
-                fileName,
-                modelName: targetModel,
-                generatedTextLength: text.length,
-            });
-
-            return {
-                success: true,
-                text,
-                usedModel: targetModel,
-                usedThinkingLevel,
-            };
+            base64Audio = await this.blobToBase64(audioBlob);
         } catch (error) {
-            geminiLogger.error('Gemini API呼び出しでエラーが発生', error, {
-                fileName,
-                modelName: targetModel,
-            });
-
-            // より詳細なエラー情報を返す
-            let errorMessage = '不明なエラーが発生しました';
-            if (error instanceof Error) {
-                errorMessage = error.message;
-
-                // ネットワークエラーチェック
-                if (errorMessage.includes('fetch') ||
-                    errorMessage.includes('network') ||
-                    errorMessage.includes('Failed to fetch') ||
-                    errorMessage.includes('NetworkError') ||
-                    errorMessage.toLowerCase().includes('offline')) {
-                    errorMessage = 'ネットワークエラー: インターネット接続を確認してください。';
-                }
-                // APIキーのエラーチェック
-                else if (errorMessage.includes('API_KEY_INVALID') || errorMessage.includes('API key not valid')) {
-                    errorMessage = 'Gemini APIキーが無効です。.env.localファイルを確認してください。';
-                } else if (errorMessage.includes('not found') || errorMessage.includes('404')) {
-                    errorMessage = `指定されたモデルが見つかりません（${targetModel}）。Gemini APIキーとモデル名を確認してください。`;
-                } else if (errorMessage.includes('PERMISSION_DENIED')) {
-                    errorMessage = 'Gemini APIへのアクセスが拒否されました。APIキーの権限を確認してください。';
-                }
-            }
-
-            return {
-                success: false,
-                error: errorMessage,
-            };
+            geminiLogger.error('Gemini API呼び出しでエラーが発生', error, { fileName, modelName: targetModel });
+            return { success: false, error: error instanceof Error ? error.message : '不明なエラーが発生しました' };
         }
+
+        return this.generateDocument(
+            { kind: 'inline', base64Data: base64Audio, mimeType: audioBlob.type || 'audio/mp3' },
+            fileName,
+            customPrompt,
+            modelName,
+            thinkingLevel,
+        );
     }
 
     /**
@@ -346,10 +248,92 @@ export class GeminiClient {
     }
 
     /**
+     * S2-1: inline 予算を超えるメディアを Files API へアップロードし、generateContent から参照できる状態
+     * (ACTIVE) になるまで待つ。1 ファイルにつき 1 回だけ呼び、全プロンプトで参照を共有すること。
+     * アップロードしたファイルは 48 時間で自動削除されるが、生成が決着したら deleteUploadedMedia で消す。
+     */
+    async uploadMedia(
+        blob: Blob,
+        fileName: string,
+        options: UploadMediaOptions = {},
+    ): Promise<UploadedMediaRef> {
+        const {
+            signal,
+            pollIntervalMs = FILES_API_ACTIVATION_POLL_MS,
+            timeoutMs = FILES_API_ACTIVATION_TIMEOUT_MS,
+        } = options;
+        const mimeType = blob.type || 'audio/mpeg';
+
+        geminiLogger.info('Files API へアップロードを開始', {
+            fileName,
+            mimeType,
+            sizeInMB: (blob.size / 1024 / 1024).toFixed(2),
+        });
+
+        const uploaded = await this.genAI.files.upload({
+            file: blob,
+            config: {
+                mimeType,
+                displayName: fileName,
+                ...(signal && { abortSignal: signal }),
+            },
+        });
+
+        let current = uploaded;
+        const deadline = Date.now() + timeoutMs;
+        // state は SDK の FileState 列挙 ('PROCESSING' | 'ACTIVE' | 'FAILED') の文字列値。
+        // 列挙オブジェクト経由にしないのは、SDK をモックしたテストで undefined 参照にならないため
+        while ((current.state as string | undefined) === 'PROCESSING') {
+            if (!current.name) {
+                throw new Error('Files API がファイル名を返さなかったため、処理状態を確認できません。');
+            }
+            if (signal?.aborted) {
+                throw signal.reason instanceof Error ? signal.reason : new Error('処理が中止されました。');
+            }
+            if (Date.now() >= deadline) {
+                throw new Error('Files API でのファイル処理が時間内に完了しませんでした。しばらくしてから再試行してください。');
+            }
+            await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+            current = await this.genAI.files.get({ name: current.name });
+        }
+
+        if ((current.state as string | undefined) === 'FAILED') {
+            throw new Error(`Files API でのファイル処理に失敗しました: ${current.error?.message ?? '理由不明'}`);
+        }
+        if (!current.uri || !current.name) {
+            throw new Error('Files API がファイルURIを返しませんでした。');
+        }
+
+        geminiLogger.info('Files API へのアップロードが完了', {
+            fileName,
+            name: current.name,
+            state: current.state,
+            sizeBytes: current.sizeBytes,
+            expirationTime: current.expirationTime,
+        });
+
+        return { name: current.name, fileUri: current.uri, mimeType: current.mimeType ?? mimeType };
+    }
+
+    /** uploadMedia で上げたファイルを消す。失敗しても 48 時間で自動削除されるため、記録だけして例外にしない */
+    async deleteUploadedMedia(name: string): Promise<void> {
+        try {
+            await this.genAI.files.delete({ name });
+            geminiLogger.info('Files API のファイルを削除', { name });
+        } catch (error) {
+            geminiLogger.warn('Files API のファイル削除に失敗（48時間で自動削除される）', {
+                name,
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+
+    /**
      * 既にBase64化したメディアで文書生成を行う（getBase64 を1回だけ行い、複数プロンプトで共有する用途）
      * @param base64Data Base64文字列（data URLのプレフィックスなし）
      * @param mimeType 'video/mp4' または 'audio/mpeg' など
      * @param thinkingLevel 思考レベル。未指定の場合は default。
+     * @param mediaBitrate 変換時のビットレート。予算超過の文言を「約N分」で出すために使う（任意）
      */
     async transcribeWithBase64(
         base64Data: string,
@@ -358,13 +342,55 @@ export class GeminiClient {
         customPrompt?: string,
         modelName?: string,
         thinkingLevel: GeminiThinkingLevel = 'default',
+        mediaBitrate?: string,
+    ): Promise<TranscriptionResult> {
+        return this.generateDocument(
+            { kind: 'inline', base64Data, mimeType },
+            fileName,
+            customPrompt,
+            modelName,
+            thinkingLevel,
+            mediaBitrate,
+        );
+    }
+
+    /**
+     * S2-1: Files API にアップロード済みのメディア (uploadMedia の戻り値) を参照して文書生成を行う。
+     * inline 予算を超えるファイルはこちらを使う。
+     */
+    async transcribeWithFileUri(
+        fileUri: string,
+        mimeType: string,
+        fileName: string,
+        customPrompt?: string,
+        modelName?: string,
+        thinkingLevel: GeminiThinkingLevel = 'default',
+    ): Promise<TranscriptionResult> {
+        return this.generateDocument(
+            { kind: 'file', fileUri, mimeType },
+            fileName,
+            customPrompt,
+            modelName,
+            thinkingLevel,
+        );
+    }
+
+    /** generateContent の唯一の入口。inline は送る前に予算を検査し、超えていれば API を呼ばずに返す */
+    private async generateDocument(
+        media: MediaSource,
+        fileName: string,
+        customPrompt: string | undefined,
+        modelName: string | undefined,
+        thinkingLevel: GeminiThinkingLevel,
+        mediaBitrate?: string,
     ): Promise<TranscriptionResult> {
         const targetModel = resolveGeminiModel(modelName ?? this.defaultModel);
         const resolvedThinkingLevel = resolveThinkingLevelForModel(thinkingLevel, targetModel);
         const usedThinkingLevel = resolvedThinkingLevel ?? 'unspecified';
+        const { mimeType } = media;
 
         try {
-            if (!base64Data || base64Data.length === 0) {
+            if (media.kind === 'inline' && (!media.base64Data || media.base64Data.length === 0)) {
                 geminiLogger.error('Base64データが空のため送信をスキップ', { fileName, mimeType });
                 return {
                     success: false,
@@ -372,55 +398,43 @@ export class GeminiClient {
                 };
             }
 
-            const defaultPrompt = mimeType.startsWith('video/')
-                ? `
-以下の動画ファイルの内容を分析し、以下の形式でMarkdown文書を作成してください：
+            const prompt = customPrompt || defaultPromptFor(mimeType);
 
-# タイトル
-（動画の主題を簡潔に）
+            if (media.kind === 'inline') {
+                // S2-1: generateContent を呼ぶ前に inline 予算を検査する。超えていれば API に投げずに
+                // 実行可能な文言で返す（API 側の「payload too large」は理由が伝わらず、課金にも時間にも無駄）
+                const promptBytes = utf8ByteLength(prompt);
+                if (selectMediaTransport(media.base64Data.length, promptBytes) !== 'inline') {
+                    geminiLogger.error('inline 予算を超えるため generateContent を呼ばずに中止', undefined, {
+                        fileName,
+                        mimeType,
+                        base64LengthChars: media.base64Data.length,
+                        promptBytes,
+                        budgetBytes: INLINE_REQUEST_BUDGET_BYTES,
+                    });
+                    return { success: false, error: describeInlineBudgetExceeded(mediaBitrate) };
+                }
 
-## 要約
-（内容の要約を3-5文で）
+                geminiLogger.info('Gemini API へ送信（Base64共有）', {
+                    fileName,
+                    mimeType,
+                    base64LengthChars: media.base64Data.length,
+                    modelName: targetModel,
+                    promptLength: prompt.length,
+                });
+            } else {
+                geminiLogger.info('Gemini API へ送信（Files API 参照）', {
+                    fileName,
+                    mimeType,
+                    fileUri: media.fileUri,
+                    modelName: targetModel,
+                    promptLength: prompt.length,
+                });
+            }
 
-## 詳細な内容
-（話されている内容を詳しく記述）
-
-## キーポイント
-- （重要なポイント1）
-- （重要なポイント2）
-- （重要なポイント3）
-
-動画が日本語の場合は日本語で、英語の場合は英語で文書を作成してください。
-`.trim()
-                : `
-以下の音声ファイルの内容を分析し、以下の形式でMarkdown文書を作成してください：
-
-# タイトル
-（音声の主題を簡潔に）
-
-## 要約
-（内容の要約を3-5文で）
-
-## 詳細な内容
-（話されている内容を詳しく記述）
-
-## キーポイント
-- （重要なポイント1）
-- （重要なポイント2）
-- （重要なポイント3）
-
-音声が日本語の場合は日本語で、英語の場合は英語で文書を作成してください。
-`.trim();
-
-            const prompt = customPrompt || defaultPrompt;
-
-            geminiLogger.info('Gemini API へ送信（Base64共有）', {
-                fileName,
-                mimeType,
-                base64LengthChars: base64Data.length,
-                modelName: targetModel,
-                promptLength: prompt.length,
-            });
+            const mediaPart = media.kind === 'inline'
+                ? { inlineData: { mimeType, data: media.base64Data } }
+                : { fileData: { fileUri: media.fileUri, mimeType } };
 
             const result = await this.genAI.models.generateContent({
                 model: targetModel,
@@ -436,7 +450,7 @@ export class GeminiClient {
                         role: 'user',
                         parts: [
                             { text: prompt },
-                            { inlineData: { mimeType, data: base64Data } },
+                            mediaPart,
                         ],
                     },
                 ],
@@ -464,22 +478,12 @@ export class GeminiClient {
             geminiLogger.error('Gemini API呼び出しでエラーが発生', error, {
                 fileName,
                 modelName: targetModel,
+                mediaKind: media.kind,
             });
 
             let errorMessage = '不明なエラーが発生しました';
             if (error instanceof Error) {
-                errorMessage = error.message;
-                if (errorMessage.includes('fetch') || errorMessage.includes('network') || errorMessage.includes('Failed to fetch') || errorMessage.includes('NetworkError') || errorMessage.toLowerCase().includes('offline')) {
-                    errorMessage = 'ネットワークエラー: インターネット接続を確認してください。';
-                } else if (errorMessage.includes('API_KEY_INVALID') || errorMessage.includes('API key not valid')) {
-                    errorMessage = 'Gemini APIキーが無効です。.env.localファイルを確認してください。';
-                } else if (errorMessage.includes('not found') || errorMessage.includes('404')) {
-                    errorMessage = `指定されたモデルが見つかりません（${targetModel}）。Gemini APIキーとモデル名を確認してください。`;
-                } else if (errorMessage.includes('PERMISSION_DENIED')) {
-                    errorMessage = 'Gemini APIへのアクセスが拒否されました。APIキーの権限を確認してください。';
-                } else if (errorMessage.includes('file too large') || errorMessage.includes('payload')) {
-                    errorMessage = '動画/音声ファイルが大きすぎます。より小さいファイルを使用してください。';
-                }
+                errorMessage = translateGeminiError(error.message, targetModel);
             }
 
             return {

--- a/src/lib/inlineMediaBudget.test.ts
+++ b/src/lib/inlineMediaBudget.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+    INLINE_REQUEST_BUDGET_BYTES,
+    base64LengthForBytes,
+    describeInlineBudgetExceeded,
+    estimateInlineLimitMinutes,
+    parseBitrateKbps,
+    selectMediaTransport,
+    utf8ByteLength,
+} from './inlineMediaBudget';
+
+const MINUTE = 60;
+/** CBR MP3 の 1 秒あたりバイト数 */
+const bytesPerSecond = (kbps: number) => (kbps * 1000) / 8;
+
+describe('selectMediaTransport (S2-1: inline か Files API かをサイズで決める)', () => {
+    it('予算内は inline、予算ちょうども inline (境界は「超えたら迂回」)', () => {
+        expect(selectMediaTransport(0)).toBe('inline');
+        expect(selectMediaTransport(INLINE_REQUEST_BUDGET_BYTES)).toBe('inline');
+    });
+
+    it('1 バイトでも超えたら files_api', () => {
+        expect(selectMediaTransport(INLINE_REQUEST_BUDGET_BYTES + 1)).toBe('files_api');
+    });
+
+    it('プロンプトのバイト数も予算に含める', () => {
+        const base64Length = INLINE_REQUEST_BUDGET_BYTES - 10;
+        expect(selectMediaTransport(base64Length, 10)).toBe('inline');
+        expect(selectMediaTransport(base64Length, 11)).toBe('files_api');
+    });
+
+    it('予算は引数で差し替えられる', () => {
+        expect(selectMediaTransport(100, 0, 100)).toBe('inline');
+        expect(selectMediaTransport(101, 0, 100)).toBe('files_api');
+    });
+
+    it('実害の再現: 192k で 11 分の録音は迂回、128k の 11 分はそのまま送れる', () => {
+        const elevenMinutes = 11 * MINUTE;
+        const promptBytes = 2_000;
+        const at192k = base64LengthForBytes(elevenMinutes * bytesPerSecond(192));
+        const at128k = base64LengthForBytes(elevenMinutes * bytesPerSecond(128));
+
+        expect(selectMediaTransport(at192k, promptBytes)).toBe('files_api');
+        expect(selectMediaTransport(at128k, promptBytes)).toBe('inline');
+    });
+});
+
+describe('base64LengthForBytes', () => {
+    it('3 バイトごとに 4 文字、端数はパディング込みで 4 文字', () => {
+        expect(base64LengthForBytes(0)).toBe(0);
+        expect(base64LengthForBytes(1)).toBe(4);
+        expect(base64LengthForBytes(3)).toBe(4);
+        expect(base64LengthForBytes(4)).toBe(8);
+        expect(base64LengthForBytes(6)).toBe(8);
+    });
+
+    it('負数は 0 として扱う', () => {
+        expect(base64LengthForBytes(-5)).toBe(0);
+    });
+});
+
+describe('utf8ByteLength', () => {
+    it('ASCII は 1 文字 1 バイト、日本語は 1 文字 3 バイト', () => {
+        expect(utf8ByteLength('abc')).toBe(3);
+        expect(utf8ByteLength('あ')).toBe(3);
+        expect(utf8ByteLength('')).toBe(0);
+    });
+});
+
+describe('parseBitrateKbps', () => {
+    it('ffmpeg 形式の k / kbps と bps 表記を kbps に直す', () => {
+        expect(parseBitrateKbps('128k')).toBe(128);
+        expect(parseBitrateKbps('64kbps')).toBe(64);
+        expect(parseBitrateKbps('192K')).toBe(192);
+        expect(parseBitrateKbps('128000')).toBe(128);
+    });
+
+    it('解釈できない値は null', () => {
+        expect(parseBitrateKbps('')).toBeNull();
+        expect(parseBitrateKbps('abc')).toBeNull();
+        expect(parseBitrateKbps('0k')).toBeNull();
+    });
+});
+
+describe('estimateInlineLimitMinutes (「約N分を超えると失敗します」の N)', () => {
+    it('既定予算では 64k=26分 / 96k=17分 / 128k=13分 / 192k=8分', () => {
+        expect(estimateInlineLimitMinutes('64k')).toBe(26);
+        expect(estimateInlineLimitMinutes('96k')).toBe(17);
+        expect(estimateInlineLimitMinutes('128k')).toBe(13);
+        expect(estimateInlineLimitMinutes('192k')).toBe(8);
+    });
+
+    it('見積もりは selectMediaTransport と整合する (N 分は inline、N+1 分は迂回)', () => {
+        for (const bitrate of ['64k', '96k', '128k', '192k']) {
+            const kbps = parseBitrateKbps(bitrate)!;
+            const minutes = estimateInlineLimitMinutes(bitrate)!;
+            const within = base64LengthForBytes(minutes * MINUTE * bytesPerSecond(kbps));
+            const beyond = base64LengthForBytes((minutes + 1) * MINUTE * bytesPerSecond(kbps));
+            expect(selectMediaTransport(within), `${bitrate} ${minutes}分`).toBe('inline');
+            expect(selectMediaTransport(beyond), `${bitrate} ${minutes + 1}分`).toBe('files_api');
+        }
+    });
+
+    it('プロンプトが長いぶんだけ短くなる', () => {
+        const withoutPrompt = estimateInlineLimitMinutes('128k', 0)!;
+        const withLongPrompt = estimateInlineLimitMinutes('128k', 4 * 1024 * 1024)!;
+        expect(withLongPrompt).toBeLessThan(withoutPrompt);
+    });
+
+    it('解釈できないビットレートは null', () => {
+        expect(estimateInlineLimitMinutes('unknown')).toBeNull();
+    });
+});
+
+describe('describeInlineBudgetExceeded (実行可能な文言)', () => {
+    it('ビットレートが分かるときは「約N分」と打てる手を示す', () => {
+        const message = describeInlineBudgetExceeded('128k');
+        expect(message).toContain('ビットレート 128k では約13分を超えると失敗します');
+        expect(message).toContain('ビットレートを下げる');
+        expect(message).toContain('ファイルを分割');
+        expect(message).not.toBe('動画/音声ファイルが大きすぎます。より小さいファイルを使用してください。');
+    });
+
+    it('ビットレートが分からないときはサイズの目安で示す', () => {
+        const message = describeInlineBudgetExceeded();
+        expect(message).toContain('約12MB');
+        expect(message).toContain('ビットレートを下げる');
+    });
+
+    it('解釈できないビットレートはサイズの目安に落ちる', () => {
+        expect(describeInlineBudgetExceeded('???')).toContain('約12MB');
+    });
+});

--- a/src/lib/inlineMediaBudget.ts
+++ b/src/lib/inlineMediaBudget.ts
@@ -1,0 +1,76 @@
+/**
+ * S2-1: Gemini generateContent へ inlineData (Base64) で送れる量の予算。
+ *
+ * Google 公表の request 上限は 20MB (Base64 化したメディア + プロンプト + JSON 封筒の合計)。
+ * 上限に張り付けると単位の解釈や封筒サイズの差で落ちるため、余裕を引いた予算で判定し、
+ * 超える分は Files API (ai.files.upload) へ迂回する。ここは SDK に依存しない純関数だけを置く。
+ */
+export const GEMINI_INLINE_REQUEST_LIMIT_BYTES = 20 * 1024 * 1024;
+
+/** JSON 封筒 (キー名・モデル名・thinkingConfig 等) と計測誤差の余裕 */
+export const INLINE_REQUEST_SAFETY_MARGIN_BYTES = 4 * 1024 * 1024;
+
+/** inline で送る request (Base64 + プロンプト) の予算。これを超えたら Files API へ */
+export const INLINE_REQUEST_BUDGET_BYTES =
+    GEMINI_INLINE_REQUEST_LIMIT_BYTES - INLINE_REQUEST_SAFETY_MARGIN_BYTES;
+
+export type MediaTransport = 'inline' | 'files_api';
+
+/** バイト列を Base64 化したときの文字数 (3 バイト → 4 文字、末尾はパディング) */
+export const base64LengthForBytes = (bytes: number): number =>
+    Math.ceil(Math.max(0, bytes) / 3) * 4;
+
+/** JSON 本文に載る UTF-8 バイト数。日本語は 1 文字 3 バイトなので length では過小評価になる */
+export const utf8ByteLength = (text: string): number => new TextEncoder().encode(text).length;
+
+export const estimateInlineRequestBytes = (base64Length: number, promptBytes = 0): number =>
+    base64Length + promptBytes;
+
+/**
+ * inline (Base64) で送るか Files API へ迂回するかを、generateContent を呼ぶ前にサイズだけで決める。
+ * 予算ちょうどは inline (境界は「超えたら迂回」)。
+ */
+export const selectMediaTransport = (
+    base64Length: number,
+    promptBytes = 0,
+    budgetBytes: number = INLINE_REQUEST_BUDGET_BYTES,
+): MediaTransport =>
+    estimateInlineRequestBytes(base64Length, promptBytes) <= budgetBytes ? 'inline' : 'files_api';
+
+/** ffmpeg 形式のビットレート文字列 ('128k' / '128kbps' / '128000') を kbps に直す。解釈できなければ null */
+export const parseBitrateKbps = (bitrate: string): number | null => {
+    const match = /^\s*(\d+(?:\.\d+)?)\s*(k(?:bps)?)?\s*$/i.exec(bitrate);
+    if (!match) return null;
+    const value = Number(match[1]);
+    if (!Number.isFinite(value) || value <= 0) return null;
+    return match[2] ? value : value / 1000;
+};
+
+/**
+ * そのビットレートで inline 予算に収まる録音の長さ (分・切り捨て)。
+ * 利用者に「約N分を超えると失敗します」と伝えるための目安で、CBR を仮定する。
+ */
+export const estimateInlineLimitMinutes = (
+    bitrate: string,
+    promptBytes = 0,
+    budgetBytes: number = INLINE_REQUEST_BUDGET_BYTES,
+): number | null => {
+    const kbps = parseBitrateKbps(bitrate);
+    if (kbps === null) return null;
+    const maxMediaBytes = Math.floor((Math.max(0, budgetBytes - promptBytes) * 3) / 4);
+    const bytesPerSecond = (kbps * 1000) / 8;
+    return Math.floor(maxMediaBytes / bytesPerSecond / 60);
+};
+
+/**
+ * inline 予算超過を利用者に伝える文言。「大きすぎます」で終わらせず、自分で打てる手を示す。
+ * ビットレートが分かるときは分数で、分からないときはサイズで目安を出す。
+ */
+export const describeInlineBudgetExceeded = (bitrate?: string): string => {
+    const minutes = bitrate ? estimateInlineLimitMinutes(bitrate) : null;
+    if (bitrate && minutes !== null) {
+        return `音声・動画データが大きすぎるため、そのままでは送信できません。ビットレート ${bitrate} では約${minutes}分を超えると失敗します。ビットレートを下げるか、ファイルを分割してください。`;
+    }
+    const maxMediaMb = Math.floor((INLINE_REQUEST_BUDGET_BYTES * 3) / 4 / 1024 / 1024);
+    return `音声・動画データが大きすぎるため、そのままでは送信できません（そのまま送れる上限の目安: 約${maxMediaMb}MB）。ビットレートを下げるか、ファイルを分割してください。`;
+};

--- a/src/lib/prompts.test.ts
+++ b/src/lib/prompts.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DefaultPromptTemplate } from './adminSettings';
+
+const mocks = vi.hoisted(() => {
+    const timestamp = { type: 'server-timestamp' };
+    const batch = {
+        set: vi.fn(),
+        delete: vi.fn(),
+        commit: vi.fn(),
+    };
+
+    return {
+        database: { name: 'mock-firestore' },
+        timestamp,
+        batch,
+        writeBatch: vi.fn(() => batch),
+        collection: vi.fn(() => ({ path: 'prompts' })),
+        query: vi.fn((...parts: unknown[]) => ({ parts })),
+        where: vi.fn((field: string, operator: string, value: unknown) => ({ field, operator, value })),
+        orderBy: vi.fn(),
+        limit: vi.fn(),
+        getDocs: vi.fn(),
+        getDoc: vi.fn(),
+        doc: vi.fn((_database: unknown, path: string, id: string) => ({ path: `${path}/${id}`, id })),
+        setDoc: vi.fn(),
+        addDoc: vi.fn(),
+        updateDoc: vi.fn(),
+        deleteDoc: vi.fn(),
+        serverTimestamp: vi.fn(() => timestamp),
+        getDefaultPrompts: vi.fn(),
+        loggerError: vi.fn(),
+        loggerInfo: vi.fn(),
+    };
+});
+
+vi.mock('firebase/firestore', () => ({
+    collection: mocks.collection,
+    addDoc: mocks.addDoc,
+    getDocs: mocks.getDocs,
+    getDoc: mocks.getDoc,
+    query: mocks.query,
+    orderBy: mocks.orderBy,
+    deleteDoc: mocks.deleteDoc,
+    doc: mocks.doc,
+    setDoc: mocks.setDoc,
+    updateDoc: mocks.updateDoc,
+    where: mocks.where,
+    serverTimestamp: mocks.serverTimestamp,
+    limit: mocks.limit,
+    writeBatch: mocks.writeBatch,
+}));
+
+vi.mock('./firebase', () => ({ db: mocks.database }));
+vi.mock('./auth', () => ({
+    getCurrentUserId: () => 'admin-1',
+    getOwnerType: () => 'user',
+}));
+vi.mock('./auditLog', () => ({ logAudit: vi.fn() }));
+vi.mock('./userManagement', () => ({ updateUserStats: vi.fn() }));
+vi.mock('./logger', () => ({
+    createLogger: () => ({ error: mocks.loggerError, info: mocks.loggerInfo }),
+}));
+vi.mock('./adminSettings', async importOriginal => {
+    const actual = await importOriginal<typeof import('./adminSettings')>();
+    return { ...actual, getDefaultPrompts: mocks.getDefaultPrompts };
+});
+
+import { syncGuestDefaultPrompts } from './prompts';
+
+/*
+ * 実装と同じ決定論的 ID 規則をここにも写す。ID 規則が変わると既存のゲスト doc を
+ * 「別物」と見なして作り直す (createdAt が消える) ので、規則の踏襲そのものを錠にする。
+ */
+function deterministicHash(value: string): string {
+    let hash = 0;
+    for (let i = 0; i < value.length; i++) {
+        hash = (hash << 5) - hash + value.charCodeAt(i);
+        hash |= 0;
+    }
+    return Math.abs(hash).toString(16).padStart(8, '0');
+}
+
+function guestDefaultId(name: string): string {
+    return `default_GUEST_${deterministicHash(`GUEST:${name}`)}`;
+}
+
+type StoredGuestDefault = {
+    name: string;
+    content: string;
+    model?: string;
+    thinkingLevel?: string;
+};
+
+function arrangeExistingGuestDefaults(stored: StoredGuestDefault[]) {
+    mocks.getDocs.mockResolvedValue({
+        docs: stored.map(data => ({
+            id: guestDefaultId(data.name),
+            data: () => ({
+                ...data,
+                isDefault: true,
+                ownerType: 'guest',
+                ownerId: 'GUEST',
+                createdBy: 'GUEST',
+                createdAt: { seconds: 1 },
+                updatedAt: { seconds: 1 },
+            }),
+        })),
+    });
+}
+
+const template = (name: string, content: string): DefaultPromptTemplate => ({
+    name,
+    content,
+    model: 'default',
+    thinkingLevel: 'default',
+});
+
+describe('syncGuestDefaultPrompts (S2-5 差分 upsert)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.batch.commit.mockResolvedValue(undefined);
+        mocks.getDefaultPrompts.mockResolvedValue([]);
+        mocks.getDocs.mockResolvedValue({ docs: [] });
+    });
+
+    it('テンプレート1件の変更は該当docだけを上書きし、他は触らず、消えた分だけ削除する', async () => {
+        arrangeExistingGuestDefaults([
+            { name: '打ち合わせの流れ', content: '旧の流れ' },
+            { name: '希望条件', content: '希望条件を整理' },
+            { name: '廃止テンプレ', content: '消える' },
+        ]);
+        mocks.getDefaultPrompts.mockResolvedValue([
+            template('打ち合わせの流れ', '新しい流れ'),
+            template('希望条件', '希望条件を整理'),
+        ]);
+
+        await expect(syncGuestDefaultPrompts()).resolves.toBeUndefined();
+
+        // 保存済み snapshot は最初の await で受け取る (adminSettings の override 受け渡し順序)
+        expect(mocks.getDefaultPrompts.mock.invocationCallOrder[0])
+            .toBeLessThan(mocks.getDocs.mock.invocationCallOrder[0]);
+
+        // 変更のあった doc だけ merge 上書き。createdAt と所有者は書かない
+        expect(mocks.batch.set).toHaveBeenCalledTimes(1);
+        expect(mocks.batch.set).toHaveBeenCalledWith(
+            expect.objectContaining({ id: guestDefaultId('打ち合わせの流れ') }),
+            {
+                name: '打ち合わせの流れ',
+                content: '新しい流れ',
+                model: 'default',
+                thinkingLevel: 'default',
+                updatedAt: mocks.timestamp,
+            },
+            { merge: true },
+        );
+        expect(mocks.batch.set.mock.calls[0][1]).not.toHaveProperty('createdAt');
+
+        // テンプレートから消えた ID だけ削除
+        expect(mocks.batch.delete).toHaveBeenCalledTimes(1);
+        expect(mocks.batch.delete).toHaveBeenCalledWith(
+            expect.objectContaining({ id: guestDefaultId('廃止テンプレ') }),
+        );
+
+        // 全削除→再作成 (旧挙動) の痕跡が無い: 単発の deleteDoc/setDoc は使わず、1 batch で確定
+        expect(mocks.deleteDoc).not.toHaveBeenCalled();
+        expect(mocks.setDoc).not.toHaveBeenCalled();
+        expect(mocks.writeBatch).toHaveBeenCalledTimes(1);
+        expect(mocks.batch.commit).toHaveBeenCalledTimes(1);
+    });
+
+    it('内容が同じなら (未設定と既定値の違いだけなら) 何も書かない', async () => {
+        arrangeExistingGuestDefaults([
+            // model/thinkingLevel 未設定の旧 doc は正規化すると既定値と同じ
+            { name: '打ち合わせの流れ', content: '流れ' },
+            { name: 'お客様情報', content: '一覧', model: ' default ', thinkingLevel: 'low' },
+        ]);
+        mocks.getDefaultPrompts.mockResolvedValue([
+            template('打ち合わせの流れ', '流れ'),
+            { name: 'お客様情報', content: '一覧', model: 'default', thinkingLevel: 'low' },
+        ]);
+
+        await expect(syncGuestDefaultPrompts()).resolves.toBeUndefined();
+
+        expect(mocks.batch.set).not.toHaveBeenCalled();
+        expect(mocks.batch.delete).not.toHaveBeenCalled();
+        expect(mocks.batch.commit).not.toHaveBeenCalled();
+        expect(mocks.deleteDoc).not.toHaveBeenCalled();
+        expect(mocks.setDoc).not.toHaveBeenCalled();
+    });
+
+    it('まだ無いテンプレートは所有者と createdAt を付けて新規作成する', async () => {
+        arrangeExistingGuestDefaults([{ name: '希望条件', content: '希望条件を整理' }]);
+        mocks.getDefaultPrompts.mockResolvedValue([
+            template('希望条件', '希望条件を整理'),
+            { name: '新規テンプレ', content: '新規', model: 'gemini-3.7-flash', thinkingLevel: 'high' },
+        ]);
+
+        await expect(syncGuestDefaultPrompts()).resolves.toBeUndefined();
+
+        expect(mocks.batch.set).toHaveBeenCalledTimes(1);
+        expect(mocks.batch.set).toHaveBeenCalledWith(
+            expect.objectContaining({ id: guestDefaultId('新規テンプレ') }),
+            {
+                name: '新規テンプレ',
+                content: '新規',
+                model: 'gemini-3.7-flash',
+                thinkingLevel: 'high',
+                isDefault: true,
+                ownerType: 'guest',
+                ownerId: 'GUEST',
+                createdBy: 'GUEST',
+                createdAt: mocks.timestamp,
+                updatedAt: mocks.timestamp,
+            },
+        );
+        expect(mocks.batch.delete).not.toHaveBeenCalled();
+        expect(mocks.batch.commit).toHaveBeenCalledTimes(1);
+    });
+
+    it('同名テンプレートは同じ ID に畳まれるため先勝ちで 1 回だけ書く', async () => {
+        mocks.getDefaultPrompts.mockResolvedValue([
+            template('重複', '先'),
+            template('重複', '後'),
+        ]);
+
+        await expect(syncGuestDefaultPrompts()).resolves.toBeUndefined();
+
+        expect(mocks.batch.set).toHaveBeenCalledTimes(1);
+        expect(mocks.batch.set.mock.calls[0][1]).toEqual(expect.objectContaining({ content: '先' }));
+    });
+
+    it('batch の確定に失敗したら同期失敗として伝播する', async () => {
+        arrangeExistingGuestDefaults([{ name: '廃止テンプレ', content: '消える' }]);
+        mocks.batch.commit.mockRejectedValueOnce(new Error('permission-denied'));
+
+        await expect(syncGuestDefaultPrompts())
+            .rejects.toThrow('ゲストデフォルトプロンプトの同期に失敗しました');
+        expect(mocks.loggerError).toHaveBeenCalled();
+    });
+});

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -13,12 +13,14 @@ import {
     where,
     serverTimestamp,
     limit,
+    writeBatch,
 } from 'firebase/firestore';
 import { getCurrentUserId, getOwnerType } from './auth';
 import { logAudit } from './auditLog';
 import {
     validatePromptSize,
     getDefaultPrompts,
+    isEquivalentDefaultPrompt,
     type DefaultPromptTemplate,
 } from './adminSettings';
 import { updateUserStats } from './userManagement';
@@ -621,12 +623,16 @@ export async function deletePrompt(promptId: string): Promise<void> {
 /**
  * ゲストユーザーのデフォルトプロンプトを管理者設定と同期
  * 管理者がデフォルトプロンプトを更新したときに呼ばれる
- * 既存のゲストデフォルトプロンプトをすべて削除して、管理者設定から再作成する
- * これにより、複数のプロンプト、個数の変化、順序の変更、名前変更などすべてに対応
+ * 決定論的 ID (ownerId + テンプレート名) をキーに差分だけを 1 つの batch で書く:
+ * - テンプレートに無い既存 doc は削除
+ * - 既存 doc は内容が変わった時だけ上書き (createdAt と所有者は保持)
+ * - 無い doc は新規作成
+ * 全削除→再作成をしないので、途中で切れてもゲストのプロンプトが 0 件になる窓は無く、
+ * 変更の無かった doc の createdAt (一覧の並び) も動かない。
  */
 export async function syncGuestDefaultPrompts(): Promise<void> {
     try {
-        // 管理者設定のデフォルトプロンプトを取得
+        // adminSettings が直前に渡した保存済み snapshot を最初の await で消費する (順序を変えない)
         const defaultPromptTemplates = await getDefaultPrompts();
 
         // ゲストユーザーの既存のデフォルトプロンプトをすべて取得
@@ -636,27 +642,74 @@ export async function syncGuestDefaultPrompts(): Promise<void> {
             where('isDefault', '==', true)
         );
         const existingGuestDefaults = await getDocs(q);
+        const existingById = new Map(
+            existingGuestDefaults.docs.map(docSnapshot => [docSnapshot.id, docSnapshot]),
+        );
 
-        // 既存のゲストデフォルトプロンプトをすべて削除
-        const deletePromises = existingGuestDefaults.docs.map((docSnapshot) => {
-            return deleteDoc(doc(db, 'prompts', docSnapshot.id));
-        });
-        await Promise.all(deletePromises);
+        const batch = writeBatch(db);
+        const desiredIds = new Set<string>();
+        const counts = { created: 0, updated: 0, unchanged: 0, deleted: 0 };
 
-        if (existingGuestDefaults.docs.length > 0) {
-            promptsLogger.info('ゲストデフォルトプロンプトを削除', {
-                deletedCount: existingGuestDefaults.docs.length,
-            });
+        for (const template of defaultPromptTemplates) {
+            const docId = generateDefaultPromptId('GUEST', template.name);
+            if (desiredIds.has(docId)) {
+                // 同名テンプレートは同じ ID に畳まれる。管理画面が保存前に弾くが、二重書きを避けて先勝ちにする
+                promptsLogger.info('同名のテンプレートが重複しているためスキップ', { name: template.name });
+                continue;
+            }
+            desiredIds.add(docId);
+
+            const promptRef = doc(db, 'prompts', docId);
+            const fields = {
+                name: template.name,
+                content: template.content,
+                model: canonicalizeGeminiModel(template.model),
+                thinkingLevel: canonicalizeThinkingLevel(template.thinkingLevel),
+            };
+            const existing = existingById.get(docId);
+
+            if (!existing) {
+                batch.set(promptRef, {
+                    ...fields,
+                    isDefault: true,
+                    ownerType: 'guest',
+                    ownerId: 'GUEST',
+                    createdBy: 'GUEST',
+                    createdAt: serverTimestamp(),
+                    updatedAt: serverTimestamp(),
+                });
+                counts.created += 1;
+                continue;
+            }
+
+            const data = existing.data();
+            const stored: DefaultPromptTemplate = {
+                name: data.name,
+                content: data.content,
+                model: data.model,
+                thinkingLevel: data.thinkingLevel,
+            };
+            if (isEquivalentDefaultPrompt(stored, fields)) {
+                counts.unchanged += 1;
+                continue;
+            }
+
+            // 内容だけ上書きし、createdAt と所有者フィールドは触らない
+            batch.set(promptRef, { ...fields, updatedAt: serverTimestamp() }, { merge: true });
+            counts.updated += 1;
         }
 
-        // 管理者設定のデフォルトプロンプトから新規作成
-        await ensureDefaultPromptsForOwner('GUEST', 'guest', 'GUEST', defaultPromptTemplates);
-
-        if (defaultPromptTemplates.length > 0) {
-            promptsLogger.info('ゲストデフォルトプロンプトを再作成', {
-                createdCount: defaultPromptTemplates.length,
-            });
+        for (const docSnapshot of existingGuestDefaults.docs) {
+            if (desiredIds.has(docSnapshot.id)) continue;
+            batch.delete(doc(db, 'prompts', docSnapshot.id));
+            counts.deleted += 1;
         }
+
+        if (counts.created + counts.updated + counts.deleted > 0) {
+            await batch.commit();
+        }
+
+        promptsLogger.info('ゲストデフォルトプロンプトを同期', counts);
     } catch (error) {
         promptsLogger.error('ゲストデフォルトプロンプトの同期に失敗', error);
         throw new Error('ゲストデフォルトプロンプトの同期に失敗しました');


### PR DESCRIPTION
## 概要
全域調査 (2026-09-03) の S2 所見 10 件 (#6〜#15) をまとめて対応します。6 レーンが独立ブランチで実装し、この統合ブランチに競合なしでマージしました。

## 対応 Issue と変更
| Issue | 内容 | 主な変更 |
|---|---|---|
| #6 長い録音が必ず失敗 | 生成前に inline 予算 (16MiB) を検査し、超過は Files API へ迂回。ビットレート選択 (64/96/128/192k) を復活、既定 192k→128k (約13分まで inline) | `gemini.ts` `useVideoProcessing.ts` `inlineMediaBudget.ts` `ConversionSettings.tsx` `home/page.tsx` |
| #7 処理中の遷移で結果が消える | ホームに離脱ガード (beforeunload + SPA 内リンク + 戻る)。ログイン/ログアウト/退会も同じ確認を通す | `useNavigationGuard.ts` `home/page.tsx` `AppHeader.tsx` |
| #8 監査ログが誰でも書ける | `auditLogs` の create を「本人 uid か未ログインの GUEST」に限定 (エミュレータ 15 ケース実測) | `firestore.rules` |
| #9 5 秒ポーリング | 非表示タブでは取得を止め、間隔 5s→30s | `DocumentListSidebar.tsx` |
| #10 設定保存で共通プロンプト全消し | 変更があった時だけ同期し、差分 upsert (空状態の窓を廃止) | `adminSettings.ts` `prompts.ts` |
| #11 ゲスト既定が検証中プロンプト | 既定を管理テンプレート由来 (isDefault) の先頭に限定、無ければ未選択 | `usePromptManagement.ts` |
| #12 CI なし | `.github/workflows/ci.yml` (tsc/lint/vitest)。Vercel Build Command の即効策を runbook に | `.github/` `README.md` |
| #13 観測性ゼロ | 未捕捉エラーを logger と Firestore `clientErrors` へ best-effort 送信 (throttle/上限付き)。Rules も追加 | `clientErrorReporter.ts` `(dashboard)/layout.tsx` `firestore.rules` |
| #14 バックアップ手順なし | `docs/ops-runbook.md` (PITR・日次バックアップ・復旧・Rules 配備手順・Vercel env) | `docs/` |
| #15 鍵の運用 | `.gitignore` に `*-firebase-adminsdk-*.json`、鍵は `~/.config` + `GOOGLE_APPLICATION_CREDENTIALS` に統一。`/docs` の ignore を解除 | `.gitignore` `scripts/README.md` |

## 検証
- 統合ブランチで `tsc --noEmit` 0 / `eslint .` 0 / `vitest run` 75 ファイル 1111 件緑 (新規テスト 106 件)
- 各レーンで変異注入 (修正前コードに戻して新テストが落ちることを確認): A 5 変異 / B 3 / C 3 / D 1 / E 4 すべて赤→修復で緑
- Rules はエミュレータでクライアント SDK 経路を実測: auditLogs 15 ケース (他人 uid のなりすまし DENY・正規経路 ALLOW)、clientErrors 10 ケース (本人/GUEST の作成 ALLOW、なりすまし・必須欠落・不正 source・4000 文字超・一般の list・update はすべて DENY、管理者の list ALLOW) すべて期待どおり

## 🔴 マージ後に必要な手作業
1. **Firestore Rules の配備** (`firebase deploy --only firestore:rules`)。#8 と #13 のルールはマージだけでは本番に効きません。配備手順は `docs/ops-runbook.md` §2.9。配備前に #3 (管理者自己昇格) の修正を同梱することを強く推奨します (別 PR で用意可)。
2. **Vercel の Build Command を `npm test && npm run build` に変更** (Actions 停止中でもテストがゲートになる)。
3. Files API 経路 (#6) は本番キーでのライブ検証が未実施。約 13 分超の録音 1 本で「送信経路を決定 transport=files_api」ログと完了を確認してください。失敗時は明示的なエラー文言で止まります (従来は無言の失敗)。

## 残課題 (別 Issue)
- `/admin` 配下はエラー捕捉の対象外 (dashboard layout のみ)。`AppShell` に載せると全ルートを覆える。
- 運用スクリプト 4 本は `serviceAccountKey.json` 固定のまま (`GOOGLE_APPLICATION_CREDENTIALS` 対応は未着手)。
- documents 画面の離脱ガードは `useNavigationGuard` へ未統合 (重複コード)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
