### PR TITLE
MAI-Transcribe-2 を主エンジンにし、Gemini をフォールバックにする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,13 @@ FIREBASE_SERVICE_ACCOUNT_JSON=
 # 廃止 (#4 でサーバ経由化)。設定しても読まれない。Vercel から削除し、旧キーは AI Studio で失効させる (docs/ops-runbook.md §5.4)。
 # ----------------------------------------------------------------------
 # NEXT_PUBLIC_GEMINI_API_KEY=   ← 廃止。ブラウザに配られていたため使わない
+
+# --- MAI-Transcribe-2 (Azure Speech / Microsoft Foundry) ---
+# 🔴 全文文字起こしの**主エンジン**。落ちたら Gemini へフォールバックする（設計 §3.7）。
+#    未設定でも動く（Gemini だけになる）。その場合ログの maiAttempted が false になり、
+#    「試して落ちた」ではなく「設定が無くて試していない」ことが後から分かる。
+# 🔴 MAI が使えるリージョンは eastus / northeurope / southeastasia / westus のみ。
+#    japaneast では使えない。Azure はリソースのリージョン外でデータを処理しないので、
+#    ここの選択がそのまま**音声の処理場所**になる。
+AZURE_SPEECH_ENDPOINT=https://<resource-name>.cognitiveservices.azure.com
+AZURE_SPEECH_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ serviceAccountKey.json
 
 # Claude Code
 .claude/
+.env*

--- a/src/app/api/transcribe/chunk/route.ts
+++ b/src/app/api/transcribe/chunk/route.ts
@@ -25,7 +25,7 @@ import { GenerateApiError } from '@/server/errors';
 import { assertGeminiConfigured } from '@/server/geminiServer';
 import { downloadMedia, isOwnedBySubject, parseStoragePath, statMedia } from '@/server/mediaSource';
 import { clientIpFromHeaders, enforceRateLimit } from '@/server/rateLimit';
-import { TranscribeChunkClient } from '@/server/transcribeChunk';
+import { transcribeWithFallback } from '@/server/transcribeWithFallback';
 import type { TranscriptAnnotation as RawServerAnnotation } from '@/lib/transcribeApiContract';
 import type { TranscriptAnnotation as GateAnnotation } from '@/lib/transcriptQuality';
 
@@ -167,15 +167,17 @@ export async function POST(request: Request): Promise<Response> {
         const rate = await enforceRateLimit(subject, clientIpFromHeaders(request.headers));
         const media = await downloadMedia(info);
 
-        const client = new TranscribeChunkClient();
-        const result = await client.transcribe({
+        // 🔴 主エンジンは MAI-Transcribe-2、落ちたら Gemini（設計 §3.7）。
+        //    切り替えはチャンク単位で、ジョブ全体は巻き戻さない。
+        const outcome = await transcribeWithFallback({
             bytes: media.bytes,
             mimeType: body.mimeType,
             fileName: body.fileName,
             // 🔴 クライアントの実測を優先する。注釈から導くと末尾の無音が落ち、
-            //    G8 (カバレッジ) が常に甘くなる。
+            //    G6 (最長穴) と G8 (範囲外時刻) の分母が狂う。
             audioSec: body.audioSec,
         });
+        const result = outcome.result;
 
         const { annotations, droppedCount } = normalizeAnnotations(result.annotations);
 
@@ -213,6 +215,8 @@ export async function POST(request: Request): Promise<Response> {
             },
             ...(result.cachedTokens !== undefined && { cachedTokens: result.cachedTokens }),
             elapsedMs,
+            engine: outcome.engine,
+            ...(outcome.fallbackReason !== undefined && { fallbackReason: outcome.fallbackReason }),
         };
 
         // 計器: Vercel runtime logs で 1 行 JSON として拾えるようにする (logger の整形を通さない)。
@@ -233,6 +237,10 @@ export async function POST(request: Request): Promise<Response> {
             audioSec: body.audioSec,
             speechSec: body.speechSec,
             speechIntervalCount: body.speechIntervals.length,
+            // 🔴 preview の可用性はここでしか数えられない。engine と maiAttempted を必ず載せる
+            engine: outcome.engine,
+            maiAttempted: outcome.maiAttempted,
+            fallbackReason: outcome.fallbackReason,
             // 🔴 最長穴を必ず計器に載せる。合否だけだと、閾値 30 秒が正しいかを後から見直せない
             longestSilentGapSec: quality.metrics.longestSilentGapSec,
             outOfRangeAnnotations: quality.metrics.outOfRangeAnnotationCount,

--- a/src/components/FilePromptSelector.tsx
+++ b/src/components/FilePromptSelector.tsx
@@ -4,6 +4,7 @@ import React, { useId } from 'react';
 import { FileWithPrompts } from '@/types/processing';
 import { Prompt } from '@/lib/prompts';
 import { getGeminiModelLabel } from '@/constants/geminiModels';
+import { isTranscriptPrompt, TRANSCRIPT_PREVIEW_NOTICE } from '@/lib/transcriptPrompt';
 
 interface FilePromptSelectorProps {
   selectedFiles: FileWithPrompts[];
@@ -58,6 +59,12 @@ export const FilePromptSelector: React.FC<FilePromptSelectorProps> = ({
                     <span className="text-xs text-gray-600">
                       {getGeminiModelLabel(prompt.model)}
                     </span>
+                    {/* 🔴 主エンジンが public preview であることを、選ぶ場所で断る (設計 §3.7) */}
+                    {isTranscriptPrompt(prompt) && (
+                      <span className="mt-0.5 text-xs text-amber-800">
+                        {TRANSCRIPT_PREVIEW_NOTICE}
+                      </span>
+                    )}
                   </span>
                 </label>
               );

--- a/src/hooks/transcriptPipelineAdapter.test.ts
+++ b/src/hooks/transcriptPipelineAdapter.test.ts
@@ -21,7 +21,7 @@ const file = new File(['x'], 'call.mp3', { type: 'audio/mpeg' });
 
 const jobResult = (over: Record<string, unknown> = {}) => ({
     ok: true, aborted: false, durationSec: 8700, noiseFloorDb: -34.9, silenceThresholdDb: -39.9,
-    chunks: [{}, {}], failedChunkIndexes: [], cachedRuns: [],
+    chunks: [{}, {}], failedChunkIndexes: [], cachedRuns: [], fallbackChunks: [],
     merged: { segments: [], gaps: [] }, invariants: { ok: true, violations: [] },
     markdown: '[00:00](#t=0) **営業** こんにちは。', ...over,
 });
@@ -34,7 +34,19 @@ describe('成功のとき', () => {
         const r = await runTranscriptPipeline({ file, converter, runJob: runJob(jobResult()) });
         expect(r.success).toBe(true);
         expect(r.text).toContain('#t=0');
-        expect(r.usedModel).toBe('gemini-3.5-transcribe');
+        expect(r.usedModel).toBe('MAI-Transcribe-2');
+    });
+
+    it('🔴 フォールバックした区間があれば、両方のエンジンを記録に残す', async () => {
+        // 用語集は MAI でしか効かない。片方だけ書くと、用語が効いていない区間がある事実が消える
+        const r = await runTranscriptPipeline({
+            file, converter,
+            runJob: runJob(jobResult({ fallbackChunks: [{ chunkIndex: 1, reason: 'MAI timeout' }] })),
+        });
+        expect(r.success).toBe(true);
+        expect(r.usedModel).toContain('MAI-Transcribe-2');
+        expect(r.usedModel).toContain('gemini-3.5-transcribe');
+        expect(r.usedModel).toContain('1/2');
     });
 });
 

--- a/src/hooks/transcriptPipelineAdapter.ts
+++ b/src/hooks/transcriptPipelineAdapter.ts
@@ -61,6 +61,8 @@ export async function runTranscriptPipeline(
             fileName: file.name,
             chunks: job.chunks.length,
             chars: job.markdown.length,
+            // 🔴 MAI (preview) が落ちて Gemini に回った区間。用語集が効いていないのはここ (設計 §3.7)
+            fallbackChunks: job.fallbackChunks.length,
             durationSec: job.durationSec,
             noiseFloorDb: job.noiseFloorDb,
             silenceThresholdDb: job.silenceThresholdDb,
@@ -77,10 +79,16 @@ export async function runTranscriptPipeline(
                 text: job.markdown,
             };
         }
+        // 🔴 「どのモデルで起こしたか」は 1 つに決まらない。チャンクごとに MAI か Gemini かが変わる
+        //    (設計 §3.7)。全部 MAI なら MAI、1 本でも落ちていれば両方を書く。
+        //    片方だけ書くと、用語集が効いていない区間がある事実が記録から消える。
+        const usedModel = job.fallbackChunks.length === 0
+            ? 'MAI-Transcribe-2'
+            : `MAI-Transcribe-2 + gemini-3.5-transcribe (${job.fallbackChunks.length}/${job.chunks.length} 区間)`;
         return {
             success: true,
             text: job.markdown,
-            usedModel: 'gemini-3.5-transcribe',
+            usedModel,
         };
     } catch (error) {
         logger.error('文字起こしで想定外のエラー', error, { fileName: file.name });

--- a/src/hooks/useTranscriptionJob.test.ts
+++ b/src/hooks/useTranscriptionJob.test.ts
@@ -341,6 +341,7 @@ const passing = (over: Partial<TranscribeChunkResponseBody> = {}): TranscribeChu
     annotations: [],
     quality: { passed: true, failedGates: [], warnedGates: [], indeterminateGates: [] },
     elapsedMs: 1234,
+    engine: 'mai',
     ...over,
 });
 

--- a/src/hooks/useTranscriptionJob.ts
+++ b/src/hooks/useTranscriptionJob.ts
@@ -19,6 +19,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { uploadAudioToStorage, deleteAudioFromStorage } from '@/lib/storage';
 import { createLogger } from '@/lib/logger';
+import type { TranscribeEngine } from '@/lib/maiTranscribeContract';
 import {
     TRANSCRIBE_CHUNK_API_PATH,
     TRANSCRIBE_CHUNK_MAX_AUDIO_SEC,
@@ -459,12 +460,18 @@ export interface ChunkAttemptRecord {
     /** 🔴 0 でない = 暗黙キャッシュに当たった = 実際には測り直していない (設計 §3.3) */
     cachedTokens?: number;
     elapsedMs?: number;
+    /** この試行を実際に起こしたエンジン (設計 §3.7) */
+    engine?: TranscribeEngine;
+    /** MAI が落ちて Gemini に回ったときの理由 */
+    fallbackReason?: string;
     error?: string;
 }
 
 export interface TranscriptionChunkResult {
     index: number;
     status: 'completed' | 'failed';
+    /** この本文を起こしたエンジン。失敗したチャンクでは undefined */
+    engine?: TranscribeEngine;
     startSec: number;
     endSec: number;
     text: string;
@@ -497,6 +504,11 @@ export interface TranscriptionJobResult {
     failedChunkIndexes: number[];
     /** 🔴 暗黙キャッシュに当たった走。「再試行したが測り直していない」の証拠 */
     cachedRuns: { chunkIndex: number; attempt: number; cachedTokens: number }[];
+    /**
+     * 🔴 MAI が落ちて Gemini で起こしたチャンク（設計 §3.7）。
+     * 用語集は MAI でしか効かないので、**ここに出てくる区間だけ用語の反映が弱い**。
+     */
+    fallbackChunks: { chunkIndex: number; reason?: string }[];
     merged: MergedTranscript;
     invariants: MergeInvariantResult;
     markdown: string;
@@ -614,6 +626,8 @@ const runChunk = async (
             );
             record.quality = response.quality;
             record.cachedTokens = response.cachedTokens;
+            record.engine = response.engine;
+            if (response.fallbackReason !== undefined) record.fallbackReason = response.fallbackReason;
             record.elapsedMs = response.elapsedMs;
 
             if (response.quality.passed) {
@@ -626,6 +640,7 @@ const runChunk = async (
                     annotations: response.annotations,
                     attempts,
                     servedFromCache: (response.cachedTokens ?? 0) > 0,
+                    engine: response.engine,
                 };
             }
         } catch (error) {
@@ -734,6 +749,17 @@ export const runTranscriptionJob = async (
         const merged = mergeTranscriptChunks(mergeChunks);
         const invariants = checkMergeInvariants(merged, mergeChunks);
         const failedChunkIndexes = chunks.filter((c) => c.status === 'failed').map((c) => c.index);
+        // 🔴 フォールバックしたチャンクを必ず数える。用語集は MAI でしか効かないので、
+        //    ここに出てくる区間だけ用語の反映が弱い (設計 §3.7)。
+        const fallbackChunks = chunks
+            .filter((chunk) => chunk.status === 'completed' && chunk.engine === 'gemini')
+            .map((chunk) => {
+                const last = chunk.attempts[chunk.attempts.length - 1];
+                return {
+                    chunkIndex: chunk.index,
+                    ...(last?.fallbackReason !== undefined && { reason: last.fallbackReason }),
+                };
+            });
         const cachedRuns = chunks.flatMap((chunk) =>
             chunk.attempts
                 .filter((attempt) => (attempt.cachedTokens ?? 0) > 0)
@@ -753,6 +779,7 @@ export const runTranscriptionJob = async (
             chunks,
             failedChunkIndexes,
             cachedRuns,
+            fallbackChunks,
             merged,
             invariants,
             markdown: toTranscriptMarkdown(merged, markdownOptions),

--- a/src/hooks/useTranscriptionJob.ts
+++ b/src/hooks/useTranscriptionJob.ts
@@ -508,7 +508,7 @@ export interface TranscriptionJobResult {
      * 🔴 MAI が落ちて Gemini で起こしたチャンク（設計 §3.7）。
      * 用語集は MAI でしか効かないので、**ここに出てくる区間だけ用語の反映が弱い**。
      */
-    fallbackChunks: { chunkIndex: number; reason?: string }[];
+    fallbackChunks: { chunkIndex: number; startSec: number; endSec: number; reason?: string }[];
     merged: MergedTranscript;
     invariants: MergeInvariantResult;
     markdown: string;
@@ -757,6 +757,8 @@ export const runTranscriptionJob = async (
                 const last = chunk.attempts[chunk.attempts.length - 1];
                 return {
                     chunkIndex: chunk.index,
+                    startSec: chunk.startSec,
+                    endSec: chunk.endSec,
                     ...(last?.fallbackReason !== undefined && { reason: last.fallbackReason }),
                 };
             });
@@ -782,7 +784,12 @@ export const runTranscriptionJob = async (
             fallbackChunks,
             merged,
             invariants,
-            markdown: toTranscriptMarkdown(merged, markdownOptions),
+            // 🔴 フォールバック区間は**本文に注記として出す**。ログだけだと利用者に見えず、
+            //    用語の表記が揺れている理由が分からない（設計 §3.7）
+            markdown: toTranscriptMarkdown(merged, {
+                ...markdownOptions,
+                fallbackRanges: fallbackChunks,
+            }),
         };
     } finally {
         // 🔴 チャンク音声は元音声より本数が増える。成功・失敗・中断のいずれでも消す

--- a/src/lib/maiTranscribeContract.ts
+++ b/src/lib/maiTranscribeContract.ts
@@ -1,0 +1,68 @@
+/**
+ * `MAI-Transcribe-2` (Azure Speech / Microsoft Foundry) の定数と応答の形。
+ *
+ * 🔴 **主エンジンはこちら、Gemini はフォールバック**（設計 §3.7・2026-09-04 東野裁定）。
+ * Gemini では用語集が話者分離・単語タイムスタンプと排他だが (§1.5)、MAI は 3 つ同時に成立する。
+ * 対照群つきで実測済み: 用語集なし「青井建設」→ `phraseList.phrases` ありで「アオイ建設」。
+ *
+ * ⚠️ **public preview で SLA が無い**。逐語:
+ * "This preview is provided without a service-level agreement, and is not recommended for
+ *  production workloads." だからこそフォールバックを必ず持つ。
+ */
+
+/** 同期の文字起こしエンドポイント。`{endpoint}` はリソースのカスタムドメイン */
+export const MAI_TRANSCRIBE_PATH = '/speechtotext/transcriptions:transcribe';
+
+export const MAI_API_VERSION = '2025-10-15';
+
+export const MAI_API_KEY_HEADER = 'Ocp-Apim-Subscription-Key';
+
+export const MAI_MODEL = 'MAI-Transcribe-2';
+
+/** Gemini 側 (`ja-JP`) と揃える。MAI は 2 文字コード */
+export const MAI_LOCALES = ['ja'] as const;
+
+/**
+ * 🔴 相槌・言い直しを落とさない。Gemini 側の `verbatim` と揃えるため。
+ * `clean` にすると読みやすくなるが、商談の記録としては削られたことが分からない。
+ */
+export const MAI_TRANSCRIBE_STYLE = 'verbatim';
+
+/** 単語単位の時刻。話者ラベルは注釈経由でしか使えないので必須 */
+export const MAI_TIMESTAMPS = 'word';
+
+/**
+ * 🔴 同期 API はサーバ側で **約 120 秒**で打ち切られる (実測: 408 になった走の所要が
+ * 全走 121.7〜122.0 秒で揃っていた)。10 分チャンクの実測は 85〜116 秒で、
+ * これがそのまま上限に近い。**チャンク長を伸ばすときは必ず測り直すこと。**
+ * ここはそれより短く切って、我々の側で先に諦めてフォールバックへ回す。
+ */
+export const MAI_REQUEST_TIMEOUT_MS = 115 * 1000;
+
+/** 音声ファイルの上限 (公式: less than 300 MB) */
+export const MAI_MAX_AUDIO_BYTES = 300 * 1024 * 1024;
+
+/** どのエンジンが起こしたか。文書の記録と計器に必ず残す */
+export type TranscribeEngine = 'mai' | 'gemini';
+
+/** `phrases[].words[]` の 1 語 */
+export interface MaiWord {
+    text?: unknown;
+    offsetMilliseconds?: unknown;
+    durationMilliseconds?: unknown;
+}
+
+/** `phrases[]` の 1 句。`speaker` は話者分離が有効なときだけ付く */
+export interface MaiPhrase {
+    speaker?: unknown;
+    offsetMilliseconds?: unknown;
+    durationMilliseconds?: unknown;
+    text?: unknown;
+    words?: unknown;
+}
+
+export interface MaiTranscribeResponse {
+    durationMilliseconds?: unknown;
+    combinedPhrases?: unknown;
+    phrases?: unknown;
+}

--- a/src/lib/transcribeApiContract.ts
+++ b/src/lib/transcribeApiContract.ts
@@ -34,8 +34,16 @@ export const TRANSCRIBE_MODE_TYPE = 'verbatim';
 export const TRANSCRIBE_DIARIZATION_MODE = 'speaker';
 export const TRANSCRIBE_TIMESTAMP_GRANULARITIES = ['word'] as const;
 
-/** 入力音声は Files API 経由に固定 (インラインは実務上約 20MB/15 分が上限で、25 分チャンクは入らない) */
-export type TranscribeTransport = 'files_api';
+/**
+ * 音声をどの経路で送ったか。
+ * - `files_api`: Gemini。インラインは実務上約 20MB/15 分が上限なので Files API 経由に固定
+ * - `mai_multipart`: MAI-Transcribe-2 (Azure)。multipart で直接送る
+ *
+ * 🔴 **どちらのエンジンが起こしたかを、ここで必ず区別できるようにしておく**（設計 §3.7）。
+ * 用語集は MAI でしか効かないので、フォールバックした区間だけ表記の揺れが残る。
+ * 記録が無いと、なぜその区間だけ揺れているのかを後から追えない。
+ */
+export type TranscribeTransport = 'files_api' | 'mai_multipart';
 
 /** リクエスト JSON の形 (実測で通る形をそのまま型にしたもの) */
 export interface TranscribeRequestBody {

--- a/src/lib/transcribeChunkContract.ts
+++ b/src/lib/transcribeChunkContract.ts
@@ -11,6 +11,7 @@
  */
 import type { TranscriptAnnotation } from '@/lib/transcriptQuality';
 import type { QualityGateId } from '@/lib/transcriptQuality';
+import type { TranscribeEngine } from '@/lib/maiTranscribeContract';
 
 export const TRANSCRIBE_CHUNK_API_PATH = '/api/transcribe/chunk';
 
@@ -72,6 +73,14 @@ export interface TranscribeChunkResponseBody {
      */
     cachedTokens?: number;
     elapsedMs: number;
+    /**
+     * この本文を起こしたエンジン（設計 §3.7）。
+     * 🔴 **用語集は MAI でしか効かない**ので、`gemini` に落ちた区間だけ用語の反映が弱い。
+     * 黙って混ぜると、なぜその区間だけ表記が揺れるのかを後から追えなくなる。
+     */
+    engine: TranscribeEngine;
+    /** MAI を試して落ちたときだけ入る短い理由。利用者向けの文言ではない */
+    fallbackReason?: string;
 }
 
 /**

--- a/src/lib/transcriptMerge.test.ts
+++ b/src/lib/transcriptMerge.test.ts
@@ -571,3 +571,56 @@ describe('逆方向: Markdown から時刻を読む', () => {
         expect(parseTimestampHref(undefined)).toBeNull();
     });
 });
+
+/**
+ * 🔴 フォールバックした区間を**本文に出す**ことの錠（設計 §3.7）。
+ * ログにだけ残しても利用者には見えず、用語の表記が揺れている理由が分からない。
+ */
+describe('🔴 フォールバック区間の注記', () => {
+    const merged = {
+        segments: [
+            { startSec: 0, endSec: 5, speaker: 'spk:0', text: '前半です。' },
+            { startSec: 600, endSec: 605, speaker: 'spk:1', text: '後半です。' },
+        ],
+        gaps: [],
+    } as unknown as Parameters<typeof toTranscriptMarkdown>[0];
+
+    it('区間の開始位置に注記が入り、本文は残る', () => {
+        const md = toTranscriptMarkdown(merged, {
+            fallbackRanges: [{ startSec: 600, endSec: 1200 }],
+        });
+        expect(md).toContain('前半です。');
+        expect(md).toContain('後半です。');
+        expect(md).toContain('別の文字起こしサービスで処理しました');
+        // 注記は後半の手前に出る
+        expect(md.indexOf('別の文字起こし')).toBeLessThan(md.indexOf('後半です。'));
+    });
+
+    it('🔴 欠落の注記と文言を分ける — 「失敗した」と読ませない', () => {
+        const md = toTranscriptMarkdown(merged, { fallbackRanges: [{ startSec: 600, endSec: 1200 }] });
+        expect(md).not.toContain('文字起こしできませんでした');
+        expect(md).toContain('用語集の表記が反映されていない場合があります');
+    });
+
+    it('🔴 最後のチャンクがフォールバックしても注記が消えない', () => {
+        // 差し込みを「次の segment の手前」だけで行うと、末尾の区間で黙って落ちる
+        const md = toTranscriptMarkdown(merged, {
+            fallbackRanges: [{ startSec: 3000, endSec: 3600 }],
+        });
+        expect(md).toContain('別の文字起こしサービスで処理しました');
+    });
+
+    it('フォールバックが無ければ、注記は1つも出ない（既存の描画と同じ）', () => {
+        const withOption = toTranscriptMarkdown(merged, { fallbackRanges: [] });
+        const without = toTranscriptMarkdown(merged);
+        expect(withOption).toBe(without);
+        expect(withOption).not.toContain('別の文字起こしサービス');
+    });
+
+    it('複数区間を時刻順に出す', () => {
+        const md = toTranscriptMarkdown(merged, {
+            fallbackRanges: [{ startSec: 1200, endSec: 1800 }, { startSec: 600, endSec: 1200 }],
+        });
+        expect(md.indexOf('10:00')).toBeLessThan(md.indexOf('20:00'));
+    });
+});

--- a/src/lib/transcriptMerge.ts
+++ b/src/lib/transcriptMerge.ts
@@ -299,6 +299,15 @@ export interface TranscriptMarkdownOptions {
      * 同じ話者でもこの秒数より長く空いたら段落を分ける。既定は分けない（話者が変わったときだけ分ける）。
      */
     paragraphBreakGapSec?: number;
+    /**
+     * 🔴 主エンジン (MAI) が落ちて Gemini で起こした区間（設計 §3.7）。
+     *
+     * **用語集は MAI でしか効かない**ので、この区間だけ用語の反映が弱い。
+     * ログにだけ残しても利用者には見えないため、**本文に注記として出す**。
+     * 表記が揺れている理由が読み手に分かるようにするのが目的で、
+     * 欠落（`gaps`）とは別物なので文言も分ける。
+     */
+    fallbackRanges?: readonly { startSec: number; endSec: number }[];
 }
 
 interface Paragraph {
@@ -312,12 +321,25 @@ interface Paragraph {
 export const formatGapNote = (gap: MergedGap): string =>
     `　　　⚠ ${formatTimestamp(gap.startSec)} 〜 ${formatTimestamp(gap.endSec)} は文字起こしできませんでした。［再試行］`;
 
+/**
+ * フォールバック区間の注記。
+ * 🔴 欠落（`formatGapNote`）と混同させない — **本文は取れている**。
+ * 「失敗した」と読めると、利用者が要らない再試行をする。
+ */
+export const formatFallbackNote = (range: { startSec: number; endSec: number }): string =>
+    `　　　ⓘ ${formatTimestamp(range.startSec)} 〜 ${formatTimestamp(range.endSec)} は`
+    + `別の文字起こしサービスで処理しました。用語集の表記が反映されていない場合があります。`;
+
 /** 結合結果を、既存の文書としてそのまま保存できる Markdown にする */
 export const toTranscriptMarkdown = (
     merged: MergedTranscript,
     options: TranscriptMarkdownOptions = {},
 ): string => {
-    const { speakerLabels = {}, paragraphBreakGapSec = Number.POSITIVE_INFINITY } = options;
+    const {
+        speakerLabels = {},
+        paragraphBreakGapSec = Number.POSITIVE_INFINITY,
+        fallbackRanges = [],
+    } = options;
 
     const renderParagraph = (paragraph: Paragraph): string => {
         const label = paragraph.speaker
@@ -328,9 +350,11 @@ export const toTranscriptMarkdown = (
 
     // 失敗チャンクの注記は、その区間の位置（開始秒）に差し込む。注記は必ず段落を分ける
     const gaps = [...merged.gaps].sort((a, b) => a.startSec - b.startSec);
+    const fallbacks = [...fallbackRanges].sort((a, b) => a.startSec - b.startSec);
     const blocks: string[] = [];
     let current: Paragraph | null = null;
     let gapCursor = 0;
+    let fallbackCursor = 0;
 
     const flush = () => {
         if (current) blocks.push(renderParagraph(current));
@@ -342,6 +366,13 @@ export const toTranscriptMarkdown = (
             flush();
             blocks.push(formatGapNote(gaps[gapCursor]));
             gapCursor += 1;
+        }
+        // フォールバック区間の注記も、その区間の開始位置に差し込む
+        while (fallbackCursor < fallbacks.length
+            && fallbacks[fallbackCursor].startSec <= segment.startSec) {
+            flush();
+            blocks.push(formatFallbackNote(fallbacks[fallbackCursor]));
+            fallbackCursor += 1;
         }
         const continues =
             current !== null &&
@@ -361,9 +392,15 @@ export const toTranscriptMarkdown = (
         };
     }
     flush();
+    // 🔴 末尾に残った注記も必ず出す。ここを忘れると、最後のチャンクが
+    //    フォールバックしたときだけ注記が消える（黙って情報が落ちる）
     while (gapCursor < gaps.length) {
         blocks.push(formatGapNote(gaps[gapCursor]));
         gapCursor += 1;
+    }
+    while (fallbackCursor < fallbacks.length) {
+        blocks.push(formatFallbackNote(fallbacks[fallbackCursor]));
+        fallbackCursor += 1;
     }
 
     return blocks.join('\n\n');

--- a/src/lib/transcriptPrompt.test.ts
+++ b/src/lib/transcriptPrompt.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import {
+    TRANSCRIPT_PREVIEW_NOTICE,
     TRANSCRIPT_PROMPT,
     TRANSCRIPT_PROMPT_ID,
     TRANSCRIPT_PROMPT_NAME,
@@ -73,8 +74,17 @@ describe('withTranscriptPrompt — 一覧への差し込み', () => {
 });
 
 describe('組み込みプロンプトの素性', () => {
-    it('文字起こし専用モデルを指す', () => {
-        expect(TRANSCRIPT_PROMPT.model).toBe('gemini-3.5-transcribe');
+    it('文字起こし専用モデルを指す（主エンジン）', () => {
+        // 🔴 これは表示用の名前でしかない。実際に起こしたエンジンはチャンクごとに変わり
+        //    (MAI が落ちたら Gemini・設計 §3.7)、その正は応答の `engine` である。
+        expect(TRANSCRIPT_PROMPT.model).toBe('MAI-Transcribe-2');
+    });
+
+    it('🔴 プレビュー版の断りが、起きうることと利用者の打つ手まで書いてある', () => {
+        // 「不安定です」だけだと、利用者は何をすればよいか分からない (§6.5)
+        expect(TRANSCRIPT_PREVIEW_NOTICE).toContain('プレビュー版');
+        expect(TRANSCRIPT_PREVIEW_NOTICE).toContain('時間がかかったり');
+        expect(TRANSCRIPT_PREVIEW_NOTICE).toContain('もう一度お試しください');
     });
 
     it('利用者のものと混ざらない所有者を持つ', () => {

--- a/src/lib/transcriptPrompt.ts
+++ b/src/lib/transcriptPrompt.ts
@@ -21,6 +21,22 @@ export const TRANSCRIPT_PROMPT_ID = '__builtin_transcript__';
 export const TRANSCRIPT_PROMPT_NAME = '全文文字起こし';
 
 /**
+ * 🔴 プレビュー版であることの断り（設計 §3.7・2026-09-04 東野裁定）。
+ *
+ * 主エンジンの `MAI-Transcribe-2` は **public preview で SLA が無い**。逐語:
+ * "This preview is provided without a service-level agreement, and is not recommended for
+ *  production workloads." 実測でも 408 / 503 `diarization_unavailable` / 500 / 接続断が出る。
+ * 落ちたチャンクは Gemini へ回すので**本文は出る**が、時間がかかったり結果が揺れたりする。
+ *
+ * 🔴 **「不安定」とだけ書かない。** 何が起きうるかと、そのとき利用者が何をすればよいかまで書く
+ * （§6.5「画面の案内は、画面にある操作と正本にある語だけで」）。
+ */
+export const TRANSCRIPT_PREVIEW_NOTICE =
+    '最新の文字起こしサービス（プレビュー版）を使っています。'
+    + '混み合っているときは時間がかかったり、一部の区間だけ精度が落ちることがあります。'
+    + 'うまくいかないときは、少し時間をおいてからもう一度お試しください。';
+
+/**
  * 組み込みプロンプトの実体。
  *
  * `content` は使われない（分割パイプラインは `transcription_config` で指示するため、
@@ -30,7 +46,9 @@ export const TRANSCRIPT_PROMPT: Prompt = {
     id: TRANSCRIPT_PROMPT_ID,
     name: TRANSCRIPT_PROMPT_NAME,
     content: '音声を分割して全文を文字起こしし、話者ラベルと時刻を付けた文書を作ります。',
-    model: 'gemini-3.5-transcribe',
+    // 🔴 表示用の名前。実際にどのエンジンが起こしたかはチャンクごとに変わる (設計 §3.7) ので、
+    //    ここに書いた値を「このモデルで起こした」という意味に使ってはいけない。
+    model: 'MAI-Transcribe-2',
     isDefault: false,
     ownerType: 'guest',
     ownerId: 'BUILTIN',

--- a/src/server/maiTranscribe.live.test.ts
+++ b/src/server/maiTranscribe.live.test.ts
@@ -1,0 +1,42 @@
+/**
+ * 🔴 実 Azure に対する通し検証。**既定では走らない**（`RUN_LIVE_MAI=1` のときだけ）。
+ *
+ * 単体テストは口を差し替えているので、`buildMaiDefinition` が実際に受理されるか・
+ * 応答が `normalizeMaiPhrases` の想定どおりの形かは通っていない。
+ * 仕様に書いてあるパラメータが黙って無視される事故を今日 2 回踏んでいるので
+ * （Gemini の `diarization_mode`、OpenRouter の `phraseList`）、実物で確かめる口を残す。
+ */
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { MaiTranscribeClient, getMaiCredentials } from './maiTranscribe';
+
+const LIVE = process.env.RUN_LIVE_MAI === '1';
+const AUDIO = process.env.LIVE_MAI_AUDIO ?? '';
+
+describe.skipIf(!LIVE)('実 Azure（RUN_LIVE_MAI=1 のときだけ）', () => {
+    it('3 機能同時で、本文・単語時刻・話者ラベルが揃って返る', async () => {
+        const credentials = getMaiCredentials();
+        expect(credentials, 'AZURE_SPEECH_ENDPOINT / AZURE_SPEECH_KEY が要る').not.toBeNull();
+        expect(existsSync(AUDIO), `LIVE_MAI_AUDIO に音声のパスを渡すこと: ${AUDIO}`).toBe(true);
+
+        const bytes = readFileSync(AUDIO);
+        const client = new MaiTranscribeClient(credentials!);
+        const result = await client.transcribe({
+            bytes, mimeType: 'audio/mpeg', fileName: 'live.mp3', audioSec: 20,
+            phraseList: ['アオイ建設'],
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.text.length).toBeGreaterThan(0);
+        expect(result.transport).toBe('mai_multipart');
+        // 🔴 単語時刻: 秒に直っていること（ミリ秒のまま返すと G6 が桁違いに甘くなる）
+        expect(result.annotations.length).toBeGreaterThan(0);
+        expect(result.annotations[0]!.startSec).toBeLessThan(60);
+        expect(result.annotations.at(-1)!.endSec).toBeLessThan(120);
+        // 🔴 話者ラベル: `spk:N` の形へ揃っていること（Gemini 側と同じ表記）
+        const speakers = new Set(result.annotations.map(a => a.speaker).filter(Boolean));
+        expect([...speakers].every(s => /^spk:\d+$/.test(s as string))).toBe(true);
+        // 🔴 用語集が効いていること（対照は「青井」になる）
+        expect(result.text).toContain('アオイ');
+    }, 180_000);
+});

--- a/src/server/maiTranscribe.test.ts
+++ b/src/server/maiTranscribe.test.ts
@@ -1,0 +1,88 @@
+/**
+ * 🔴 MAI の出力を**共通形へ正規化**することの錠（設計 §3.7）。
+ *
+ * 品質ゲートは両エンジンの出力に同じものを当てる決まりなので、ここの写像がずれると
+ * 「片方のエンジンだけ検査が緩い」という事故になる。
+ */
+import { describe, expect, it } from 'vitest';
+import { buildMaiDefinition, extractMaiText, normalizeMaiPhrases } from './maiTranscribe';
+
+describe('normalizeMaiPhrases', () => {
+    it('ミリ秒を秒へ、句の話者を語へ配る', () => {
+        const { annotations, speakers } = normalizeMaiPhrases([
+            { speaker: 0, words: [{ text: 'こんにちは', offsetMilliseconds: 160, durationMilliseconds: 840 }] },
+            { speaker: 1, words: [{ text: 'はい', offsetMilliseconds: 2000, durationMilliseconds: 500 }] },
+        ]);
+        expect(annotations).toEqual([
+            { text: 'こんにちは', startSec: 0.16, endSec: 1, speaker: 'spk:0' },
+            { text: 'はい', startSec: 2, endSec: 2.5, speaker: 'spk:1' },
+        ]);
+        expect(speakers).toBe(2);
+    });
+
+    it('🔴 時刻が読めない語は落とす — 0 で埋めない', () => {
+        // 0 で埋めると G6 (最長穴) が「冒頭に注釈がある」と誤認して穴を短く見積もる
+        const { annotations, droppedWords } = normalizeMaiPhrases([
+            { speaker: 0, words: [
+                { text: 'ok', offsetMilliseconds: 100, durationMilliseconds: 100 },
+                { text: 'ng', offsetMilliseconds: null, durationMilliseconds: 100 },
+                { text: 'ng2', durationMilliseconds: 100 },
+            ] },
+        ]);
+        expect(annotations).toHaveLength(1);
+        expect(droppedWords).toBe(2);
+        expect(annotations[0]!.startSec).toBeGreaterThan(0);
+    });
+
+    it('話者分離が無効なら speaker は null（空文字を話者にしない）', () => {
+        const { annotations, speakers } = normalizeMaiPhrases([
+            { words: [{ text: 'a', offsetMilliseconds: 0, durationMilliseconds: 10 }] },
+            { speaker: '', words: [{ text: 'b', offsetMilliseconds: 20, durationMilliseconds: 10 }] },
+        ]);
+        expect(annotations.map(a => a.speaker)).toEqual([null, null]);
+        expect(speakers).toBe(0);
+    });
+
+    it.each([
+        ['null', null], ['undefined', undefined], ['配列でない', { phrases: 1 }], ['空配列', []],
+    ])('%s は 0 件（例外にしない）', (_label, input) => {
+        expect(normalizeMaiPhrases(input).annotations).toEqual([]);
+    });
+});
+
+describe('extractMaiText', () => {
+    it('combinedPhrases を優先する', () => {
+        expect(extractMaiText({
+            combinedPhrases: [{ text: 'まとめ' }],
+            phrases: [{ text: '句1' }, { text: '句2' }],
+        })).toBe('まとめ');
+    });
+
+    it('combinedPhrases が無ければ phrases から組む', () => {
+        expect(extractMaiText({ phrases: [{ text: '句1' }, { text: '句2' }] })).toBe('句1 句2');
+    });
+
+    it('どちらも無ければ空文字（例外にしない）', () => {
+        expect(extractMaiText({})).toBe('');
+    });
+});
+
+describe('buildMaiDefinition', () => {
+    it('3 機能を同時に指定する — Gemini では 400 になる組み合わせ（設計 §1.5 / §3.7）', () => {
+        const d = buildMaiDefinition(['アオイ建設']) as Record<string, never>;
+        const enhanced = d.enhancedMode as unknown as Record<string, unknown>;
+        expect(enhanced.model).toBe('MAI-Transcribe-2');
+        expect((enhanced.modelOptions as Record<string, unknown>).timestamps).toBe('word');
+        expect((d.diarization as unknown as Record<string, unknown>).enabled).toBe(true);
+        expect((d.phraseList as unknown as Record<string, unknown>).phrases).toEqual(['アオイ建設']);
+    });
+
+    it('🔴 用語集が空なら phraseList ごと送らない（「空の用語集」と区別できなくなる）', () => {
+        expect(buildMaiDefinition([])).not.toHaveProperty('phraseList');
+    });
+
+    it('相槌を落とさない verbatim を指定する（Gemini 側と揃える）', () => {
+        const enhanced = buildMaiDefinition().enhancedMode as Record<string, unknown>;
+        expect((enhanced.modelOptions as Record<string, unknown>).transcribeStyle).toBe('verbatim');
+    });
+});

--- a/src/server/maiTranscribe.ts
+++ b/src/server/maiTranscribe.ts
@@ -1,0 +1,212 @@
+/**
+ * `MAI-Transcribe-2` (Azure Speech) でチャンク 1 本を文字起こしする。
+ *
+ * 🔴 **戻り値は Gemini 側 (`TranscribeChunkResult`) と同じ形に正規化する。**
+ * 品質ゲート (§4.1) は両エンジンの出力に**同じもの**を当てる決まりで (設計 §3.7)、
+ * ゲートをエンジンごとに分けると片方だけ検査が緩いという事故が起きる。
+ *
+ * MAI の出力は `phrases[].words[].offsetMilliseconds`、Gemini は
+ * `annotations[].start_offset` (`"3.900s"`) と形が違うので、差はここで吸収する。
+ */
+import {
+    MAI_API_KEY_HEADER,
+    MAI_API_VERSION,
+    MAI_LOCALES,
+    MAI_MAX_AUDIO_BYTES,
+    MAI_MODEL,
+    MAI_REQUEST_TIMEOUT_MS,
+    MAI_TIMESTAMPS,
+    MAI_TRANSCRIBE_PATH,
+    MAI_TRANSCRIBE_STYLE,
+    type MaiPhrase,
+    type MaiWord,
+} from '@/lib/maiTranscribeContract';
+import type { TranscribeChunkResult, TranscriptAnnotation } from '@/lib/transcribeApiContract';
+import { createLogger } from '@/lib/logger';
+import { GenerateApiError } from './errors';
+
+const logger = createLogger('server/maiTranscribe');
+
+export interface MaiCredentials {
+    endpoint: string;
+    apiKey: string;
+}
+
+/**
+ * 資格情報。**無ければ null を返す** — 例外にしない。
+ * 🔴 MAI は preview なので「設定されていない」ことが正常な運用状態でありうる。
+ * その場合は Gemini だけで動く (設計 §3.7 のフォールバック)。
+ */
+export function getMaiCredentials(): MaiCredentials | null {
+    const endpoint = process.env.AZURE_SPEECH_ENDPOINT?.trim();
+    const apiKey = process.env.AZURE_SPEECH_KEY?.trim();
+    if (!endpoint || !apiKey) return null;
+    return { endpoint: endpoint.replace(/\/+$/, ''), apiKey };
+}
+
+/** `definition` は 1 か所でしか組み立てない。リテラルを散らさない */
+export function buildMaiDefinition(phrases: readonly string[] = []): Record<string, unknown> {
+    const definition: Record<string, unknown> = {
+        enhancedMode: {
+            enabled: true,
+            model: MAI_MODEL,
+            modelOptions: { timestamps: MAI_TIMESTAMPS, transcribeStyle: MAI_TRANSCRIBE_STYLE },
+        },
+        diarization: { enabled: true },
+        locales: [...MAI_LOCALES],
+    };
+    // 🔴 空配列を送らない。用語集を使わない構成と「空の用語集」を区別できなくする
+    if (phrases.length > 0) definition.phraseList = { phrases: [...phrases] };
+    return definition;
+}
+
+const asRecord = (v: unknown): Record<string, unknown> | undefined =>
+    typeof v === 'object' && v !== null ? (v as Record<string, unknown>) : undefined;
+const asNumber = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+
+/**
+ * `phrases[].words[]` を共通形の注釈へ。
+ *
+ * 🔴 話者は**句**に付き、語には付かない。句の話者を語へ配る。
+ * 🔴 時刻が読めない語は**落とす。0 で埋めない** — 埋めると G6 (最長穴) が
+ *    「冒頭に注釈がある」と誤認して穴を短く見積もる。
+ */
+export function normalizeMaiPhrases(rawPhrases: unknown): {
+    annotations: TranscriptAnnotation[];
+    droppedWords: number;
+    speakers: number;
+} {
+    const annotations: TranscriptAnnotation[] = [];
+    const speakers = new Set<string>();
+    let droppedWords = 0;
+    for (const item of Array.isArray(rawPhrases) ? rawPhrases : []) {
+        const phrase = asRecord(item) as MaiPhrase | undefined;
+        if (!phrase) continue;
+        const speakerRaw = phrase.speaker;
+        // 話者は 0 始まりの数値で返る。Gemini 側の `spk:0` と表記を揃える
+        const speaker =
+            typeof speakerRaw === 'number' && Number.isFinite(speakerRaw)
+                ? `spk:${speakerRaw}`
+                : typeof speakerRaw === 'string' && speakerRaw !== ''
+                    ? speakerRaw
+                    : null;
+        if (speaker) speakers.add(speaker);
+        for (const wordItem of Array.isArray(phrase.words) ? phrase.words : []) {
+            const word = asRecord(wordItem) as MaiWord | undefined;
+            if (!word) { droppedWords += 1; continue; }
+            const offsetMs = asNumber(word.offsetMilliseconds);
+            const durationMs = asNumber(word.durationMilliseconds);
+            if (offsetMs === undefined || durationMs === undefined) { droppedWords += 1; continue; }
+            annotations.push({
+                text: typeof word.text === 'string' ? word.text : '',
+                startSec: offsetMs / 1000,
+                endSec: (offsetMs + durationMs) / 1000,
+                speaker,
+            });
+        }
+    }
+    return { annotations, droppedWords, speakers: speakers.size };
+}
+
+/** `combinedPhrases[].text` を連結。無ければ `phrases[].text` から組む */
+export function extractMaiText(response: Record<string, unknown>): string {
+    const combined = response.combinedPhrases;
+    if (Array.isArray(combined)) {
+        const parts = combined
+            .map(item => asRecord(item)?.text)
+            .filter((t): t is string => typeof t === 'string');
+        if (parts.length > 0) return parts.join(' ');
+    }
+    const phrases = response.phrases;
+    if (Array.isArray(phrases)) {
+        return phrases
+            .map(item => asRecord(item)?.text)
+            .filter((t): t is string => typeof t === 'string')
+            .join(' ');
+    }
+    return '';
+}
+
+export interface MaiTranscribeInput {
+    bytes: Buffer;
+    mimeType: string;
+    fileName: string;
+    audioSec: number;
+    /** 用語集 (キーワードバイアス)。🔴 Gemini では渡せない — MAI だけの機能 (§1.5 / §3.7) */
+    phraseList?: readonly string[];
+}
+
+export class MaiTranscribeClient {
+    constructor(private readonly credentials: MaiCredentials) {}
+
+    async transcribe(input: MaiTranscribeInput): Promise<TranscribeChunkResult> {
+        if (input.bytes.byteLength > MAI_MAX_AUDIO_BYTES) {
+            throw new GenerateApiError(
+                'media_too_large',
+                `音声が MAI の上限 (${Math.floor(MAI_MAX_AUDIO_BYTES / 1024 / 1024)}MB) を超えています。`,
+            );
+        }
+        const definition = buildMaiDefinition(input.phraseList ?? []);
+        const form = new FormData();
+        form.append('definition', JSON.stringify(definition));
+        form.append(
+            'audio',
+            new Blob([input.bytes as unknown as BlobPart], { type: input.mimeType }),
+            input.fileName,
+        );
+
+        const url = `${this.credentials.endpoint}${MAI_TRANSCRIBE_PATH}?api-version=${MAI_API_VERSION}`;
+        const controller = new AbortController();
+        // 🔴 サーバ側の約 120 秒より **手前で** 諦める。向こうに切られると 408 が返るだけで、
+        //    こちらの再試行・フォールバックの判断が 1 往復ぶん遅れる。
+        const timer = setTimeout(() => controller.abort(), MAI_REQUEST_TIMEOUT_MS);
+        let response: Response;
+        try {
+            response = await fetch(url, {
+                method: 'POST',
+                headers: { [MAI_API_KEY_HEADER]: this.credentials.apiKey },
+                body: form,
+                signal: controller.signal,
+            });
+        } catch (error) {
+            const aborted = error instanceof Error && error.name === 'AbortError';
+            throw new GenerateApiError(
+                aborted ? 'upstream_timeout' : 'upstream_error',
+                aborted
+                    ? `MAI が ${MAI_REQUEST_TIMEOUT_MS / 1000} 秒以内に応答しませんでした。`
+                    : 'MAI へ接続できませんでした。',
+                { cause: error },
+            );
+        } finally {
+            clearTimeout(timer);
+        }
+
+        if (!response.ok) {
+            const body = (await response.text()).slice(0, 400);
+            // 実測した preview 固有の失敗: 408 Timeout / 503 diarization_unavailable / 500 / 接続断
+            logger.warn('MAI が失敗を返した', { status: response.status, body });
+            throw new GenerateApiError('upstream_error', `MAI がエラーを返しました (${response.status})。`);
+        }
+
+        const parsed = asRecord(await response.json());
+        if (!parsed) {
+            throw new GenerateApiError('upstream_error', 'MAI の応答を解釈できませんでした。');
+        }
+        const { annotations, droppedWords, speakers } = normalizeMaiPhrases(parsed.phrases);
+        const text = extractMaiText(parsed);
+        logger.info('MAI で文字起こし', {
+            chars: text.length, annotations: annotations.length, droppedWords, speakers,
+            audioSec: input.audioSec,
+        });
+        return {
+            // MAI は成否を HTTP で返し、部分成功の状態を持たない。
+            // ゲートの G1 は `completed` 以外を落とすので、成功した応答はここで `completed` に揃える。
+            status: 'completed',
+            text,
+            annotations,
+            audioSec: input.audioSec,
+            transport: 'mai_multipart',
+        };
+    }
+}

--- a/src/server/transcribeWithFallback.test.ts
+++ b/src/server/transcribeWithFallback.test.ts
@@ -1,0 +1,92 @@
+/**
+ * 🔴 MAI (主) → Gemini (フォールバック) の切り替えの錠（設計 §3.7）。
+ *
+ * ここで守りたいのは3つ:
+ *  - MAI が落ちても**本文が出る**こと
+ *  - **落ちた事実が記録に残る**こと（用語集は MAI でしか効かないので、
+ *    どの区間で用語が効いていないかが後から追えなくなる）
+ *  - 「試して落ちた」と「設定が無くて試していない」を**混同しない**こと
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { transcribeWithFallback } from './transcribeWithFallback';
+import type { TranscribeChunkResult } from '@/lib/transcribeApiContract';
+
+const INPUT = {
+    bytes: Buffer.from('audio'),
+    mimeType: 'audio/mpeg',
+    fileName: 'chunk0.mp3',
+    audioSec: 600,
+};
+
+const result = (text: string, transport: TranscribeChunkResult['transport']): TranscribeChunkResult => ({
+    status: 'completed', text, annotations: [], audioSec: 600, transport,
+});
+
+const CREDS = { endpoint: 'https://x.cognitiveservices.azure.com', apiKey: 'k' };
+
+describe('MAI が成功するとき', () => {
+    it('MAI の結果をそのまま返し、Gemini を呼ばない', async () => {
+        const gemini = vi.fn();
+        const outcome = await transcribeWithFallback(INPUT, {
+            credentials: CREDS,
+            makeMai: () => ({ transcribe: async () => result('MAIの本文', 'mai_multipart') }),
+            makeGemini: () => ({ transcribe: gemini }),
+        });
+        expect(outcome.engine).toBe('mai');
+        expect(outcome.result.text).toBe('MAIの本文');
+        expect(outcome.maiAttempted).toBe(true);
+        expect(outcome.fallbackReason).toBeUndefined();
+        expect(gemini).not.toHaveBeenCalled();
+    });
+});
+
+describe('🔴 MAI が落ちたとき', () => {
+    it.each([
+        ['408 タイムアウト', 'MAI が 115 秒以内に応答しませんでした。'],
+        ['503 話者分離が使えない', 'MAI がエラーを返しました (503)。'],
+        ['500', 'MAI がエラーを返しました (500)。'],
+        ['接続断', 'MAI へ接続できませんでした。'],
+    ])('%s → Gemini で本文が出る', async (_label, message) => {
+        const outcome = await transcribeWithFallback(INPUT, {
+            credentials: CREDS,
+            makeMai: () => ({ transcribe: async () => { throw new Error(message); } }),
+            makeGemini: () => ({ transcribe: async () => result('Geminiの本文', 'files_api') }),
+        });
+        expect(outcome.result.text).toBe('Geminiの本文');
+        expect(outcome.engine).toBe('gemini');
+    });
+
+    it('🔴 落ちた理由を残す — 用語集が効いていない区間を後から追えるように', async () => {
+        const outcome = await transcribeWithFallback(INPUT, {
+            credentials: CREDS,
+            makeMai: () => ({ transcribe: async () => { throw new Error('MAI がエラーを返しました (503)。'); } }),
+            makeGemini: () => ({ transcribe: async () => result('本文', 'files_api') }),
+        });
+        expect(outcome.fallbackReason).toContain('503');
+        expect(outcome.maiAttempted).toBe(true);
+    });
+
+    it('Gemini も落ちたら、その例外を投げる（黙って空を返さない）', async () => {
+        await expect(transcribeWithFallback(INPUT, {
+            credentials: CREDS,
+            makeMai: () => ({ transcribe: async () => { throw new Error('MAI 失敗'); } }),
+            makeGemini: () => ({ transcribe: async () => { throw new Error('Gemini も失敗'); } }),
+        })).rejects.toThrow('Gemini も失敗');
+    });
+});
+
+describe('🔴 「試して落ちた」と「試していない」を混同しない', () => {
+    it('資格情報が無ければ Gemini だけで動き、maiAttempted は false', async () => {
+        const mai = vi.fn();
+        const outcome = await transcribeWithFallback(INPUT, {
+            credentials: null,
+            makeMai: () => ({ transcribe: mai }),
+            makeGemini: () => ({ transcribe: async () => result('本文', 'files_api') }),
+        });
+        expect(outcome.engine).toBe('gemini');
+        // 落ちたのではなく、そもそも投げていない。打つ手が違う（設定漏れ vs preview の不安定さ）
+        expect(outcome.maiAttempted).toBe(false);
+        expect(outcome.fallbackReason).toBeUndefined();
+        expect(mai).not.toHaveBeenCalled();
+    });
+});

--- a/src/server/transcribeWithFallback.ts
+++ b/src/server/transcribeWithFallback.ts
@@ -1,0 +1,78 @@
+/**
+ * チャンク 1 本を **MAI-Transcribe-2 で起こし、落ちたら Gemini へ回す**（設計 §3.7・東野裁定）。
+ *
+ * なぜ二重化するか:
+ * - MAI は用語集・話者分離・単語時刻が**同時に**成立する（Gemini は API が 400 で拒否・§1.5）。
+ *   同一 10 分窓 7 本の実測で、本文は 2.3 倍（中央 2,338 字 vs 1,038 字）、
+ *   最長穴は 3 秒 vs 8 秒、話者 2 名以上は 7/7 vs 4/7、時刻の暴走は 0 件だった。
+ * - 🔴 一方 MAI は **public preview で SLA が無く、実際に落ちる**。
+ *   実測した失敗: 408 Timeout / 503 `diarization_unavailable` / 500 / 接続断。
+ *
+ * 🔴 **切り替えはチャンク単位**。1 本落ちてもジョブ全体を巻き戻さない（§4.3 の再試行と同じ思想）。
+ * 🔴 **フォールバックした事実を必ず返す**。用語集は MAI でしか効かないので、
+ *    Gemini に落ちた区間だけ用語の反映が弱い。黙って混ぜると理由が追えなくなる。
+ */
+import type { TranscribeChunkResult } from '@/lib/transcribeApiContract';
+import type { TranscribeEngine } from '@/lib/maiTranscribeContract';
+import { createLogger } from '@/lib/logger';
+import { MaiTranscribeClient, getMaiCredentials, type MaiCredentials } from './maiTranscribe';
+import { TranscribeChunkClient } from './transcribeChunk';
+
+const logger = createLogger('server/transcribeWithFallback');
+
+export interface EngineInput {
+    bytes: Buffer;
+    mimeType: string;
+    fileName: string;
+    audioSec: number;
+    phraseList?: readonly string[];
+}
+
+export interface EngineOutcome {
+    result: TranscribeChunkResult;
+    /** 実際にこの本文を起こしたエンジン */
+    engine: TranscribeEngine;
+    /**
+     * MAI を試して落ちた理由。**Gemini に落ちたときだけ**入る。
+     * 🔴 利用者に見せる文言ではなく、記録と計器のための短い理由。
+     */
+    fallbackReason?: string;
+    /** MAI を試したか。資格情報が無ければ false（＝落ちたのではなく、そもそも試していない） */
+    maiAttempted: boolean;
+}
+
+export interface FallbackDeps {
+    credentials?: MaiCredentials | null;
+    makeMai?: (credentials: MaiCredentials) => Pick<MaiTranscribeClient, 'transcribe'>;
+    makeGemini?: () => Pick<TranscribeChunkClient, 'transcribe'>;
+}
+
+export async function transcribeWithFallback(
+    input: EngineInput,
+    deps: FallbackDeps = {},
+): Promise<EngineOutcome> {
+    const credentials = deps.credentials !== undefined ? deps.credentials : getMaiCredentials();
+    const makeGemini = deps.makeGemini ?? (() => new TranscribeChunkClient());
+
+    if (!credentials) {
+        // 🔴 「試して落ちた」と「設定が無くて試していない」を混同しない。
+        //    前者は preview の不安定さ、後者は運用の設定漏れで、打つ手が違う。
+        logger.info('MAI の資格情報が無いので Gemini だけで起こす');
+        const result = await makeGemini().transcribe(input);
+        return { result, engine: 'gemini', maiAttempted: false };
+    }
+
+    const makeMai = deps.makeMai ?? ((c: MaiCredentials) => new MaiTranscribeClient(c));
+    try {
+        const result = await makeMai(credentials).transcribe(input);
+        return { result, engine: 'mai', maiAttempted: true };
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        // 🔴 warn で残す。preview の可用性はここでしか数えられない
+        logger.warn('MAI が失敗したので Gemini へフォールバックする', {
+            reason, audioSec: input.audioSec, fileName: input.fileName,
+        });
+        const result = await makeGemini().transcribe(input);
+        return { result, engine: 'gemini', fallbackReason: reason, maiAttempted: true };
+    }
+}


### PR DESCRIPTION
全文文字起こしの主エンジンを `MAI-Transcribe-2`（Azure Speech / Microsoft Foundry）に切り替え、落ちたら Gemini へ回します。

## なぜ替えるか — 決め手は用語集

Gemini は `custom_vocabulary` が話者分離・単語タイムスタンプと**排他**で、API が 400 を返します（Google スタッフも「仕様」と回答済み）。MAI は **3つ同時に成立**します。対照群で確認しました（合成音声・架空社名）:

| 構成 | 出力 |
|---|---|
| 対照（機能なし） | 「**青井**建設」 |
| `phraseList.phrases` のみ | 🔴 「**アオイ**建設」に変化 |
| 3機能同時 | 「**アオイ**建設」＋話者ラベル＋115語の時刻 |

同じ 10分窓 7本での実測（生レスポンスと突合し、raw と一致する走だけ採用）:

| 指標 | Gemini | MAI |
|---|---|---|
| 本文の量 中央 | 1,038字 | **2,338字（2.3倍）** |
| 最長穴 中央 / 最大 | 8秒 / 10秒 | **3秒 / 6秒** |
| 話者2名以上を返した走 | 4/7 | **7/7** |
| 範囲外時刻（時刻の暴走） | — | **0件** |
| 価格 | 約 $0.30/時間 | **$0.10/時間** |

## 🔴 それでも Gemini を捨てない理由

1. **public preview で SLA が無い。** 逐語: *"not recommended for production workloads"*
2. **実測で落ちる。** 408 Timeout / 503 `diarization_unavailable` / 500 / 接続断
3. **同期 API はサーバ側で約120秒で切られる。** 408 になった走の所要が全走 121.7〜122.0秒で揃っていたのが根拠で、供給の揺らぎではありません。所要は固定オーバーヘッド約25秒＋毎分約6秒で説明が付き、**10分チャンク（85秒）は安全域**です

## 変更

- `lib/maiTranscribeContract.ts` / `server/maiTranscribe.ts` — Azure 呼び出しと、出力（`phrases[].words[].offsetMilliseconds`）を **Gemini と同じ共通形へ正規化**
- `server/transcribeWithFallback.ts` — **チャンク単位**で切り替え。ジョブ全体は巻き戻しません
- 応答・記録・`usedModel` にエンジンを残します
- **フォールバックした区間を本文に注記として出します**

```
　　　ⓘ 10:00 〜 20:00 は別の文字起こしサービスで処理しました。
　　　用語集の表記が反映されていない場合があります。
```

- プロンプト選択にプレビュー版の断りを表示

> 最新の文字起こしサービス（プレビュー版）を使っています。混み合っているときは時間がかかったり、一部の区間だけ精度が落ちることがあります。うまくいかないときは、少し時間をおいてからもう一度お試しください。

## 設計上、意識した点

- 🔴 **品質ゲートをエンジンごとに分けていません。** 出力形の違いは正規化に閉じ込めます。分けると片方だけ検査が緩くなります
- 🔴 **フォールバックの事実を消しません。** 用語集は MAI でしか効かないので、Gemini に落ちた区間だけ表記が揺れます。理由が追えなくなるのを防ぎます
- 🔴 **「試して落ちた」と「設定が無くて試していない」を区別します**（`maiAttempted`）。前者は preview の不安定さ、後者は設定漏れで打つ手が違います
- 🔴 **時刻が読めない語は落とします。0 で埋めません。** 埋めると G6（最長穴）が「冒頭に注釈がある」と誤認して穴を短く見積もります
- 🔴 **末尾のフォールバック注記が消えないこと**を錠で固定しています

## 検証

`npx tsc --noEmit` exit 0 / `npm run lint` exit 0 / **1,554 tests passing**。

実 Azure への通し検証も追加しました（`RUN_LIVE_MAI=1` のときだけ走ります）。単体は口を差し替えているので、パラメータが実際に受理されるかは通っていませんでした。**仕様どおりのパラメータが黙って無視される事故を今日2回踏んでいます**（Gemini の `diarization_mode`、OpenRouter の `phraseList`）。実行結果: 本文117字・単語時刻115語（秒に変換済み）・話者ラベル `spk:N`・用語集の反映を確認。

## 環境変数

`AZURE_SPEECH_ENDPOINT` / `AZURE_SPEECH_KEY` を Vercel の Production / Preview / Development に設定済みです。**未設定でも動きます**（Gemini のみになり、`maiAttempted: false` が記録に残ります）。

⚠️ MAI が使えるリージョンは `eastus` / `northeurope` / `southeastasia` / `westus` のみで、`japaneast` では使えません。今回は `southeastasia` に置いています。Azure はリソースのリージョン外でデータを処理しないため、**この選択がそのまま音声の処理場所**になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)