### PR TITLE
G7（話者2名未満）を fail から warn へ — 本文ごと捨てない

### DIFF
--- a/src/lib/transcriptQuality.test.ts
+++ b/src/lib/transcriptQuality.test.ts
@@ -39,6 +39,10 @@ const gateChunk = (text: string, overrides: Partial<ChunkResult> = {}): ChunkRes
 const gatesOf = (chunk: ChunkResult, options = {}): QualityGateId[] =>
     evaluateChunkQuality(chunk, options).failedGates;
 
+/** 警告だけのゲート。🔴 合格に丸めない — 「落ちない」と「何も言っていない」は別物 */
+const warningsOf = (chunk: ChunkResult, options = {}): QualityGateId[] =>
+    evaluateChunkQuality(chunk, options).warnedGates;
+
 /**
  * 境界テスト用のユニット列。
  * distinct 文 と 2 種類の相槌を交互に置くので、同一ユニットは 1 度も連続しない (最長連続 1) =
@@ -430,34 +434,35 @@ describe('G6 (最長穴) の境界', () => {
     });
 });
 
-describe('G7 (話者の妥当性)', () => {
-    it('話者分離 ON で 1 種類しか居なければ落ち、2 種類なら落ちない', () => {
-        const audioSec = 600;
-        const single = makeChunk(NORMAL_LONG_TRANSCRIPT, {
-            audioSec,
-            speechSec: 740,
-            annotations: makeAnnotations(audioSec, 0.99, ['spk:0']),
+describe('G7 (話者の妥当性) — 🔴 warn 止まり', () => {
+    const audioSec = 600;
+    const withSpeakers = (speakers: Array<string | null>) =>
+        makeChunk(NORMAL_LONG_TRANSCRIPT, {
+            audioSec, speechSec: 740,
+            annotations: makeAnnotations(audioSec, 0.99, speakers),
         });
-        const pair = makeChunk(NORMAL_LONG_TRANSCRIPT, {
-            audioSec,
-            speechSec: 740,
-            annotations: makeAnnotations(audioSec, 0.99, ['spk:0', 'spk:1']),
-        });
-        expect(gatesOf(single)).toContain('G7');
-        expect(gatesOf(pair)).not.toContain('G7');
+
+    it('話者分離 ON で 1 種類しか居なければ警告し、2 種類なら警告しない', () => {
+        expect(warningsOf(withSpeakers(['spk:0']))).toContain('G7');
+        expect(warningsOf(withSpeakers(['spk:0', 'spk:1']))).not.toContain('G7');
+    });
+
+    it('🔴 本文ごと捨てない — 話者ラベルはメタデータであって本文ではない', () => {
+        // 実測: Gemini は 10 分窓 9 走中 3 走で話者を 1 名も返さない。fail のままだと
+        // MAI から Gemini へフォールバックしたチャンクの約 3 割がゲートで捨てられ、
+        // フォールバックが用をなさない（設計 §3.7）
+        const report = evaluateChunkQuality(withSpeakers(['spk:0']));
+        expect(report.failedGates).not.toContain('G7');
+        expect(report.passed).toBe(true);
+        expect(report.findings.find(f => f.gate === 'G7')?.severity).toBe('warn');
     });
 
     it('話者分離 OFF (speaker が null) では判定しない', () => {
-        const audioSec = 600;
-        const chunk = makeChunk(NORMAL_LONG_TRANSCRIPT, {
-            audioSec,
-            speechSec: 740,
-            annotations: makeAnnotations(audioSec, 0.99, [null]),
-        });
+        const chunk = withSpeakers([null]);
         expect(evaluateChunkQuality(chunk).metrics.speakerCount).toBe(0);
-        expect(gatesOf(chunk)).not.toContain('G7');
-        // 有効だと明示したときだけ落ちる (話者分離を単独指定すると注釈に speaker が付かない実測がある)
-        expect(gatesOf(chunk, { diarizationEnabled: true })).toContain('G7');
+        expect(warningsOf(chunk)).not.toContain('G7');
+        // 有効だと明示したときだけ警告する (話者分離を単独指定すると注釈に speaker が付かない実測がある)
+        expect(warningsOf(chunk, { diarizationEnabled: true })).toContain('G7');
     });
 });
 
@@ -568,8 +573,10 @@ describe('レポートの形', () => {
                 annotations: makeAnnotations(1200, 0.5, ['spk:0']),
             }),
         );
-        // 注釈は音声の 50% までしか無い = 末尾 600 秒が穴 (G6)。話者は 1 種類 (G7)。
-        expect(report.failedGates).toEqual(['G1', 'G3', 'G4', 'G5', 'G6', 'G7']);
+        // 注釈は音声の 50% までしか無い = 末尾 600 秒が穴 (G6)。
+        expect(report.failedGates).toEqual(['G1', 'G3', 'G4', 'G5', 'G6']);
+        // 🔴 話者 1 種類は warn。不合格の一覧に混ぜない（本文ごと捨てる理由にはならない）
+        expect(report.warnedGates).toContain('G7');
     });
 });
 

--- a/src/lib/transcriptQuality.ts
+++ b/src/lib/transcriptQuality.ts
@@ -158,7 +158,21 @@ export const MAX_COVERAGE_RATIO = 1.05;
  */
 export const MAX_OUT_OF_RANGE_ANNOTATION_RATIO = 0.01;
 
-/** G7: 商談は最低この人数の話者が居るはず */
+/**
+ * G7: 商談は最低この人数の話者が居るはず。
+ *
+ * 🔴 **`warn` であって `fail` ではない（2026-09-04 改訂）。**
+ * 話者ラベルはメタデータであって本文ではない。落ちたチャンクを**捨てると本文ごと失われる**が、
+ * 話者が付かないだけなら本文は読める（G8 の「時刻の暴走は本文の欠陥ではない」と同じ考え方）。
+ *
+ * 実測でこれが効く: Gemini は 10 分窓 **9 走中 3 走で話者を 1 名も返さない**（silent fail-open）。
+ * G7 を fail のままにすると、**MAI が落ちて Gemini に回ったチャンクの約 3 割がゲートで捨てられ、
+ * フォールバックが用をなさない**（設計 §3.7）。MAI は 11 走すべてで 2〜3 名を返しており、
+ * 主エンジンが動いている限り警告は出ない。
+ *
+ * ⚠️ 警告が増えたら、それは「話者分離が効いていない」という**別の問題の合図**である。
+ * 件数を計器で数えること。
+ */
 export const MIN_SPEAKERS = 2;
 
 export interface QualityGateOptions {
@@ -523,12 +537,13 @@ export const evaluateChunkQuality = (
         });
     }
 
-    // G7: 話者の妥当性。商談は最低 2 話者。話者分離が有効なときだけ判定する
+    // G7: 話者の妥当性。🔴 warn 止まり — 本文は読めるので、チャンクごと捨てない（定数のコメント参照）
     if (diarizationEnabled && metrics.speakerCount < minSpeakers) {
         add({
             gate: 'G7',
-            severity: 'fail',
-            reason: `話者分離が有効なのに話者が ${metrics.speakerCount} 種類 — 商談として不自然`,
+            severity: 'warn',
+            reason: `話者分離が有効なのに話者が ${metrics.speakerCount} 種類 — `
+                + '話者ラベルが付かないだけで本文は読める（警告のみ・不合格にはしない）',
             observed: metrics.speakerCount,
             threshold: minSpeakers,
         });


### PR DESCRIPTION
🔴 **フォールバックが用をなさない状態でした。**

## 実データ

| エンジン | 10分窓の話者数 | G7（2名未満で不合格）に落ちる走 |
|---|---|---|
| Gemini | 4, **0**, 4, 3, **0**, 3, 3, 2, **0** | **3/9（33%）** |
| MAI | 3,3,2,2,2,3,2,2,3,3,3 | 0/11 |

Gemini は 10分窓の3割で話者を1名も返しません（silent fail-open）。G7 が `fail` のままだと、**MAI が落ちて Gemini に回ったチャンクの約3割がゲートで捨てられます**。フォールバックの意味がなくなります。

## 考え方

**話者ラベルはメタデータであって本文ではありません。** チャンクを落とすと本文ごと失われますが、話者が付かないだけなら本文は読めます。G8 で「時刻の暴走は本文の欠陥ではない」として隔離に切り替えたのと同じ考え方です。

⚠️ 警告が増えたら「話者分離が効いていない」という**別の問題の合図**なので、件数を計器で数えます。

## 発見の経緯

本番の実ブラウザ確認で踏みました。20秒の合成音声で MAI は成功して 115字 / 114注釈を返したのに、話者1名のため G7 で不合格 → 3回再試行 → チャンク全滅 → 画面に「1個の区間を文字起こしできませんでした」。

チャンク API を直接叩いた応答:

```
engine   : mai
status   : completed | 字数: 115 | 注釈: 114
quality  : passed=False failed=['G7'] warn=[] indet=['G1']
```

**エンジンも正規化も配線もすべて正しく動いており、ゲートの判定だけが誤っていました。**

`npx tsc --noEmit` exit 0 / `npm run lint` exit 0 / **1,558 tests passing**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)