### PR TITLE
音声入力で FFmpeg を読み込まず、分割パイプラインが必ず失敗していた

### DIFF
--- a/src/hooks/useProcessingWorkflow.test.ts
+++ b/src/hooks/useProcessingWorkflow.test.ts
@@ -53,6 +53,7 @@ vi.mock('@/lib/logger', () => ({
 
 import { CONVERSION_QUEUE_WAIT_LIMIT_MS, useProcessingWorkflow } from './useProcessingWorkflow';
 import { canSendAudioAsIs } from '@/lib/mediaInput';
+import { TRANSCRIPT_PROMPT_ID } from '@/lib/transcriptPrompt';
 import { GENERATE_MAX_MEDIA_BYTES } from '@/lib/generateApiContract';
 
 const BITRATE = '192k';
@@ -252,6 +253,21 @@ describe('handleStartProcessing failure reporting', () => {
 
         expect(result.ok).toBe(false);
         expect(harness.statuses[0]).toMatchObject({ status: 'error', failedPhase: 'engine_init' });
+        expect(serviceMocks.convertVideoToAudioSegments).not.toHaveBeenCalled();
+    });
+
+    it('🔴 全文文字起こしを選んだら、入力が音声でも FFmpeg を読み込む', async () => {
+        // 実害 (2026-09-04): 本番で mp3 を上げると converter が null のまま分割パイプラインが
+        // 呼ばれ、「音声変換の準備ができていません」で必ず失敗していた。
+        // 分割パイプラインは入力が音声でもチャンクの切り出しと無音走査に FFmpeg を使う。
+        const harness = useWorkflowHarness();
+        const file = createFile('talk.mp3', 'audio/mpeg');
+        file.selectedPromptIds = [TRANSCRIPT_PROMPT_ID];
+
+        await harness.workflow.handleStartProcessing([file], ['f1'], BITRATE, SAMPLE_RATE);
+
+        expect(serviceMocks.ffmpegLoad).toHaveBeenCalled();
+        // 変換自体は要らない（そのまま送れる音声なので）
         expect(serviceMocks.convertVideoToAudioSegments).not.toHaveBeenCalled();
     });
 

--- a/src/hooks/useProcessingWorkflow.ts
+++ b/src/hooks/useProcessingWorkflow.ts
@@ -4,6 +4,7 @@ import { GeminiClient } from '@/lib/gemini';
 import { FileWithPrompts, FileProcessingStatus, DebugErrorMode } from '@/types/processing';
 import { convertVideoToAudioSegments, resumeVideoConversion } from '@/lib/videoConversionService';
 import { canSendAudioAsIs } from '@/lib/mediaInput';
+import { TRANSCRIPT_PROMPT_ID } from '@/lib/transcriptPrompt';
 import type { JobClaim, TranscriptionJobRef } from '@/hooks/useVideoProcessing';
 import { createLogger } from '@/lib/logger';
 
@@ -162,10 +163,16 @@ export const useProcessingWorkflow = ({
         try {
             // H6: エンジンの初期化も失敗を捕捉できる位置に置き、
             //     音声のみの場合は FFmpeg を読み込まない
-            // 🔴 上限を超える音声は変換に回すので、その場合も FFmpeg が要る。
-            //    ここを isAudioInput のままにすると、変換が必要なのにエンジンが無い状態で落ちる。
+            // 🔴 FFmpeg が要る条件は 2 つあり、**どちらか一方でも当てはまれば読み込む**。
+            //  (1) 変換が要る入力（動画、または上限を超える音声）
+            //  (2) 🔴 **全文文字起こしを選んでいる**。分割パイプラインは入力が音声でも
+            //      チャンクの切り出しと無音走査に FFmpeg を使う（設計 §3.1）。
+            //      ここを (1) だけにすると、mp3 を上げたときに converter が null のまま
+            //      呼ばれ、「音声変換の準備ができていません」で必ず失敗する。
+            //      実害 (2026-09-04): 本番で音声入力の全文文字起こしが一度も動いていなかった。
             const needsFfmpeg = !sendVideoDirectly
-                && selectedFiles.some(file => !canSendAudioAsIs(file.file));
+                && selectedFiles.some(file =>
+                    !canSendAudioAsIs(file.file) || file.selectedPromptIds.includes(TRANSCRIPT_PROMPT_ID));
 
             try {
                 await prepareEngines(needsFfmpeg);


### PR DESCRIPTION
🔴 **本番で「全文文字起こし」が音声入力に対して一度も動いていませんでした。** 実ブラウザ（Playwright・本番）での通し確認で踏みました。

```
プロンプト「全文文字起こし」: 音声変換の準備ができていません。ページを再読み込みしてください。
```

## 原因

FFmpeg を読み込む条件が「**変換が要る入力か**」だけでした。音声はそのまま送れるので `needsFfmpeg` が false になり、`converterRef.current` が null のまま `runTranscriptPipeline` へ渡ります。

しかし**分割パイプラインは入力が音声でも FFmpeg を使います** — チャンクの切り出しと無音走査（発話区間＝G6 の入力）に必要だからです。

#46 から入っていた欠陥で、#47 の変更が原因ではありません（変更前の `!isAudioInput(file)` でも mp3 では同じく false になります）。

## 修正

FFmpeg が要る条件を2つにし、**どちらか一方でも当てはまれば読み込む**ようにしました。

1. 変換が要る入力（動画、または上限を超える音声）
2. **全文文字起こしを選んでいる**

## 錠

欠陥を注入して、錠が実際に捕まえることを確認しています。

```
--- 条件を元に戻した状態 ---
× 🔴 全文文字起こしを選んだら、入力が音声でも FFmpeg を読み込む
  → expected "spy" to be called at least once
--- 修正を戻した状態 ---
Tests  23 passed
```

`npx tsc --noEmit` exit 0 / `npm run lint` exit 0 / **1,555 tests passing**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)