### PR TITLE
失敗の理由を利用者と記録の両方に残す — 件数だけでは直せない

### DIFF
--- a/src/hooks/transcriptPipelineAdapter.test.ts
+++ b/src/hooks/transcriptPipelineAdapter.test.ts
@@ -5,7 +5,7 @@
  * 下流（下書き・保存・冪等）は分岐を知らないので、成功/失敗の判定はここが最後の砦。
  */
 import { describe, expect, it, vi } from 'vitest';
-import { buildTranscriptionJobDeps, runTranscriptPipeline } from './transcriptPipelineAdapter';
+import { buildTranscriptionJobDeps, runTranscriptPipeline, summarizeChunkFailures } from './transcriptPipelineAdapter';
 import type { VideoConverter } from '@/lib/ffmpeg';
 
 vi.mock('@/lib/logger', () => ({
@@ -133,5 +133,45 @@ describe('🔴 buildTranscriptionJobDeps — 本番の配線', () => {
         expect(spy).not.toHaveBeenCalled();
         await deps.scanSilence(new File([new Uint8Array(1)], 'a.mp3'), { durationSec: 10 }).catch(() => {});
         expect(spy).toHaveBeenCalledTimes(1);
+    });
+});
+
+/**
+ * 🔴 原因を名指ししない警報は、鳴っていても直らない。
+ * 実害 (2026-09-04): 本番で 9 区間が落ちたが、文言が件数だけで、
+ * サーバのログ保持窓も過ぎており、理由をどこからも追えなかった。
+ */
+describe('summarizeChunkFailures', () => {
+    const chunk = (status: string, attempts: unknown[]) =>
+        ({ status, attempts }) as unknown as Parameters<typeof summarizeChunkFailures>[0][number];
+
+    it('落ちたゲートを名指しし、件数の多い順に並べる', () => {
+        const r = summarizeChunkFailures([
+            chunk('failed', [{ quality: { failedGates: ['G6'] } }]),
+            chunk('failed', [{ quality: { failedGates: ['G6'] } }]),
+            chunk('failed', [{ error: 'fetch failed' }]),
+            chunk('completed', [{}]),
+        ]);
+        expect(r.text).toBe('品質検査 G6 2件・通信または処理の失敗 1件');
+        expect(r.counts).toEqual({ '品質検査 G6': 2, '通信または処理の失敗': 1 });
+    });
+
+    it('🔴 最後の試行の落ち方を採る（再試行で様式が変わる）', () => {
+        const r = summarizeChunkFailures([
+            chunk('failed', [{ error: 'timeout' }, { quality: { failedGates: ['G3'] } }]),
+        ]);
+        expect(r.text).toBe('品質検査 G3 1件');
+    });
+
+    it('成功したチャンクは数えない', () => {
+        expect(summarizeChunkFailures([chunk('completed', [{}])]).counts).toEqual({});
+    });
+
+    it('理由が何も無ければ「原因不明」として残す（黙って空にしない）', () => {
+        expect(summarizeChunkFailures([chunk('failed', [{}])]).text).toBe('原因不明 1件');
+    });
+
+    it('失敗が無ければ、その旨を返す（例外にしない）', () => {
+        expect(summarizeChunkFailures([]).text).toBe('原因を特定できませんでした');
     });
 });

--- a/src/hooks/transcriptPipelineAdapter.ts
+++ b/src/hooks/transcriptPipelineAdapter.ts
@@ -84,6 +84,34 @@ export function buildTranscriptionJobDeps(converter: VideoConverter): Transcript
     };
 }
 
+/**
+ * 失敗したチャンクの理由を数え上げ、人が読む一文にする。
+ *
+ * 🔴 原因を名指ししない警報は、鳴っていても直らない。件数だけでなく
+ * 「品質検査に通らなかった」「通信に失敗した」の別と、**どのゲートか**まで残す。
+ */
+export function summarizeChunkFailures(
+    chunks: readonly { status: string; attempts: readonly { error?: string; quality?: { failedGates: readonly string[] } }[] }[],
+): { text: string; counts: Record<string, number> } {
+    const counts: Record<string, number> = {};
+    for (const chunk of chunks) {
+        if (chunk.status !== 'failed') continue;
+        // 最後の試行が、その区間の最終的な落ち方
+        const last = chunk.attempts[chunk.attempts.length - 1];
+        const gates = last?.quality?.failedGates ?? [];
+        const key = gates.length > 0
+            ? `品質検査 ${[...gates].join('/')}`
+            : last?.error
+                ? '通信または処理の失敗'
+                : '原因不明';
+        counts[key] = (counts[key] ?? 0) + 1;
+    }
+    const parts = Object.entries(counts)
+        .sort((a, b) => b[1] - a[1])
+        .map(([key, n]) => `${key} ${n}件`);
+    return { text: parts.length > 0 ? parts.join('・') : '原因を特定できませんでした', counts };
+}
+
 export async function runTranscriptPipeline(
     input: RunTranscriptPipelineInput,
 ): Promise<TranscriptionResult> {
@@ -110,14 +138,23 @@ export async function runTranscriptPipeline(
             // 🔴 1本でも失敗チャンクがあれば成功にしない（設計 §4.4）。
             //    ただし**本文は捨てない** — 取れたところまでは読める形で返し、
             //    欠落は本文中に注記として残っている。
+            // 🔴 **件数だけ伝えない。** 「9 個の区間を文字起こしできませんでした」では、
+            //    利用者も我々も次に何をすればよいか分からない。原因を名指ししない警報は直らない。
+            //    実害 (2026-09-04): 本番で 9 区間が落ちたが、サーバのログ保持窓を過ぎていて
+            //    理由が追えなかった。理由は**この文言と記録の両方**に載せる。
+            const summary = summarizeChunkFailures(job.chunks);
             const detail = job.aborted
                 ? '文字起こしを中止しました。'
-                : `${job.failedChunkIndexes.length} 個の区間を文字起こしできませんでした。`;
+                : `${job.failedChunkIndexes.length} 個の区間を文字起こしできませんでした`
+                    + `（${summary.text}）。もう一度お試しいただくと、通ることがあります。`;
             logger.warn('文字起こしが完全には終わらなかった', {
                 fileName: file.name,
                 aborted: job.aborted,
                 failedChunks: job.failedChunkIndexes.length,
                 chars: job.markdown?.length ?? 0,
+                // 🔴 内訳を必ず残す。件数だけだと、次に何を直せばよいか決められない
+                failureBreakdown: summary.counts,
+                fallbackChunks: job.fallbackChunks.length,
             });
             return { success: false, error: detail, ...(job.markdown ? { text: job.markdown } : {}) };
         }


### PR DESCRIPTION
🔴 本番で実商談を通したところ「**9 個の区間を文字起こしできませんでした**」とだけ表示され、サーバのログ保持窓も過ぎていたため、**理由をどこからも追えませんでした**。

原因を名指ししない警報は、鳴っていても直りません。

## 変更

失敗したチャンクの**最終試行**から、落ちたゲート名／通信失敗の別を数え上げ、画面の文言と記録の両方に載せます。

```
9 個の区間を文字起こしできませんでした（品質検査 G6 6件・通信または処理の失敗 3件）。
もう一度お試しいただくと、通ることがあります。
```

ログには内訳（`failureBreakdown`）とフォールバック件数を残します。

- 🔴 **最後の試行の落ち方を採ります。** 再試行（境界ずらし・引き直し）で失敗の様式が変わるためです
- 🔴 **理由が無ければ「原因不明」として残します。** 黙って空にすると、検査が走らなかったのか原因が無いのかが区別できません

`npx tsc --noEmit` exit 0 / `npm run lint` exit 0 / **1,563 tests passing**。

⚠️ これは**診断のための変更で、失敗そのものを直すものではありません。** 9区間が落ちた原因は未特定です。次の走行でこの内訳が出れば、そこから原因を絞れます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)