### PR TITLE
上限を超える音声を変換せずに上げていた — 「権限がありません」の正体

### DIFF
--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -16,6 +16,7 @@ import { useFileManagement } from '@/hooks/useFileManagement';
 import { usePromptManagement } from '@/hooks/usePromptManagement';
 import { useVideoProcessing } from '@/hooks/useVideoProcessing';
 import { useProcessingWorkflow } from '@/hooks/useProcessingWorkflow';
+import { canSendAudioAsIs } from '@/lib/mediaInput';
 import { useNavigationGuard } from '@/hooks/useNavigationGuard';
 import { DebugErrorMode, FileProcessingStatus } from '@/types/processing';
 import { Prompt } from '@/lib/prompts';
@@ -362,6 +363,7 @@ export default function HomePage() {
                   bitrate={bitrate}
                   onBitrateChange={setBitrate}
                   disabled={isBusy}
+                  appliesToSelection={selectedFiles.some(file => !canSendAudioAsIs(file.file))}
                 />
               )}
 

--- a/src/components/ConversionSettings.tsx
+++ b/src/components/ConversionSettings.tsx
@@ -22,15 +22,28 @@ interface ConversionSettingsProps {
     bitrate: string;
     onBitrateChange: (bitrate: string) => void;
     disabled?: boolean;
+    /**
+     * 選んだファイルが 1 つでも変換を通るか。
+     * 🔴 圧縮済みで上限内の音声はそのまま送られる＝**ビットレートは一切効かない**。
+     * 効かないのに選べる状態にしておくと、上限に当たったときに
+     * 「下げたのに直らない」という誤解を生む（2026-09-04 の実害）。
+     */
+    appliesToSelection?: boolean;
 }
 
 export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
     bitrate,
     onBitrateChange,
     disabled = false,
+    appliesToSelection = true,
 }) => (
     <fieldset className="rounded-lg border border-gray-200 bg-gray-50 p-4" disabled={disabled}>
         <legend className="px-1 text-sm font-medium text-gray-900">音声のビットレート</legend>
+        {!appliesToSelection && (
+            <p className="mt-1 rounded-md bg-amber-50 px-2 py-1.5 text-[13px] text-amber-900">
+                選択中の音声ファイルはそのまま送られるため、この設定は使われません。
+            </p>
+        )}
         <p className="mt-1 text-[13px] text-gray-700">
             低いほど長い録音を扱えます。2 時間程度の商談は 96 kbps、3 時間を超える録音は 64 kbps を選んでください。表示の長さを超えるファイルは変換できないため、ビットレートを下げるか、ファイルを分割してください。
         </p>

--- a/src/hooks/useProcessingWorkflow.test.ts
+++ b/src/hooks/useProcessingWorkflow.test.ts
@@ -52,12 +52,15 @@ vi.mock('@/lib/logger', () => ({
 }));
 
 import { CONVERSION_QUEUE_WAIT_LIMIT_MS, useProcessingWorkflow } from './useProcessingWorkflow';
+import { canSendAudioAsIs } from '@/lib/mediaInput';
+import { GENERATE_MAX_MEDIA_BYTES } from '@/lib/generateApiContract';
 
 const BITRATE = '192k';
 const SAMPLE_RATE = 44100;
 
-const createFile = (name: string, type: string): FileWithPrompts => ({
-    file: { name, type } as File,
+/** 既定のサイズは上限内。上限超えを測るテストだけ明示的に大きくする */
+const createFile = (name: string, type: string, size = 1024): FileWithPrompts => ({
+    file: { name, type, size } as File,
     selectedPromptIds: ['prompt-a'],
 });
 
@@ -264,6 +267,51 @@ describe('handleStartProcessing failure reporting', () => {
     });
 });
 
+/**
+ * 🔴 実害 (2026-09-04): 1時間22分の WAV は 301MB あり、Storage ルールの 100MB 上限に当たって
+ * `storage/unauthorized`（権限がありません）になっていた。音声入力は変換を丸ごと飛ばしていたため、
+ * **ビットレートを下げても同じ 301MB が上がり続けた**。
+ */
+describe('🔴 上限を超える音声は、変換を飛ばさない', () => {
+    const OVER_LIMIT = GENERATE_MAX_MEDIA_BYTES + 1;
+
+    it('上限を超える WAV は変換に回す（元ファイルをそのまま送らない）', async () => {
+        const harness = useWorkflowHarness();
+
+        await harness.workflow.handleStartProcessing(
+            [createFile('long.wav', 'audio/wav', OVER_LIMIT)], ['f1'], BITRATE, SAMPLE_RATE
+        );
+
+        expect(serviceMocks.convertVideoToAudioSegments).toHaveBeenCalledTimes(1);
+        // 変換に回すなら FFmpeg が要る。ここを飛ばすと「変換が必要なのにエンジンが無い」で落ちる
+        expect(serviceMocks.ffmpegLoad).toHaveBeenCalled();
+    });
+
+    it('上限ちょうどはそのまま送る / 1 バイト超えたら変換する（境界）', async () => {
+        const at = useWorkflowHarness();
+        await at.workflow.handleStartProcessing(
+            [createFile('at.mp3', 'audio/mpeg', GENERATE_MAX_MEDIA_BYTES)], ['f1'], BITRATE, SAMPLE_RATE
+        );
+        expect(serviceMocks.convertVideoToAudioSegments).not.toHaveBeenCalled();
+
+        vi.clearAllMocks();
+        const over = useWorkflowHarness();
+        await over.workflow.handleStartProcessing(
+            [createFile('over.mp3', 'audio/mpeg', OVER_LIMIT)], ['f1'], BITRATE, SAMPLE_RATE
+        );
+        expect(serviceMocks.convertVideoToAudioSegments).toHaveBeenCalledTimes(1);
+    });
+
+    it('size が読めないファイルは変換に回す（安全側。合格に丸めない）', async () => {
+        const harness = useWorkflowHarness();
+        const noSize = { file: { name: 'x.wav', type: 'audio/wav' } as File, selectedPromptIds: ['prompt-a'] };
+
+        await harness.workflow.handleStartProcessing([noSize], ['f1'], BITRATE, SAMPLE_RATE);
+
+        expect(serviceMocks.convertVideoToAudioSegments).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe('handleResumeFile checkpoint planning', () => {
     const resume = async (
         harness: Harness,
@@ -432,5 +480,24 @@ describe('conversion queue wait limit (V8)', () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+});
+
+
+describe('canSendAudioAsIs', () => {
+    const f = (name: string, type: string, size: number) => ({ name, type, size }) as File;
+
+    it('圧縮済みで上限内の音声だけ、そのまま送る', () => {
+        expect(canSendAudioAsIs(f('a.mp3', 'audio/mpeg', 1024))).toBe(true);
+        expect(canSendAudioAsIs(f('a.m4a', 'audio/mp4', 1024))).toBe(true);
+    });
+
+    it('🔴 上限を超える音声は、拡張子が何であれ変換に回す', () => {
+        expect(canSendAudioAsIs(f('a.wav', 'audio/wav', GENERATE_MAX_MEDIA_BYTES + 1))).toBe(false);
+        expect(canSendAudioAsIs(f('a.mp3', 'audio/mpeg', GENERATE_MAX_MEDIA_BYTES + 1))).toBe(false);
+    });
+
+    it('動画はそのまま送らない', () => {
+        expect(canSendAudioAsIs(f('a.mp4', 'video/mp4', 1024))).toBe(false);
     });
 });

--- a/src/hooks/useProcessingWorkflow.ts
+++ b/src/hooks/useProcessingWorkflow.ts
@@ -3,7 +3,7 @@ import { VideoConverter } from '@/lib/ffmpeg';
 import { GeminiClient } from '@/lib/gemini';
 import { FileWithPrompts, FileProcessingStatus, DebugErrorMode } from '@/types/processing';
 import { convertVideoToAudioSegments, resumeVideoConversion } from '@/lib/videoConversionService';
-import { getSupportedMediaKind } from '@/components/FileDropZone';
+import { canSendAudioAsIs } from '@/lib/mediaInput';
 import type { JobClaim, TranscriptionJobRef } from '@/hooks/useVideoProcessing';
 import { createLogger } from '@/lib/logger';
 
@@ -33,8 +33,6 @@ export interface WorkflowResult {
 type ResumePlan = 'save_only' | 'transcribe' | 'convert_resume' | 'convert_full';
 
 const processingWorkflowLogger = createLogger('useProcessingWorkflow');
-
-const isAudioInput = (file: File) => getSupportedMediaKind(file) === 'audio';
 
 const describeAbort = (signal: AbortSignal): string =>
     signal.reason instanceof Error ? signal.reason.message : '処理を中止しました。';
@@ -164,8 +162,10 @@ export const useProcessingWorkflow = ({
         try {
             // H6: エンジンの初期化も失敗を捕捉できる位置に置き、
             //     音声のみの場合は FFmpeg を読み込まない
+            // 🔴 上限を超える音声は変換に回すので、その場合も FFmpeg が要る。
+            //    ここを isAudioInput のままにすると、変換が必要なのにエンジンが無い状態で落ちる。
             const needsFfmpeg = !sendVideoDirectly
-                && selectedFiles.some(file => !isAudioInput(file.file));
+                && selectedFiles.some(file => !canSendAudioAsIs(file.file));
 
             try {
                 await prepareEngines(needsFfmpeg);
@@ -206,8 +206,8 @@ export const useProcessingWorkflow = ({
 
                 const job: TranscriptionJobRef = { file, fileIndex: i, fileId, signal: claim.signal };
 
-                if (isAudioInput(file.file)) {
-                    // 音声ファイルの場合：音声変換をスキップして直接文書生成へ
+                if (canSendAudioAsIs(file.file)) {
+                    // 圧縮済みで上限内の音声：変換をスキップして直接文書生成へ
                     updateById(fileId, status => ({ ...status, convertedAudioBlob: file.file as Blob }));
                     transcriptionPromises.push(
                         processTranscription(job, file.file as Blob, bitrate, sampleRate)
@@ -321,7 +321,7 @@ export const useProcessingWorkflow = ({
             return 'transcribe';
         }
 
-        if (isAudioInput(file.file) || sendVideoDirectly) {
+        if (canSendAudioAsIs(file.file) || sendVideoDirectly) {
             return 'transcribe';
         }
 
@@ -423,7 +423,7 @@ export const useProcessingWorkflow = ({
 
             if (plan === 'save_only' || plan === 'transcribe') {
                 const audioBlob = status.convertedAudioBlob
-                    ?? (isAudioInput(file.file) || sendVideoDirectly ? (file.file as Blob) : null);
+                    ?? (canSendAudioAsIs(file.file) || sendVideoDirectly ? (file.file as Blob) : null);
 
                 if (plan === 'transcribe' && !audioBlob) {
                     const message = '変換済みの音声が見つかりませんでした。音声変換からやり直してください。';

--- a/src/hooks/useVideoProcessing.ts
+++ b/src/hooks/useVideoProcessing.ts
@@ -3,6 +3,7 @@ import { VideoConverter } from '@/lib/ffmpeg';
 import { GeminiClient } from '@/lib/gemini';
 import { saveTranscription } from '@/lib/firestore';
 import { uploadAudioToStorage } from '@/lib/storage';
+import { GENERATE_MAX_MEDIA_BYTES } from '@/lib/generateApiContract';
 import {
     FileProcessingStatus,
     FileWithPrompts,
@@ -524,6 +525,23 @@ export const useVideoProcessing = (
             if (needsGeneration) {
                 if (!audioBlob) {
                     failJob('upload', ['変換済みの音声データが見つかりませんでした。音声変換からやり直してください。']);
+                    return;
+                }
+
+                // 🔴 上限超過は、Storage に投げると `storage/unauthorized`（権限がありません）で返る。
+                //    ルールが `request.resource.size < 上限` を条件にしているためで、
+                //    利用者にはサイズの問題が**権限の問題として見える**（2026-09-04 の実害）。
+                //    投げる前にこちらで落として、何をすればよいかを書いた文言を出す。
+                if (audioBlob.size > GENERATE_MAX_MEDIA_BYTES) {
+                    const sizeMb = (audioBlob.size / 1024 / 1024).toFixed(0);
+                    const limitMb = Math.floor(GENERATE_MAX_MEDIA_BYTES / 1024 / 1024);
+                    videoProcessingLogger.error('アップロードするファイルが上限超', undefined, {
+                        fileId, fileIndex, blobSizeBytes: audioBlob.size, limit: GENERATE_MAX_MEDIA_BYTES, bitrate,
+                    });
+                    failJob('upload', [
+                        `この音声は ${sizeMb}MB で、アップロードできる上限 ${limitMb}MB を超えています。`
+                        + 'ビットレートを下げるか、録音を分割してから、もう一度お試しください。',
+                    ]);
                     return;
                 }
 

--- a/src/lib/mediaInput.ts
+++ b/src/lib/mediaInput.ts
@@ -1,0 +1,28 @@
+/**
+ * 入力ファイルを「そのまま送れるか / 変換が要るか」で分ける判定。
+ *
+ * 🔴 フックではなく lib に置いてある。画面側 (`home/page.tsx`) と処理側
+ * (`useProcessingWorkflow`) の両方が使うが、画面のテストはフックをモックするため、
+ * フックから export するとモックに載せ忘れた瞬間に落ちる（実際に落とした）。
+ */
+import { getSupportedMediaKind } from '@/components/FileDropZone';
+import { GENERATE_MAX_MEDIA_BYTES } from '@/lib/generateApiContract';
+
+export const isAudioInput = (file: File): boolean => getSupportedMediaKind(file) === 'audio';
+
+/**
+ * 音声ファイルでも「変換を飛ばして元ファイルをそのまま上げてよい」とは限らない。
+ *
+ * 🔴 実害 (2026-09-04): 1時間22分・16kHz ステレオの **WAV は 301MB** あり、
+ * Storage ルールの 100MB 上限に当たって `storage/unauthorized` になっていた。
+ * 「権限がありません」と表示されるので原因が権限だと誤読され、しかも
+ * **ビットレートの選択は変換を通らないため一切効かなかった**（64k にしても同じ 301MB が上がる）。
+ *
+ * 圧縮済み (mp3/m4a/aac/ogg) で上限に収まっているものだけ、そのまま送る。
+ * 非圧縮 (wav/flac) や、圧縮済みでも上限を超えるものは変換に回す。
+ *
+ * 🔴 `size` が読めないファイルは **false**（＝変換に回す）。判定できないものを
+ * 「そのまま送ってよい」に丸めると、上限超過が再びゲートの外へ出る。
+ */
+export const canSendAudioAsIs = (file: File): boolean =>
+    isAudioInput(file) && typeof file.size === 'number' && file.size <= GENERATE_MAX_MEDIA_BYTES;

--- a/storage.rules
+++ b/storage.rules
@@ -18,14 +18,23 @@ service firebase.storage {
         || (request.auth != null && request.auth.uid == ownerId)
         || isSuperuser();
 
-      // 書き込み（create/update）:
-      //   - ゲスト: 未認証でも GUEST ディレクトリに書き込み可
-      //   - ログインユーザー: 自分のディレクトリにのみ書き込み可
+      // 所有者判定（ゲストは GUEST ディレクトリ、ログインユーザーは自分のディレクトリ）
+      function isOwner() {
+        return ownerId == "GUEST" || (request.auth != null && request.auth.uid == ownerId);
+      }
+
+      // 作成・更新:
       //   - ファイルサイズ上限: 100MB
       //   - content-type: audio/* のみ許可
-      allow write: if (ownerId == "GUEST" || (request.auth != null && request.auth.uid == ownerId))
+      allow create, update: if isOwner()
         && request.resource.size < 100 * 1024 * 1024
         && request.resource.contentType.matches('audio/.*');
+
+      // 削除:
+      // 🔴 `write` にまとめてはいけない。削除では `request.resource` が null になり、
+      //    サイズと content-type の条件が評価できずに常に拒否される（実測: DELETE が 403）。
+      //    その結果、ゲストが上げ直しても古いファイルが消えずに溜まり続けていた。
+      allow delete: if isOwner();
     }
   }
 }


### PR DESCRIPTION
本番で報告された `Firebase Storage: User does not have permission to access 'audio/GUEST/….wav.mp3' (storage/unauthorized)` の修正です。

**権限の問題ではありませんでした。** 音声入力は変換を丸ごと飛ばして元ファイルをそのまま上げており、1時間22分・16kHz ステレオの WAV は **301MB** あって Storage ルールの 100MB 上限に当たっていました。ルールが `request.resource.size < 100MB` を条件にしているため、サイズ超過が**権限エラーとして返る**のが混乱の元です。しかも変換を通らないので、**ビットレートを 64k に下げても同じ 301MB が上がり続けます**。

## 実測で切り分けた記録

| 確認したこと | 結果 |
|---|---|
| 配備中の Storage ルール vs リポジトリ | **完全一致**（ルールは無実） |
| GUEST で 1KB / 40MB を書き込み | HTTP 200 |
| GUEST で 113MB を書き込み | **HTTP 403 Permission denied**（報告と同一） |
| 本番バンドルの既定ビットレート | `useState("96k")` = 最新 main で正しい |
| 問題の WAV | 1時間22分・16kHz ステレオ PCM・**301MB** |
| 同じ WAV を変換 | 96k → 56.6MB / 64k → 37.7MB（どちらも上限内） |

## 変更

1. **上限を超える音声は変換に回す**（`src/lib/mediaInput.ts` の `canSendAudioAsIs`）。圧縮済みで上限内のものだけそのまま送ります。`size` が読めないファイルは**安全側**（変換に回す）
2. **変換が要るなら FFmpeg を読み込む** — `needsFfmpeg` の条件も同じ判定に揃えました。ここを直さないと「変換が必要なのにエンジンが無い」で落ちます
3. **アップロード前にサイズを検査**し、`この音声は 301MB で、アップロードできる上限 100MB を超えています。ビットレートを下げるか、録音を分割してから、もう一度お試しください。` と出します。生の権限エラーを利用者に見せません
4. **そのまま送られる選択のときは、ビットレート欄に「この設定は使われません」**と出します。効かないのに選べると「下げたのに直らない」という誤解を生みます
5. **Storage ルール: 削除を `write` から分離。** 削除では `request.resource` が null になり、サイズと content-type の条件が評価できず**常に拒否**されていました（実測 403）。ゲストが上げ直しても古いファイルが消えず溜まり続けます

判定関数はフックではなく `lib` に置いています。画面のテストはフックをモックするため、フックから export するとモックへの載せ忘れで落ちます（実際に落としました）。

## 検証

`storage.rules` は配備前に本番のルール評価 API で8件検証済み（すべて期待どおり）:

| ケース | 期待 | 結果 |
|---|---|---|
| ゲスト作成 99MB/audio | 許可 | ✅ |
| ゲスト作成 100MB/audio | 拒否 | ✅ |
| ゲスト作成 50MB/octet-stream | 拒否 | ✅ |
| **ゲスト削除（resource なし）** | 許可 | ✅ |
| 他人のディレクトリへ作成 | 拒否 | ✅ |
| **他人のディレクトリを削除** | 拒否 | ✅ |

`npx tsc --noEmit` exit 0 / `npm run lint` exit 0 / `npx vitest run` **1,526 tests passing**。

⚠️ **`storage.rules` の変更は、マージしても自動では配備されません。** `firebase deploy --only storage` が別途必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)