### PR TITLE
分割パイプラインの依存が本番で1つも配線されていなかった

### DIFF
--- a/src/hooks/transcriptPipelineAdapter.test.ts
+++ b/src/hooks/transcriptPipelineAdapter.test.ts
@@ -5,7 +5,7 @@
  * 下流（下書き・保存・冪等）は分岐を知らないので、成功/失敗の判定はここが最後の砦。
  */
 import { describe, expect, it, vi } from 'vitest';
-import { runTranscriptPipeline } from './transcriptPipelineAdapter';
+import { buildTranscriptionJobDeps, runTranscriptPipeline } from './transcriptPipelineAdapter';
 import type { VideoConverter } from '@/lib/ffmpeg';
 
 vi.mock('@/lib/logger', () => ({
@@ -96,5 +96,42 @@ describe('🔴 成功にしてはいけない場合', () => {
         });
         expect(r.success).toBe(false);
         expect(r.error).toContain('ffmpeg');
+    });
+});
+
+/**
+ * 🔴 本番の依存が実際に組まれていることの錠。
+ *
+ * 以前は `{ converter, ...deps } as TranscriptionJobDeps` と**型を黙らせて**いたため、
+ * `scanSilence` などが 1 つも配線されないまま tsc もテストも緑で、
+ * 本番だけ `scanSilence is not a function` で落ちていた（2026-09-04・実ブラウザで発見）。
+ */
+describe('🔴 buildTranscriptionJobDeps — 本番の配線', () => {
+    const converter = {
+        getFfmpeg: () => ({
+            writeFile: vi.fn(), exec: vi.fn(), deleteFile: vi.fn(), on: vi.fn(), off: vi.fn(),
+        }),
+        convertSegmentToMp3: vi.fn(),
+    } as unknown as Parameters<typeof buildTranscriptionJobDeps>[0];
+
+    it('必要な依存が 1 つ残らず関数として揃っている', () => {
+        const deps = buildTranscriptionJobDeps(converter);
+        for (const key of ['scanSilence', 'uploadChunk', 'deleteChunk', 'postChunk'] as const) {
+            expect(typeof deps[key], key).toBe('function');
+        }
+        expect(deps.converter).toBe(converter);
+    });
+
+    it('🔴 ffmpeg の取り出しは走査するときまで遅らせる（組み立てだけで load を要求しない）', async () => {
+        const spy = vi.fn(() => ({
+            writeFile: vi.fn(), exec: vi.fn(async () => undefined), deleteFile: vi.fn(),
+            on: vi.fn(), off: vi.fn(),
+        }));
+        const deps = buildTranscriptionJobDeps(
+            { getFfmpeg: spy } as unknown as Parameters<typeof buildTranscriptionJobDeps>[0],
+        );
+        expect(spy).not.toHaveBeenCalled();
+        await deps.scanSilence(new File([new Uint8Array(1)], 'a.mp3'), { durationSec: 10 }).catch(() => {});
+        expect(spy).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/hooks/transcriptPipelineAdapter.ts
+++ b/src/hooks/transcriptPipelineAdapter.ts
@@ -10,7 +10,14 @@
 import type { VideoConverter } from '@/lib/ffmpeg';
 import type { TranscriptionResult } from '@/lib/gemini';
 import { createLogger } from '@/lib/logger';
-import { runTranscriptionJob, type TranscriptionJobDeps } from '@/hooks/useTranscriptionJob';
+import {
+    createFfmpegSilenceScanner,
+    runTranscriptionJob,
+    type TranscriptionJobDeps,
+} from '@/hooks/useTranscriptionJob';
+import { deleteAudioFromStorage, uploadAudioToStorage } from '@/lib/storage';
+import { TRANSCRIBE_CHUNK_API_PATH, type TranscribeChunkResponseBody } from '@/lib/transcribeChunkContract';
+import { GENERATE_AUTH_HEADER } from '@/lib/generateApiContract';
 
 const logger = createLogger('transcriptPipeline');
 
@@ -24,6 +31,59 @@ export interface RunTranscriptPipelineInput {
     runJob?: typeof runTranscriptionJob;
 }
 
+/**
+ * 本番の依存一式。テストは個別に差し替えるので、ここは**実物だけ**を組む。
+ *
+ * 🔴 `converter` は `load()` 済みであること。別インスタンスを立てると wasm を再ロードする。
+ */
+export function buildTranscriptionJobDeps(converter: VideoConverter): TranscriptionJobDeps {
+    return {
+        converter,
+        // 🔴 無音走査は**同じ ffmpeg インスタンス**を使う（設計 §3.1）。
+        //    別に立てると wasm core をもう一度ロードする。
+        // 🔴 ffmpeg の取り出しは**走査するときまで遅らせる**。ここで呼ぶと、
+        //    走らせないのに load 済みであることを要求してしまう。
+        scanSilence: (file, options) => createFfmpegSilenceScanner(
+            converter.getFfmpeg(),
+            async (f) => new Uint8Array(await f.arrayBuffer()),
+        )(file, options),
+        uploadChunk: (blob, fileName) =>
+            uploadAudioToStorage(blob, fileName, {
+                originalFileName: fileName,
+                originalFileType: 'audio',
+            }),
+        deleteChunk: (storagePath) => deleteAudioFromStorage(storagePath),
+        postChunk: async (body, signal) => {
+            // 認証は既存の生成 API と同じ形。未ログイン (ゲスト) はヘッダを付けない
+            // 🔴 firebase はここで**遅延 import** する。モジュール先頭で読むと、
+            //    このアダプタを import しただけで Auth が初期化され、
+            //    鍵の無い環境（テスト・prerender）が `auth/invalid-api-key` で落ちる。
+            let token: string | null = null;
+            try {
+                const { auth } = await import('@/lib/firebase');
+                token = (await auth.currentUser?.getIdToken()) ?? null;
+            } catch {
+                token = null;
+            }
+            const headers: Record<string, string> = { 'content-type': 'application/json' };
+            if (token) headers[GENERATE_AUTH_HEADER] = `Bearer ${token}`;
+            const response = await fetch(TRANSCRIBE_CHUNK_API_PATH, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(body),
+                ...(signal ? { signal } : {}),
+            });
+            const json = (await response.json()) as TranscribeChunkResponseBody & { message?: string };
+            if (!response.ok) {
+                // 🔴 サーバの文言をそのまま使う。ここで作文すると、上限超過などの
+                //    「次に何をすればよいか」が書かれた文言が失われる
+                throw new Error(json.message ?? `チャンクの文字起こしに失敗しました (${response.status})`);
+            }
+            return json;
+        },
+    };
+}
+
 export async function runTranscriptPipeline(
     input: RunTranscriptPipelineInput,
 ): Promise<TranscriptionResult> {
@@ -35,9 +95,14 @@ export async function runTranscriptPipeline(
     }
 
     try {
+        // 🔴 **本番の依存をここで実際に組み立てる。**
+        //    以前は `{ converter, ...deps } as TranscriptionJobDeps` と**型を黙らせて**いたため、
+        //    `scanSilence` / `uploadChunk` / `deleteChunk` / `postChunk` が 1 つも配線されておらず、
+        //    本番で必ず `scanSilence is not a function` で落ちていた（2026-09-04・実ブラウザで発見）。
+        //    型アサーションで穴を塞ぐと、tsc もテストも緑のまま本番だけ壊れる。
         const job = await runJob(
             file,
-            { converter, ...(deps ?? {}) } as TranscriptionJobDeps,
+            { ...buildTranscriptionJobDeps(converter), ...(deps ?? {}) },
             { ...(signal ? { signal } : {}) },
         );
 


### PR DESCRIPTION
🔴 本番で「全文文字起こし」が `t.scanSilence is not a function` で必ず失敗していました。実ブラウザでの通し確認で発見しています。

## 原因は型アサーション

```ts
{ converter, ...(deps ?? {}) } as TranscriptionJobDeps
```

`as` で**型を黙らせて**いたため、`scanSilence` / `uploadChunk` / `deleteChunk` / `postChunk` が**1つも配線されないまま** tsc もテストも緑で、本番だけ壊れていました。

🔴 **型アサーションで穴を塞ぐと、検査は全部通るのに実行時だけ落ちます。** #46 でこの機能を入れて以来、分割パイプラインは一度も本番で動いていません。

## 修正

`buildTranscriptionJobDeps()` を追加し、本番の依存を実際に組みます（無音走査・チャンクの上げ下ろし・チャンク API の呼び出しと認証ヘッダ）。

あわせて2点:

- 🔴 **ffmpeg の取り出しは走査するときまで遅らせます。** 組み立てだけで `load()` 済みを要求しません
- 🔴 **firebase は遅延 import。** モジュール先頭で読むと、このアダプタを import しただけで Auth が初期化され、鍵の無い環境（テスト・prerender）が `auth/invalid-api-key` で落ちます（実際に落としました）

## 錠

- 必要な依存が1つ残らず**関数として**揃っていること
- ffmpeg の取り出しが遅延すること（組み立て時点では呼ばれない）

`npx tsc --noEmit` exit 0 / `npm run lint` exit 0 / **1,557 tests passing（96 ファイル）**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)