### PR TITLE
feat(お知らせ): ホーム上部のバナーを「最新 1 件 + 直近 1 週間の全件」に統一

### DIFF
--- a/src/hooks/selectBannerNotifications.test.ts
+++ b/src/hooks/selectBannerNotifications.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { SystemNotification } from '@/lib/systemNotifications';
+import {
+    MAX_BANNER_ITEMS,
+    RECENT_BANNER_WINDOW_MS,
+    selectBannerNotifications,
+} from './useSystemNotifications';
+
+const NOW = Date.parse('2026-09-03T00:00:00.000Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+function notice(id: string, daysAgo: number): SystemNotification {
+    return {
+        id,
+        title: `お知らせ ${id}`,
+        body: '本文',
+        severity: 'info',
+        published: true,
+        publishedAt: new Date(NOW - daysAgo * DAY),
+        publishedBy: 'admin',
+    };
+}
+
+describe('selectBannerNotifications（最新 1 件 + 直近 1 週間）', () => {
+    it('直近 1 週間のお知らせは全件、新しい順に出す', () => {
+        const list = [notice('a', 0), notice('b', 3), notice('c', 6.9), notice('d', 8)];
+        expect(selectBannerNotifications(list, [], NOW).map(n => n.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('最新 1 件は 1 週間より古くても出す（お知らせが途絶えても最後の 1 件は残す）', () => {
+        const list = [notice('old', 40), notice('older', 90)];
+        expect(selectBannerNotifications(list, [], NOW).map(n => n.id)).toEqual(['old']);
+    });
+
+    it('最新 1 件が 1 週間以内なら重複させない', () => {
+        const list = [notice('a', 1), notice('b', 2)];
+        expect(selectBannerNotifications(list, [], NOW).map(n => n.id)).toEqual(['a', 'b']);
+    });
+
+    it('閉じたお知らせは除外し、最新も閉じていれば次に新しいものを最新として扱う', () => {
+        const list = [notice('a', 0), notice('b', 20), notice('c', 30)];
+        expect(selectBannerNotifications(list, ['a'], NOW).map(n => n.id)).toEqual(['b']);
+        expect(selectBannerNotifications(list, ['a', 'b', 'c'], NOW)).toEqual([]);
+    });
+
+    it('入力の並びに依存せず publishedAt の新しい順に揃える', () => {
+        const list = [notice('b', 3), notice('a', 0), notice('c', 5)];
+        expect(selectBannerNotifications(list, [], NOW).map(n => n.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('境界: ちょうど 7 日前は「直近」に含め、7 日 + 1ms 前は含めない', () => {
+        const exactly = { ...notice('x', 0), publishedAt: new Date(NOW - RECENT_BANNER_WINDOW_MS) };
+        const justOutside = { ...notice('y', 0), publishedAt: new Date(NOW - RECENT_BANNER_WINDOW_MS - 1) };
+        const latest = notice('latest', 0);
+        expect(selectBannerNotifications([latest, exactly, justOutside], [], NOW).map(n => n.id)).toEqual(['latest', 'x']);
+    });
+
+    it('直近 1 週間に上限を超えて投入されても MAX_BANNER_ITEMS 件までに抑える', () => {
+        const list = Array.from({ length: MAX_BANNER_ITEMS + 5 }, (_, i) => notice(`n${i}`, i * 0.1));
+        expect(selectBannerNotifications(list, [], NOW)).toHaveLength(MAX_BANNER_ITEMS);
+    });
+
+    it('0 件なら空', () => {
+        expect(selectBannerNotifications([], [], NOW)).toEqual([]);
+    });
+});

--- a/src/hooks/useSystemNotifications.ts
+++ b/src/hooks/useSystemNotifications.ts
@@ -8,8 +8,34 @@ import {
     subscribeToPublishedNotifications,
 } from '@/lib/systemNotifications';
 
-const ONE_MONTH_MS = 30 * 24 * 60 * 60 * 1000;
-const MAX_BANNER_ITEMS_AUTHED = 5;
+/** ホーム最上部バナーに出す「直近」の窓。最新 1 件はこの窓に関係なく必ず出す。 */
+export const RECENT_BANNER_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+/** 直近 1 週間に大量投入された場合の表示上限（画面を埋め尽くさないための保険）。 */
+export const MAX_BANNER_ITEMS = 10;
+
+/**
+ * バナーに出す通知 = 「一番新しいお知らせ 1 件」+「直近 1 週間のお知らせ全件」（閉じたものは除く・新しい順）。
+ * 最新 1 件は公開日に関係なく出す（お知らせが久しく無くても最後の 1 件は残す）。
+ * 純関数にして時刻を引数で受け、テストと hook の両方から同じ判定を使う。
+ */
+export function selectBannerNotifications(
+    notifications: readonly SystemNotification[],
+    dismissedIds: readonly string[],
+    now: number,
+): SystemNotification[] {
+    const dismissed = new Set(dismissedIds);
+    const visible = notifications
+        .filter(n => !dismissed.has(n.id))
+        .slice()
+        .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+    if (visible.length === 0) return [];
+
+    const cutoff = now - RECENT_BANNER_WINDOW_MS;
+    const recent = visible.filter(n => n.publishedAt.getTime() >= cutoff);
+    const latest = visible[0];
+    const picked = recent.some(n => n.id === latest.id) ? recent : [latest, ...recent];
+    return picked.slice(0, MAX_BANNER_ITEMS);
+}
 
 export interface UseSystemNotificationsResult {
     notifications: SystemNotification[];
@@ -19,7 +45,7 @@ export interface UseSystemNotificationsResult {
     stale: boolean;
     retrying: boolean;
     retry: () => void;
-    /** ホーム最上部バナーに出す通知（dismiss 済み除外）。未認証時は1ヶ月以内最新1件のみ */
+    /** ホーム最上部バナーに出す通知 = 最新 1 件 + 直近 1 週間（dismiss 済み除外・未認証は dismiss 無し） */
     bannerNotifications: SystemNotification[];
 }
 
@@ -37,7 +63,7 @@ export function useSystemNotifications(): UseSystemNotificationsResult {
     const [dismissalsAttempt, setDismissalsAttempt] = useState(0);
     const notificationsAttemptRef = useRef(0);
     const dismissalsAttemptRef = useRef(0);
-    // 1ヶ月以内判定の基準時刻。マウント時に固定して useMemo 内で純粋に扱えるようにする。
+    // 「直近 1 週間」判定の基準時刻。マウント時に固定して useMemo 内で純粋に扱えるようにする。
     const [mountedAt] = useState(() => Date.now());
 
     // user 切替時に dismiss 状態をリセット（Adjusting state during render パターン）。
@@ -114,17 +140,11 @@ export function useSystemNotifications(): UseSystemNotificationsResult {
         }
     }, [currentUid, dismissalsError, notificationsError]);
 
-    const bannerNotifications = useMemo<SystemNotification[]>(() => {
-        if (user?.uid) {
-            const dismissed = new Set(dismissedIds);
-            return notifications
-                .filter(n => !dismissed.has(n.id))
-                .slice(0, MAX_BANNER_ITEMS_AUTHED);
-        }
-        const cutoff = mountedAt - ONE_MONTH_MS;
-        const latest = notifications.find(n => n.publishedAt.getTime() >= cutoff);
-        return latest ? [latest] : [];
-    }, [user?.uid, notifications, dismissedIds, mountedAt]);
+    const bannerNotifications = useMemo<SystemNotification[]>(
+        // 未認証には dismiss の概念が無いので除外リストは空。
+        () => selectBannerNotifications(notifications, user?.uid ? dismissedIds : [], mountedAt),
+        [user?.uid, notifications, dismissedIds, mountedAt],
+    );
 
     // 未認証時は dismiss の概念がないのでロード待ちにしない。
     const effectiveDismissalsLoaded = user?.uid ? dismissalsLoaded : true;

--- a/src/hooks/useSystemNotifications.ts
+++ b/src/hooks/useSystemNotifications.ts
@@ -7,35 +7,8 @@ import {
     subscribeToDismissals,
     subscribeToPublishedNotifications,
 } from '@/lib/systemNotifications';
+import { selectBannerNotifications } from '@/lib/selectBannerNotifications';
 
-/** ホーム最上部バナーに出す「直近」の窓。最新 1 件はこの窓に関係なく必ず出す。 */
-export const RECENT_BANNER_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-/** 直近 1 週間に大量投入された場合の表示上限（画面を埋め尽くさないための保険）。 */
-export const MAX_BANNER_ITEMS = 10;
-
-/**
- * バナーに出す通知 = 「一番新しいお知らせ 1 件」+「直近 1 週間のお知らせ全件」（閉じたものは除く・新しい順）。
- * 最新 1 件は公開日に関係なく出す（お知らせが久しく無くても最後の 1 件は残す）。
- * 純関数にして時刻を引数で受け、テストと hook の両方から同じ判定を使う。
- */
-export function selectBannerNotifications(
-    notifications: readonly SystemNotification[],
-    dismissedIds: readonly string[],
-    now: number,
-): SystemNotification[] {
-    const dismissed = new Set(dismissedIds);
-    const visible = notifications
-        .filter(n => !dismissed.has(n.id))
-        .slice()
-        .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
-    if (visible.length === 0) return [];
-
-    const cutoff = now - RECENT_BANNER_WINDOW_MS;
-    const recent = visible.filter(n => n.publishedAt.getTime() >= cutoff);
-    const latest = visible[0];
-    const picked = recent.some(n => n.id === latest.id) ? recent : [latest, ...recent];
-    return picked.slice(0, MAX_BANNER_ITEMS);
-}
 
 export interface UseSystemNotificationsResult {
     notifications: SystemNotification[];

--- a/src/lib/selectBannerNotifications.test.ts
+++ b/src/lib/selectBannerNotifications.test.ts
@@ -4,7 +4,7 @@ import {
     MAX_BANNER_ITEMS,
     RECENT_BANNER_WINDOW_MS,
     selectBannerNotifications,
-} from './useSystemNotifications';
+} from '@/lib/selectBannerNotifications';
 
 const NOW = Date.parse('2026-09-03T00:00:00.000Z');
 const DAY = 24 * 60 * 60 * 1000;

--- a/src/lib/selectBannerNotifications.ts
+++ b/src/lib/selectBannerNotifications.ts
@@ -1,0 +1,30 @@
+import type { SystemNotification } from '@/lib/systemNotifications';
+
+/** ホーム最上部バナーに出す「直近」の窓。最新 1 件はこの窓に関係なく必ず出す。 */
+export const RECENT_BANNER_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+/** 直近 1 週間に大量投入された場合の表示上限（画面を埋め尽くさないための保険）。 */
+export const MAX_BANNER_ITEMS = 10;
+
+/**
+ * バナーに出す通知 = 「一番新しいお知らせ 1 件」+「直近 1 週間のお知らせ全件」（閉じたものは除く・新しい順）。
+ * 最新 1 件は公開日に関係なく出す（お知らせが久しく無くても最後の 1 件は残す）。
+ * 純関数にして時刻を引数で受け、テストと hook の両方から同じ判定を使う。
+ */
+export function selectBannerNotifications(
+    notifications: readonly SystemNotification[],
+    dismissedIds: readonly string[],
+    now: number,
+): SystemNotification[] {
+    const dismissed = new Set(dismissedIds);
+    const visible = notifications
+        .filter(n => !dismissed.has(n.id))
+        .slice()
+        .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+    if (visible.length === 0) return [];
+
+    const cutoff = now - RECENT_BANNER_WINDOW_MS;
+    const recent = visible.filter(n => n.publishedAt.getTime() >= cutoff);
+    const latest = visible[0];
+    const picked = recent.some(n => n.id === latest.id) ? recent : [latest, ...recent];
+    return picked.slice(0, MAX_BANNER_ITEMS);
+}


### PR DESCRIPTION
## 変更の趣旨
ホーム上部のお知らせバナーを「一番新しいお知らせ 1 件 + 直近 1 週間のお知らせ全件」に統一します (2026-09-03 東野指示)。

## 変更前
- ログイン時: 閉じていないお知らせを新しい順に最大 5 件
- 未ログイン時: 1 か月以内の最新 1 件のみ (1 か月を過ぎると何も出ない)

## 変更後 (ログイン・未ログイン共通)
- 直近 7 日以内のお知らせは全件 (新しい順)
- 最新 1 件は公開日に関係なく必ず出す (お知らせが途絶えても最後の 1 件は残る)
- ログイン時に「閉じる」したものは除外。最新を閉じた場合は次に新しいものを最新として扱う
- 保険として最大 10 件

## 実装
- `useSystemNotifications.ts` に純関数 `selectBannerNotifications(notifications, dismissedIds, now)` を追加し、hook はこれを呼ぶだけに。時刻は引数で受けるのでテストが日付に依存しない。
- バナーのコンポーネント (`NotificationBanner.tsx`) は変更なし (もともと複数件をリスト表示できる)。

## 検証
- 新規テスト 8 件 (7 日境界・最新が古い場合・閉じた場合の繰り上げ・並び順・上限・0 件)
- 既存の hook / バナー / お知らせ画面テストを含め全量緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)
