### PR TITLE
ビットレート欄を「実際に扱える録音の長さ」表示にし、既定を 96k へ

### DIFF
--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -59,7 +59,7 @@ export default function HomePage() {
   // 🎬 動画を直接送信する機能（試験的）
   const [sendVideoDirectly, setSendVideoDirectly] = useState(false);
 
-  // S2-1: 192k 固定だと約 10 分で inline 上限に達して失敗していた。既定を 128k に下げ、画面から選べるようにする
+  // S2-1: 192k 固定だと約 10 分で inline 上限に達して失敗していた。既定を下げ、画面から選べるようにする
   const [bitrate, setBitrate] = useState<string>(DEFAULT_AUDIO_BITRATE);
   const sampleRate = 44100;
 

--- a/src/app/(dashboard)/home/page.wiring.test.tsx
+++ b/src/app/(dashboard)/home/page.wiring.test.tsx
@@ -474,11 +474,11 @@ describe('bitrate wiring (S2-1)', () => {
         hookMocks.handleStartProcessing.mockResolvedValue({ ok: true });
     });
 
-    it('既定の 128k を開始処理へ渡す (192k 固定だと約 10 分で送れなくなる)', async () => {
+    it('既定の 96k を開始処理へ渡す (128k だと 2 時間の商談が上限に届かない)', async () => {
         await click('変換・文書生成を開始する');
 
         expect(hookMocks.handleStartProcessing).toHaveBeenCalledTimes(1);
-        expect(hookMocks.handleStartProcessing.mock.calls[0][2]).toBe('128k');
+        expect(hookMocks.handleStartProcessing.mock.calls[0][2]).toBe('96k');
         expect(hookMocks.handleStartProcessing.mock.calls[0][3]).toBe(44100);
     });
 
@@ -487,7 +487,7 @@ describe('bitrate wiring (S2-1)', () => {
             typeof element.props.onBitrateChange === 'function'
         );
         expect(settings, 'ConversionSettings が配線されていない').toBeDefined();
-        expect(settings!.props.bitrate).toBe('128k');
+        expect(settings!.props.bitrate).toBe('96k');
 
         (settings!.props.onBitrateChange as (bitrate: string) => void)('64k');
         await click('変換・文書生成を開始する');

--- a/src/components/ConversionSettings.test.tsx
+++ b/src/components/ConversionSettings.test.tsx
@@ -6,6 +6,7 @@ import {
     ConversionSettings,
     DEFAULT_AUDIO_BITRATE,
 } from './ConversionSettings';
+import { estimateMaxRecordingMinutes } from '@/lib/inlineMediaBudget';
 
 const render = (bitrate: string, disabled = false) =>
     renderToStaticMarkup(
@@ -16,9 +17,11 @@ const radios = (markup: string): string[] =>
     [...markup.matchAll(/<input\b[^>]*type="radio"[^>]*>/g)].map(match => match[0]);
 
 describe('ConversionSettings (S2-1: ビットレート選択)', () => {
-    it('既定は安全側の 128k (192k だと約 10 分で送れなくなる)', () => {
-        expect(DEFAULT_AUDIO_BITRATE).toBe('128k');
+    it('既定は 96k (主用途の 2〜3 時間の商談が 128k では上限に届かない)', () => {
+        expect(DEFAULT_AUDIO_BITRATE).toBe('96k');
         expect(AUDIO_BITRATE_OPTIONS.map(option => option.value)).toContain(DEFAULT_AUDIO_BITRATE);
+        // 既定は 2 時間の商談をそのまま扱えること (128k の約 109 分では足りない)
+        expect(estimateMaxRecordingMinutes(DEFAULT_AUDIO_BITRATE)).toBeGreaterThanOrEqual(120);
     });
 
     it('64 / 96 / 128 / 192 kbps を選べる', () => {
@@ -32,12 +35,20 @@ describe('ConversionSettings (S2-1: ビットレート選択)', () => {
         expect(checked[0]).toContain('value="64k"');
     });
 
-    it('各選択肢に「そのまま送れる目安」の分数を出す', () => {
-        const markup = render('128k');
-        expect(markup).toContain('約26分');
-        expect(markup).toContain('約17分');
-        expect(markup).toContain('約13分');
-        expect(markup).toContain('約8分');
+    it('各選択肢に Storage 上限 (100MB) から逆算した「扱える録音の長さ」を出す', () => {
+        const markup = render('96k');
+        expect(markup).toContain('約3時間38分までの録音に対応');
+        expect(markup).toContain('約2時間25分までの録音に対応');
+        expect(markup).toContain('約1時間49分までの録音に対応');
+        expect(markup).toContain('約1時間12分までの録音に対応');
+    });
+
+    it('inline 予算 (Files API へ迂回すれば超えられる内部の分岐点) の分数は出さない', () => {
+        // 実害: 64k に「そのまま送れる目安: 約26分」と出て、2〜3 時間の商談が扱えないと読めていた
+        const markup = render('96k');
+        for (const stale of ['約26分', '約17分', '約13分', '約8分', 'そのまま送れる']) {
+            expect(markup).not.toContain(stale);
+        }
     });
 
     it('処理中は fieldset ごと無効になる', () => {

--- a/src/components/ConversionSettings.tsx
+++ b/src/components/ConversionSettings.tsx
@@ -1,19 +1,21 @@
 'use client';
 
 import React from 'react';
-import { estimateInlineLimitMinutes } from '@/lib/inlineMediaBudget';
+import { estimateMaxRecordingMinutes, formatDurationJa } from '@/lib/inlineMediaBudget';
 
 /**
- * S2-1: 既定は 128k。192k だと約 10 分でそのまま送れる上限に達し、長い商談録音が全滅していた。
- * 音声認識の用途では 128k で十分で、そのまま送れる長さが 1.5 倍に伸びる。
+ * S2-1: 既定は 128k だった。192k だと約 10 分で inline 予算に達し、長い商談録音が全滅していた。
+ *
+ * 本サービスの主用途は 2〜3 時間の営業商談。128k では Storage 上限 (100MB) に約 1 時間 49 分でぶつかり、
+ * 2 時間の商談が扱えない。音声認識の用途では 96k で十分なので、既定を 96k (約 2 時間 25 分) に下げる。
  */
-export const DEFAULT_AUDIO_BITRATE = '128k';
+export const DEFAULT_AUDIO_BITRATE = '96k';
 
 export const AUDIO_BITRATE_OPTIONS = [
     { value: '64k', label: '64 kbps', description: '長い録音向け（音質は低め）' },
-    { value: '96k', label: '96 kbps', description: '長めの録音向け' },
-    { value: '128k', label: '128 kbps', description: '標準（推奨）' },
-    { value: '192k', label: '192 kbps', description: '高音質（短い録音向け）' },
+    { value: '96k', label: '96 kbps', description: '標準（推奨）' },
+    { value: '128k', label: '128 kbps', description: '高音質' },
+    { value: '192k', label: '192 kbps', description: '最高音質（短い録音向け）' },
 ] as const;
 
 interface ConversionSettingsProps {
@@ -30,11 +32,11 @@ export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
     <fieldset className="rounded-lg border border-gray-200 bg-gray-50 p-4" disabled={disabled}>
         <legend className="px-1 text-sm font-medium text-gray-900">音声のビットレート</legend>
         <p className="mt-1 text-[13px] text-gray-700">
-            低いほど長い録音をそのまま送れます。目安を超える長さは、サーバーが大きなファイル用の送信方式に自動で切り替えます。うまくいかない場合はビットレートを下げるか、ファイルを分割してください。
+            低いほど長い録音を扱えます。2 時間程度の商談は 96 kbps、3 時間を超える録音は 64 kbps を選んでください。表示の長さを超えるファイルは変換できないため、ビットレートを下げるか、ファイルを分割してください。
         </p>
         <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
             {AUDIO_BITRATE_OPTIONS.map(option => {
-                const minutes = estimateInlineLimitMinutes(option.value);
+                const minutes = estimateMaxRecordingMinutes(option.value);
                 return (
                     <label
                         key={option.value}
@@ -55,7 +57,7 @@ export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
                             </span>
                             {minutes !== null && (
                                 <span className="block text-xs text-gray-600">
-                                    そのまま送れる目安: 約{minutes}分
+                                    {formatDurationJa(minutes)}までの録音に対応
                                 </span>
                             )}
                         </span>

--- a/src/lib/inlineMediaBudget.test.ts
+++ b/src/lib/inlineMediaBudget.test.ts
@@ -4,6 +4,8 @@ import {
     base64LengthForBytes,
     describeInlineBudgetExceeded,
     estimateInlineLimitMinutes,
+    estimateMaxRecordingMinutes,
+    formatDurationJa,
     parseBitrateKbps,
     selectMediaTransport,
     utf8ByteLength,
@@ -129,5 +131,48 @@ describe('describeInlineBudgetExceeded (実行可能な文言)', () => {
 
     it('解釈できないビットレートはサイズの目安に落ちる', () => {
         expect(describeInlineBudgetExceeded('???')).toContain('約12MB');
+    });
+});
+
+describe('estimateMaxRecordingMinutes (画面に出す「扱える録音の長さ」)', () => {
+    it('Storage 上限 100MB から逆算する (inline 予算 16MB ではない)', () => {
+        // 100MB / (kbps*1000/8) / 60 の切り捨て。inline 予算由来の 26/17/13/8 分とは別物
+        expect(estimateMaxRecordingMinutes('64k')).toBe(218);
+        expect(estimateMaxRecordingMinutes('96k')).toBe(145);
+        expect(estimateMaxRecordingMinutes('128k')).toBe(109);
+        expect(estimateMaxRecordingMinutes('192k')).toBe(72);
+    });
+
+    it('inline 予算の目安より必ず長い (Files API 迂回のぶん実際に扱える)', () => {
+        for (const bitrate of ['64k', '96k', '128k', '192k']) {
+            expect(estimateMaxRecordingMinutes(bitrate)!).toBeGreaterThan(estimateInlineLimitMinutes(bitrate)!);
+        }
+    });
+
+    it('その長さの音声が上限ちょうどに収まり、1 分足すと超える', () => {
+        const maxBytes = 8 * 1024 * 1024;
+        const minutes = estimateMaxRecordingMinutes('64k', maxBytes)!;
+        const bytesPerMinute = (64 * 1000 / 8) * 60;
+        expect(minutes * bytesPerMinute).toBeLessThanOrEqual(maxBytes);
+        expect((minutes + 1) * bytesPerMinute).toBeGreaterThan(maxBytes);
+    });
+
+    it('解釈できないビットレートは null', () => {
+        expect(estimateMaxRecordingMinutes('unknown')).toBeNull();
+    });
+});
+
+describe('formatDurationJa', () => {
+    it('1 時間未満は分だけ、境界の 60 分は「約1時間」', () => {
+        expect(formatDurationJa(59)).toBe('約59分');
+        expect(formatDurationJa(60)).toBe('約1時間');
+        expect(formatDurationJa(61)).toBe('約1時間1分');
+    });
+
+    it('時間と分を並べる', () => {
+        expect(formatDurationJa(218)).toBe('約3時間38分');
+        expect(formatDurationJa(145)).toBe('約2時間25分');
+        expect(formatDurationJa(120)).toBe('約2時間');
+        expect(formatDurationJa(0)).toBe('約0分');
     });
 });

--- a/src/lib/inlineMediaBudget.ts
+++ b/src/lib/inlineMediaBudget.ts
@@ -5,6 +5,8 @@
  * 上限に張り付けると単位の解釈や封筒サイズの差で落ちるため、余裕を引いた予算で判定し、
  * 超える分は Files API (ai.files.upload) へ迂回する。ここは SDK に依存しない純関数だけを置く。
  */
+import { GENERATE_MAX_MEDIA_BYTES } from '@/lib/generateApiContract';
+
 export const GEMINI_INLINE_REQUEST_LIMIT_BYTES = 20 * 1024 * 1024;
 
 /** JSON 封筒 (キー名・モデル名・thinkingConfig 等) と計測誤差の余裕 */
@@ -73,4 +75,29 @@ export const describeInlineBudgetExceeded = (bitrate?: string): string => {
     }
     const maxMediaMb = Math.floor((INLINE_REQUEST_BUDGET_BYTES * 3) / 4 / 1024 / 1024);
     return `音声・動画データが大きすぎるため、そのままでは送信できません（そのまま送れる上限の目安: 約${maxMediaMb}MB）。ビットレートを下げるか、ファイルを分割してください。`;
+};
+
+/**
+ * そのビットレートで扱える録音の長さ (分・切り捨て)。
+ *
+ * inline 予算 (estimateInlineLimitMinutes) は Files API へ迂回すれば超えられる内部の分岐点でしかなく、
+ * 利用者が実際にぶつかる壁は Storage のサイズ上限 (100MB) のほう。画面にはこちらを出す。
+ */
+export const estimateMaxRecordingMinutes = (
+    bitrate: string,
+    maxMediaBytes: number = GENERATE_MAX_MEDIA_BYTES,
+): number | null => {
+    const kbps = parseBitrateKbps(bitrate);
+    if (kbps === null) return null;
+    const bytesPerSecond = (kbps * 1000) / 8;
+    return Math.floor(Math.max(0, maxMediaBytes) / bytesPerSecond / 60);
+};
+
+/** 分を「約3時間38分」「約45分」の形にする。1 時間未満は分だけ、ちょうどの時間は「約2時間」 */
+export const formatDurationJa = (minutes: number): string => {
+    const total = Math.max(0, Math.floor(minutes));
+    if (total < 60) return `約${total}分`;
+    const hours = Math.floor(total / 60);
+    const rest = total % 60;
+    return rest === 0 ? `約${hours}時間` : `約${hours}時間${rest}分`;
 };


### PR DESCRIPTION
## 背景

アップロード画面のビットレート欄に出ている「そのまま送れる目安: 約26分」は、**利用者にとっての制限ではありません**。Gemini の inline (Base64 直送) 予算 16MB から逆算した値で、これを超えると `src/server/geminiServer.ts:245` が自動的に Files API 送信へ切り替えて処理は成功します。単なる内部の送信方式の分岐点です。

本サービスの主用途は 2〜3 時間の営業商談なので、「約26分」の表示は「この長さしか扱えない」という誤解を招きます。

一方で、利用者が実際にぶつかる壁である **Storage 上限 100MB** (`GENERATE_MAX_MEDIA_BYTES` / storage.rules) は画面のどこにも出ていませんでした。100MB から逆算すると:

| ビットレート | 変更前の表示 (inline 予算) | 実際に扱える長さ (100MB) |
|---|---|---|
| 64 kbps | 約26分 | **約3時間38分** |
| 96 kbps | 約17分 | **約2時間25分** |
| 128 kbps (旧既定) | 約13分 | **約1時間49分** |
| 192 kbps | 約8分 | 約1時間12分 |

表示の向きが実態と逆に効いており、しかも既定の 128 kbps では約1時間49分で本当に 413 で弾かれることが無告知でした。

## 変更

- `estimateMaxRecordingMinutes` / `formatDurationJa` を `inlineMediaBudget.ts` に追加し、100MB 基準の長さ (「約2時間25分までの録音に対応」) を各選択肢に表示
- **既定を 128k → 96k**。2 時間の商談が既定のまま扱えるようにする (128k では約1時間49分で届かない)。音声認識用途では 96k で品質は足りる
- 説明文を「2 時間程度の商談は 96 kbps、3 時間を超える録音は 64 kbps」と、選び方が分かる形へ
- 各選択肢の description を新しい既定に合わせて調整 (96k=標準(推奨) / 128k=高音質)

`estimateInlineLimitMinutes` / `describeInlineBudgetExceeded` は内部の分岐点を表す純関数として残しますが、画面からは参照しません (inline 予算由来の分数が再び画面に出ないことをテストで固定)。

## 検証

- `npx vitest run` — 83 files / 1242 tests 全通過
- `npx tsc --noEmit` — exit 0
- `npx eslint <変更ファイル>` — exit 0
- ローカル `next build` は Firebase の env 未設定で `auth/invalid-api-key` により失敗しますが、**変更前の origin/main でも同じ失敗**を確認済み (環境要因・本変更とは無関係)

## 別件 (この PR では未対応)

`/api/generate` の `maxDuration = 300` (5分)。3 時間音声の生成が 5 分を超えると Vercel 側でタイムアウトする可能性があり、実測での確認が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)