### PR TITLE
feat(文字起こし): 全文文字起こしを非同期バッチ方式へ移行し、同期・分割・300秒に由来する不安定を根絶

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -421,5 +421,13 @@ service cloud.firestore {
       // 削除した瞬間から isApprovedSupervisorOf は false になり、以後の読取は拒否される。
       allow delete: if isRelationshipParticipant();
     }
+
+    // 非同期バッチ文字起こしのジョブ状態(設計 §3.7 改訂・2026-09-05)。
+    // 🔴 サーバ(Admin SDK)専用。クライアントは /api/transcribe/status 経由でしか状態を見ない。
+    //    Admin SDK はルールをバイパスするので、ここは明示的に全拒否にして意図を固定する
+    //    (rateLimits と同じく、既定拒否に頼らず「クライアントからは触れない」を宣言する)。
+    match /transcriptionJobs/{jobId} {
+      allow read, write: if false;
+    }
   }
 }

--- a/src/app/api/transcribe/batch.contract.test.ts
+++ b/src/app/api/transcribe/batch.contract.test.ts
@@ -1,0 +1,177 @@
+/**
+ * 契約テスト（L5-問3(a)）: submit / status の**実ルート**を、外界の I/O だけ差し替えて通す。
+ *
+ * 🔴 本番で3回出た「tsc もテストも緑なのに壊れる」型は、いずれも継ぎ目がモックされ、
+ *    ルートの orchestration（何を呼ぶか）を一度も実行していなかったのが原因（L5-問2）。
+ *    ここでは parseStoragePath / isOwnedBySubject / parseBatchResult / buildTranscriptMarkdownFromBatch を
+ *    **実物のまま**通し、「submit が実際に submitBatchJob と文書作成とジョブ作成を呼ぶ」
+ *    「status が Succeeded で確定処理を最後まで配線している」ことを錠にする。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AzureBatchResult } from '@/lib/azureBatchContract';
+
+// --- 外界の I/O だけモック（純関数は実物のまま） ---
+vi.mock('@/server/auth', () => ({
+    GUEST_OWNER_ID: 'GUEST',
+    resolveRequestSubject: vi.fn(),
+}));
+vi.mock('@/server/rateLimit', () => ({
+    enforceRateLimit: vi.fn(async () => ({ allowed: true, count: 1, limit: 50 })),
+    clientIpFromHeaders: vi.fn(() => '203.0.113.1'),
+}));
+vi.mock('@/server/mediaSource', async (importActual) => ({
+    ...(await importActual<typeof import('@/server/mediaSource')>()),
+    statMedia: vi.fn(async () => ({ storagePath: 'audio/GUEST/x.mp3', sizeBytes: 8_000_000 })),
+    getSignedReadUrl: vi.fn(async () => 'https://signed.example/x.mp3?sig=abc'),
+}));
+vi.mock('@/server/azureBatchTranscribe', async (importActual) => ({
+    ...(await importActual<typeof import('@/server/azureBatchTranscribe')>()),
+    getAzureCredentials: vi.fn(() => ({ endpoint: 'https://ep', apiKey: 'k' })),
+    submitBatchJob: vi.fn(async () => ({ selfUrl: 'https://ep/speechtotext/transcriptions/JID?api-version=2024-11-15' })),
+    getBatchJob: vi.fn(),
+    fetchBatchResult: vi.fn(),
+    deleteBatchJob: vi.fn(async () => undefined),
+}));
+vi.mock('@/server/transcriptionDocument', () => ({
+    createProcessingDocument: vi.fn(async () => 'doc-1'),
+    completeTranscriptionDocument: vi.fn(async () => undefined),
+    failTranscriptionDocument: vi.fn(async () => undefined),
+}));
+vi.mock('@/server/transcriptionJob', () => ({
+    createTranscriptionJob: vi.fn(async () => 'job-1'),
+    getTranscriptionJob: vi.fn(),
+    updateTranscriptionJob: vi.fn(async () => undefined),
+}));
+
+import { POST as submitPOST } from './submit/route';
+import { POST as statusPOST } from './status/route';
+import { resolveRequestSubject } from '@/server/auth';
+import { submitBatchJob, getBatchJob, fetchBatchResult, deleteBatchJob } from '@/server/azureBatchTranscribe';
+import { createProcessingDocument, completeTranscriptionDocument, failTranscriptionDocument } from '@/server/transcriptionDocument';
+import { createTranscriptionJob, getTranscriptionJob, updateTranscriptionJob } from '@/server/transcriptionJob';
+
+const guest = { kind: 'guest' as const };
+const req = (body: unknown) => new Request('http://t/api', { method: 'POST', body: JSON.stringify(body) });
+
+const sampleAzureResult = (): AzureBatchResult => ({
+    durationMilliseconds: 60_000,
+    combinedRecognizedPhrases: [{ display: 'こんにちは。よろしくお願いします。' }],
+    recognizedPhrases: [
+        { offsetMilliseconds: 0, durationMilliseconds: 2000, speaker: 1, nBest: [{ display: 'こんにちは。' }] },
+        { offsetMilliseconds: 3000, durationMilliseconds: 2000, speaker: 2, nBest: [{ display: 'よろしくお願いします。' }] },
+    ],
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resolveRequestSubject).mockResolvedValue(guest);
+});
+
+describe('POST /api/transcribe/submit（実ルートの配線）', () => {
+    const validBody = {
+        storagePath: 'audio/GUEST/x.mp3',
+        fileName: 'x.mp3',
+        mimeType: 'audio/mpeg',
+        audioSec: 600,
+        promptName: '全文文字起こし',
+        originalFileType: 'audio',
+    };
+
+    it('🔴 submitBatchJob・文書作成・ジョブ作成を実際に呼び、{jobId,docId} を返す', async () => {
+        const res = await submitPOST(req(validBody));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ jobId: 'job-1', docId: 'doc-1' });
+        // #50 型（配線漏れ）の再発防止: 「呼ばれた」で錠にする
+        expect(submitBatchJob).toHaveBeenCalledTimes(1);
+        expect(createProcessingDocument).toHaveBeenCalledTimes(1);
+        expect(createTranscriptionJob).toHaveBeenCalledTimes(1);
+        // ジョブは Azure の self URL と文書 ID を結びつけて持つ
+        expect(vi.mocked(createTranscriptionJob).mock.calls[0][0]).toMatchObject({
+            docId: 'doc-1',
+            azureSelfUrl: expect.stringContaining('/transcriptions/JID'),
+            ownerType: 'guest',
+        });
+    });
+
+    it('所有者でないパスは 403（Azure を呼ばない）', async () => {
+        const res = await submitPOST(req({ ...validBody, storagePath: 'audio/someuser/x.mp3' }));
+        expect(res.status).toBe(403);
+        expect(submitBatchJob).not.toHaveBeenCalled();
+    });
+
+    it('音声長が 240 分超は 400（提出しない）', async () => {
+        const res = await submitPOST(req({ ...validBody, audioSec: 241 * 60 }));
+        expect(res.status).toBe(400);
+        expect(submitBatchJob).not.toHaveBeenCalled();
+    });
+
+    it('audioSec 欠落は 400', async () => {
+        const { audioSec, ...noSec } = validBody; void audioSec;
+        const res = await submitPOST(req(noSec));
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('POST /api/transcribe/status（確定処理の配線）', () => {
+    const runningJob = {
+        id: 'job-1', ownerId: 'GUEST', ownerType: 'guest' as const, docId: 'doc-1',
+        azureSelfUrl: 'https://ep/speechtotext/transcriptions/JID?api-version=2024-11-15',
+        status: 'running' as const, audioSec: 600, storagePath: 'audio/GUEST/x.mp3',
+        promptName: 'p', createdAtMs: 0, updatedAtMs: 0,
+    };
+
+    it('Azure が Running のうちは文書を確定しない', async () => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue(runningJob);
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Running' });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual({ status: 'running', docId: 'doc-1' });
+        expect(completeTranscriptionDocument).not.toHaveBeenCalled();
+    });
+
+    it('🔴 Succeeded で結果取得→Markdown化→文書完成→ジョブ更新→Azure削除まで貫通する', async () => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue(runningJob);
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+        vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(completeTranscriptionDocument).toHaveBeenCalledTimes(1);
+        // 実の buildTranscriptMarkdownFromBatch を通した本文が入る（話者ラベル＋時刻）
+        const [docId, markdown, model] = vi.mocked(completeTranscriptionDocument).mock.calls[0];
+        expect(docId).toBe('doc-1');
+        expect(markdown).toContain('よろしくお願いします');
+        expect(model).toContain('Azure');
+        expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', expect.objectContaining({ status: 'succeeded' }));
+        expect(deleteBatchJob).toHaveBeenCalledTimes(1);
+    });
+
+    it('🔴 Failed でも文書は消さず、理由を残して failed を返す（L2-D1 是正）', async () => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue(runningJob);
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Failed', error: 'AudioLengthLimitExceeded' });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        const body = await res.json();
+        expect(body.status).toBe('failed');
+        expect(body.error).toContain('AudioLength');
+        expect(failTranscriptionDocument).toHaveBeenCalledTimes(1);
+        expect(completeTranscriptionDocument).not.toHaveBeenCalled();
+    });
+
+    it('🔴 既に succeeded のジョブは Azure を叩かず即返す（冪等・二重確定しない）', async () => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue({ ...runningJob, status: 'succeeded' });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(getBatchJob).not.toHaveBeenCalled();
+        expect(completeTranscriptionDocument).not.toHaveBeenCalled();
+    });
+
+    it('他人のジョブは 403', async () => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue({ ...runningJob, ownerId: 'someuser', ownerType: 'user' });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(res.status).toBe(403);
+    });
+
+    it('存在しないジョブは 404', async () => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue(null);
+        const res = await statusPOST(req({ jobId: 'nope' }));
+        expect(res.status).toBe(404);
+    });
+});

--- a/src/app/api/transcribe/batch.contract.test.ts
+++ b/src/app/api/transcribe/batch.contract.test.ts
@@ -12,19 +12,45 @@ import type { AzureBatchResult } from '@/lib/azureBatchContract';
 
 const documentDb = vi.hoisted(() => ({
     data: undefined as Record<string, unknown> | undefined,
-    ref: { id: 'doc-1' },
+    jobData: undefined as Record<string, unknown> | undefined,
+    ref: { id: 'doc-1', path: 'transcriptions/doc-1' },
+    jobRef: { id: 'job-1', path: 'transcriptionJobs/job-1' },
     tx: { get: vi.fn(), set: vi.fn() },
     runTransaction: vi.fn(),
+    commitError: undefined as Error | undefined,
     warn: vi.fn(),
+}));
+
+const clientDb = vi.hoisted(() => ({
+    getDocs: vi.fn(),
+    getDoc: vi.fn(),
+    tx: { get: vi.fn(), set: vi.fn(), update: vi.fn() },
+    runTransaction: vi.fn(),
 }));
 
 // --- 外界の I/O だけモック（純関数は実物のまま） ---
 vi.mock('@/server/firebaseAdmin', () => ({
     getAdminFirestore: () => ({
-        collection: () => ({ doc: () => documentDb.ref }),
+        collection: (name: string) => ({
+            doc: () => name === 'transcriptionJobs' ? documentDb.jobRef : documentDb.ref,
+        }),
         runTransaction: documentDb.runTransaction,
     }),
 }));
+vi.mock('firebase/firestore', async (importActual) => ({
+    ...(await importActual<typeof import('firebase/firestore')>()),
+    collection: vi.fn(),
+    doc: () => documentDb.ref,
+    query: vi.fn(),
+    getDocs: clientDb.getDocs,
+    getDoc: clientDb.getDoc,
+    runTransaction: clientDb.runTransaction,
+}));
+vi.mock('@/lib/firebase', () => ({ db: {} }));
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: () => 'GUEST', getOwnerType: () => 'guest' }));
+vi.mock('@/lib/auditLog', () => ({ logAudit: vi.fn(async () => undefined) }));
+vi.mock('@/lib/adminSettings', () => ({ validateDocumentSize: vi.fn(async () => ({ valid: true })) }));
+vi.mock('@/lib/userManagement', () => ({ updateUserStats: vi.fn() }));
 vi.mock('@/lib/logger', () => ({
     createLogger: () => ({ info: vi.fn(), warn: documentDb.warn, error: vi.fn(), debug: vi.fn() }),
 }));
@@ -54,25 +80,28 @@ vi.mock('@/server/transcriptionDocument', async (importActual) => {
     return {
         ...actual,
         createProcessingDocument: vi.fn(async () => 'doc-1'),
-        completeTranscriptionDocument: vi.fn(actual.completeTranscriptionDocument),
-        failTranscriptionDocument: vi.fn(actual.failTranscriptionDocument),
     };
 });
-vi.mock('@/server/transcriptionJob', () => ({
-    FINALIZE_LEASE_MS: 3 * 60 * 1000,
-    claimJobForFinalize: vi.fn(),
-    createTranscriptionJob: vi.fn(async () => 'job-1'),
-    getTranscriptionJob: vi.fn(),
-    updateTranscriptionJob: vi.fn(async () => undefined),
-}));
+vi.mock('@/server/transcriptionJob', async (importActual) => {
+    const actual = await importActual<typeof import('@/server/transcriptionJob')>();
+    return {
+        ...actual,
+        claimJobForFinalize: vi.fn(),
+        commitTerminalOutcome: vi.fn(actual.commitTerminalOutcome),
+        createTranscriptionJob: vi.fn(async () => 'job-1'),
+        getTranscriptionJob: vi.fn(),
+        updateTranscriptionJob: vi.fn(async () => undefined),
+    };
+});
 
 import { POST as submitPOST } from './submit/route';
 import { POST as statusPOST } from './status/route';
 import { resolveRequestSubject } from '@/server/auth';
 import { submitBatchJob, getAzureCredentials, getBatchJob, fetchBatchResult, deleteBatchJob } from '@/server/azureBatchTranscribe';
 import { getSignedReadUrl } from '@/server/mediaSource';
-import { createProcessingDocument, completeTranscriptionDocument, failTranscriptionDocument } from '@/server/transcriptionDocument';
-import { claimJobForFinalize, FINALIZE_LEASE_MS, createTranscriptionJob, getTranscriptionJob, updateTranscriptionJob } from '@/server/transcriptionJob';
+import { createProcessingDocument } from '@/server/transcriptionDocument';
+import { claimJobForFinalize, commitTerminalOutcome, FINALIZE_LEASE_MS, createTranscriptionJob, getTranscriptionJob, updateTranscriptionJob } from '@/server/transcriptionJob';
+import { getTranscriptionDocuments, getTranscriptions, getTranscriptionsByOwnerId, restoreTranscription } from '@/lib/firestore';
 import * as finalization from '@/server/finalizeTranscription';
 
 const guest = { kind: 'guest' as const };
@@ -91,14 +120,31 @@ beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(resolveRequestSubject).mockResolvedValue(guest);
     documentDb.data = { ownerId: 'GUEST', status: 'processing', title: '合成の文書', transcription: '処理中' };
-    documentDb.tx.get.mockImplementation(async () => ({
-        exists: documentDb.data !== undefined,
-        data: () => documentDb.data,
-    }));
-    documentDb.tx.set.mockImplementation((_ref, patch) => {
-        documentDb.data = { ...documentDb.data, ...patch };
+    documentDb.jobData = { status: 'finalizing' };
+    documentDb.commitError = undefined;
+    documentDb.tx.get.mockImplementation(async (ref) => {
+        const data = ref.path === documentDb.jobRef.path ? documentDb.jobData : documentDb.data;
+        return { exists: data !== undefined, data: () => data };
     });
-    documentDb.runTransaction.mockImplementation(async (fn) => fn(documentDb.tx));
+    documentDb.runTransaction.mockImplementation(async (fn) => {
+        const writes: Array<{ ref: { path: string }; patch: Record<string, unknown> }> = [];
+        documentDb.tx.set.mockImplementation((ref, patch) => { writes.push({ ref, patch }); });
+        const result = await fn(documentDb.tx);
+        if (documentDb.commitError) {
+            const error = documentDb.commitError;
+            documentDb.commitError = undefined;
+            throw error;
+        }
+        for (const { ref, patch } of writes) {
+            if (ref.path === documentDb.jobRef.path) documentDb.jobData = { ...documentDb.jobData, ...patch };
+            else documentDb.data = { ...documentDb.data, ...patch };
+        }
+        return result;
+    });
+    clientDb.tx.get.mockResolvedValue({ exists: () => false });
+    clientDb.tx.set.mockImplementation((_ref, patch) => { documentDb.data = { ...patch }; });
+    clientDb.getDoc.mockImplementation(async () => ({ exists: () => true, data: () => documentDb.data }));
+    clientDb.runTransaction.mockImplementation(async (_db, fn) => fn(clientDb.tx));
 });
 
 afterEach(() => {
@@ -174,27 +220,34 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Running' });
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect(await res.json()).toEqual({ status: 'running', docId: 'doc-1' });
-        expect(completeTranscriptionDocument).not.toHaveBeenCalled();
+        expect(commitTerminalOutcome).not.toHaveBeenCalled();
         expect(claimJobForFinalize).toHaveBeenCalledWith('job-1');
         expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'running' });
     });
 
-    it('🔴 Succeeded で結果取得→Markdown化→文書完成→ジョブ更新→Azure削除まで貫通する', async () => {
+    it('🔴 Succeeded で結果取得→Markdown化→文書とジョブの原子的確定→Azure削除まで貫通する', async () => {
         vi.mocked(getTranscriptionJob).mockResolvedValue(runningJob);
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
         vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
-        expect(completeTranscriptionDocument).toHaveBeenCalledTimes(1);
+        expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
         // 実の buildTranscriptMarkdownFromBatch を通した本文が入る（話者ラベル＋時刻）
-        const [docId, markdown, model, expectedOwnerId] = vi.mocked(completeTranscriptionDocument).mock.calls[0];
-        expect(docId).toBe('doc-1');
-        expect(markdown).toContain('よろしくお願いします');
-        expect(model).toContain('Azure');
-        expect(expectedOwnerId).toBe('GUEST');
-        expect(documentDb.data).toMatchObject({ status: 'completed', transcription: markdown, title: '合成の文書' });
-        expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', expect.objectContaining({ status: 'succeeded' }));
+        expect(commitTerminalOutcome).toHaveBeenCalledWith({
+            jobId: 'job-1', docId: 'doc-1', expectedOwnerId: 'GUEST',
+            outcome: {
+                kind: 'succeeded', transcription: expect.stringContaining('よろしくお願いします'),
+                generatedByModel: expect.stringContaining('Azure'), speakers: 2,
+            },
+        });
+        expect(documentDb.data).toMatchObject({
+            status: 'completed', transcription: expect.stringContaining('よろしくお願いします'), title: '合成の文書',
+        });
+        expect(documentDb.jobData).toMatchObject({ status: 'succeeded', speakers: 2 });
+        expect(documentDb.runTransaction).toHaveBeenCalledTimes(1);
+        expect(updateTranscriptionJob).not.toHaveBeenCalled();
         expect(deleteBatchJob).toHaveBeenCalledTimes(1);
+        expect(documentDb.tx.set.mock.invocationCallOrder.at(-1)).toBeLessThan(vi.mocked(deleteBatchJob).mock.invocationCallOrder[0]);
     });
 
     it('🔴 Failed でも文書は消さず、理由を残して failed を返す（L2-D1 是正）', async () => {
@@ -204,12 +257,16 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const body = await res.json();
         expect(body.status).toBe('failed');
         expect(body.error).toContain('AudioLength');
-        expect(failTranscriptionDocument).toHaveBeenCalledTimes(1);
-        expect(failTranscriptionDocument).toHaveBeenCalledWith('doc-1', 'AudioLengthLimitExceeded', 'GUEST');
+        expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
+        expect(commitTerminalOutcome).toHaveBeenCalledWith({
+            jobId: 'job-1', docId: 'doc-1', expectedOwnerId: 'GUEST',
+            outcome: { kind: 'failed', reason: 'AudioLengthLimitExceeded' },
+        });
         expect(documentDb.data).toMatchObject({ status: 'failed', title: '合成の文書' });
         expect(documentDb.data?.transcription).toContain('AudioLengthLimitExceeded');
-        expect(completeTranscriptionDocument).not.toHaveBeenCalled();
-        expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'failed', error: 'AudioLengthLimitExceeded' });
+        expect(documentDb.jobData).toMatchObject({ status: 'failed', error: 'AudioLengthLimitExceeded' });
+        expect(updateTranscriptionJob).not.toHaveBeenCalled();
+        expect(deleteBatchJob).toHaveBeenCalledTimes(1);
     });
 
     it('🔴 既に succeeded のジョブは Azure を叩かず即返す（冪等・二重確定しない）', async () => {
@@ -217,7 +274,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
         expect(getBatchJob).not.toHaveBeenCalled();
-        expect(completeTranscriptionDocument).not.toHaveBeenCalled();
+        expect(commitTerminalOutcome).not.toHaveBeenCalled();
         expect(claimJobForFinalize).not.toHaveBeenCalled();
     });
 
@@ -247,7 +304,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
         expect(claimJobForFinalize).toHaveBeenCalledWith('job-1');
-        expect(completeTranscriptionDocument).toHaveBeenCalledTimes(1);
+        expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
     });
 
     it.each(['running', 'finalizing', 'succeeded', 'failed'] as const)(
@@ -285,7 +342,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         expect(await (await first).json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
         expect(getBatchJob).toHaveBeenCalledTimes(1);
         expect(fetchBatchResult).toHaveBeenCalledTimes(1);
-        expect(completeTranscriptionDocument).toHaveBeenCalledTimes(1);
+        expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
         expect(deleteBatchJob).toHaveBeenCalledTimes(1);
     });
 
@@ -302,10 +359,10 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect(res.status).toBe(502);
         expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'running' });
-        expect(failTranscriptionDocument).not.toHaveBeenCalled();
+        expect(commitTerminalOutcome).not.toHaveBeenCalled();
     });
 
-    it.each(['結果一覧取得', '結果 JSON 取得', '結果解析', 'Markdown 化', '文書保存'])(
+    it.each(['結果一覧取得', '結果 JSON 取得', '結果解析', 'Markdown 化'])(
         'Succeeded 後の%s失敗は理由付き failed にし、未取り込みの Azure 結果を残す', async (stage) => {
             vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
             vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
@@ -327,31 +384,52 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
                 vi.spyOn(finalization, 'buildTranscriptMarkdownFromBatch').mockImplementationOnce(() => {
                     throw new Error('合成の整形エラー');
                 });
-            } else {
-                documentDb.runTransaction.mockRejectedValueOnce(new Error('合成の保存エラー'));
             }
 
             const res = await statusPOST(req({ jobId: 'job-1' }));
             const reason = '文字起こし結果の取り込みに失敗しました。もう一度お試しください。';
             expect(res.status).toBe(200);
             expect(await res.json()).toEqual({ status: 'failed', docId: 'doc-1', error: reason });
-            expect(failTranscriptionDocument).toHaveBeenCalledWith('doc-1', reason, 'GUEST');
+            expect(commitTerminalOutcome).toHaveBeenCalledWith({
+                jobId: 'job-1', docId: 'doc-1', expectedOwnerId: 'GUEST', outcome: { kind: 'failed', reason },
+            });
             expect(documentDb.data).toMatchObject({ status: 'failed', title: '合成の文書' });
             expect(documentDb.data?.transcription).toContain(reason);
-            expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'failed', error: reason });
+            expect(documentDb.jobData).toMatchObject({ status: 'failed', error: reason });
+            expect(updateTranscriptionJob).not.toHaveBeenCalled();
             expect(deleteBatchJob).not.toHaveBeenCalled();
         },
     );
 
-    it('失敗理由の文書保存まで失敗してもジョブの終端化を試み、Azure 結果は削除しない', async () => {
-        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
-        vi.mocked(fetchBatchResult).mockRejectedValueOnce(new Error('合成の取得エラー'));
-        documentDb.runTransaction.mockRejectedValueOnce(new Error('合成の保存エラー'));
-        const res = await statusPOST(req({ jobId: 'job-1' }));
-        expect(res.status).toBe(502);
-        expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', expect.objectContaining({ status: 'failed' }));
-        expect(deleteBatchJob).not.toHaveBeenCalled();
-    });
+    it.each(['Succeeded', 'Failed', '取り込み失敗'] as const)(
+        '%s の終端 commit が失敗すると両方非終端に留まり、リース切れ後に本文を保存できる', async (stage) => {
+            vi.mocked(getBatchJob).mockResolvedValue({ status: stage === 'Failed' ? 'Failed' : 'Succeeded' });
+            vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
+            if (stage === '取り込み失敗') {
+                vi.mocked(fetchBatchResult).mockRejectedValueOnce(new Error('合成の取得エラー'));
+            }
+            const original = { ...documentDb.data };
+            documentDb.commitError = new Error('合成の commit エラー');
+            const res = await statusPOST(req({ jobId: 'job-1' }));
+            expect(res.status).toBe(502);
+            expect(documentDb.tx.set).toHaveBeenCalledTimes(2);
+            expect(documentDb.data).toEqual(original);
+            expect(documentDb.jobData).toEqual({ status: 'finalizing' });
+            expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
+            expect(updateTranscriptionJob).not.toHaveBeenCalled();
+            expect(deleteBatchJob).not.toHaveBeenCalled();
+
+            vi.mocked(getTranscriptionJob).mockResolvedValueOnce({
+                ...runningJob, status: 'finalizing', updatedAtMs: Date.now() - FINALIZE_LEASE_MS - 1,
+            });
+            vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+            const retried = await statusPOST(req({ jobId: 'job-1' }));
+            expect(await retried.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+            expect(documentDb.data).toMatchObject({ status: 'completed', transcription: expect.stringContaining('よろしくお願いします') });
+            expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
+            expect(deleteBatchJob).toHaveBeenCalledTimes(1);
+        },
+    );
 
     it.each(['Succeeded', 'Failed'] as const)('利用者が削除した文書を Azure %s で復活させない', async (status) => {
         documentDb.data = undefined;
@@ -360,9 +438,52 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect((await res.json()).status).toBe(status === 'Succeeded' ? 'succeeded' : 'failed');
         expect(documentDb.data).toBeUndefined();
-        expect(documentDb.tx.set).not.toHaveBeenCalled();
+        expect(documentDb.tx.set).toHaveBeenCalledTimes(1);
+        expect(documentDb.tx.set).toHaveBeenCalledWith(documentDb.jobRef, expect.objectContaining({
+            status: status === 'Succeeded' ? 'succeeded' : 'failed',
+        }), { merge: true });
+        expect(deleteBatchJob).toHaveBeenCalledTimes(1);
         expect(documentDb.warn).toHaveBeenCalled();
     });
+
+    it.each(['Succeeded', 'Failed', '取り込み失敗'] as const)(
+        '%s の commit が not_owner なら最新の失敗理由を返し、文書更新も Azure 削除もしない', async (stage) => {
+            const reason = '別リクエストが確定した合成の失敗理由';
+            documentDb.jobData = { status: 'failed', error: reason };
+            vi.mocked(getTranscriptionJob)
+                .mockResolvedValueOnce(runningJob)
+                .mockResolvedValueOnce({ ...runningJob, status: 'failed', error: reason });
+            vi.mocked(getBatchJob).mockResolvedValue({ status: stage === 'Failed' ? 'Failed' : 'Succeeded' });
+            vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
+            if (stage === '取り込み失敗') {
+                vi.mocked(fetchBatchResult).mockRejectedValueOnce(new Error('合成の取得エラー'));
+            }
+            const res = await statusPOST(req({ jobId: 'job-1' }));
+            expect(await res.json()).toEqual({ status: 'failed', docId: 'doc-1', error: reason });
+            expect(commitTerminalOutcome).toHaveResolvedWith('not_owner');
+            expect(getTranscriptionJob).toHaveBeenCalledTimes(2);
+            expect(documentDb.tx.set).not.toHaveBeenCalled();
+            expect(updateTranscriptionJob).not.toHaveBeenCalled();
+            expect(deleteBatchJob).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each(['running', 'finalizing', 'succeeded', 'deleted'] as const)(
+        'commit 権を失った後の現在状態 %s を返す', async (status) => {
+            // commit の時点では running に戻っていて、再読込時に次の処理が進んでいる場合も含む。
+            documentDb.jobData = status === 'deleted' ? undefined : { status: 'running' };
+            vi.mocked(getTranscriptionJob)
+                .mockResolvedValueOnce(runningJob)
+                .mockResolvedValueOnce(status === 'deleted' ? null : { ...runningJob, status });
+            vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+            vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
+            const res = await statusPOST(req({ jobId: 'job-1' }));
+            if (status === 'deleted') expect(res.status).toBe(404);
+            else expect(await res.json()).toEqual({ status: status === 'finalizing' ? 'running' : status, docId: 'doc-1' });
+            expect(documentDb.tx.set).not.toHaveBeenCalled();
+            expect(deleteBatchJob).not.toHaveBeenCalled();
+        },
+    );
 
     it('他人のジョブは 403', async () => {
         vi.mocked(getTranscriptionJob).mockResolvedValue({ ...runningJob, ownerId: 'someuser', ownerType: 'user' });
@@ -378,21 +499,26 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
 });
 
 describe.each(['completed', 'failed'] as const)('文書を %s にする際のトランザクション', (terminalStatus) => {
-    const finalizeDocument = () => terminalStatus === 'completed'
-        ? completeTranscriptionDocument('doc-1', '合成の文字起こし本文', '合成のモデル', 'GUEST')
-        : failTranscriptionDocument('doc-1', '合成の失敗理由', 'GUEST');
+    const finalizeDocument = () => commitTerminalOutcome({
+        jobId: 'job-1', docId: 'doc-1', expectedOwnerId: 'GUEST',
+        outcome: terminalStatus === 'completed'
+            ? { kind: 'succeeded', transcription: '合成の文字起こし本文', generatedByModel: '合成のモデル', speakers: 2 }
+            : { kind: 'failed', reason: '合成の失敗理由' },
+    });
 
     it('所有者が一致する processing のみ更新し、再確定で本文を上書きしない', async () => {
-        await finalizeDocument();
+        await expect(finalizeDocument()).resolves.toBe('committed');
         expect(documentDb.runTransaction).toHaveBeenCalledTimes(1);
+        expect(documentDb.tx.get).toHaveBeenCalledWith(documentDb.jobRef);
         expect(documentDb.tx.get).toHaveBeenCalledWith(documentDb.ref);
         expect(documentDb.tx.set).toHaveBeenCalledWith(documentDb.ref, expect.objectContaining({
             status: terminalStatus,
         }), { merge: true });
         expect(documentDb.data).toMatchObject({ status: terminalStatus, ownerId: 'GUEST', title: '合成の文書' });
         const saved = { ...documentDb.data };
-        await finalizeDocument();
-        expect(documentDb.tx.set).toHaveBeenCalledTimes(1);
+        expect(documentDb.jobData).toMatchObject({ status: terminalStatus === 'completed' ? 'succeeded' : 'failed' });
+        await expect(finalizeDocument()).resolves.toBe('not_owner');
+        expect(documentDb.tx.set).toHaveBeenCalledTimes(2);
         expect(documentDb.data).toEqual(saved);
     });
 
@@ -402,12 +528,64 @@ describe.each(['completed', 'failed'] as const)('文書を %s にする際のト
             else if (state === 'other-owner') documentDb.data = { ...documentDb.data, ownerId: 'synthetic-other-owner' };
             else documentDb.data = { ...documentDb.data, status: state === 'missing-status' ? undefined : state };
             const before = documentDb.data === undefined ? undefined : { ...documentDb.data };
-            await finalizeDocument();
+            await expect(finalizeDocument()).resolves.toBe('committed');
             expect(documentDb.runTransaction).toHaveBeenCalledTimes(1);
             expect(documentDb.tx.get).toHaveBeenCalledWith(documentDb.ref);
-            expect(documentDb.tx.set).not.toHaveBeenCalled();
+            expect(documentDb.tx.set).toHaveBeenCalledTimes(1);
+            expect(documentDb.tx.set).toHaveBeenCalledWith(documentDb.jobRef, expect.objectContaining({
+                status: terminalStatus === 'completed' ? 'succeeded' : 'failed',
+            }), { merge: true });
             expect(documentDb.data).toEqual(before);
             expect(documentDb.warn).toHaveBeenCalled();
         },
     );
+});
+
+describe('処理中の文書の読取・復元とバッチ確定', () => {
+    const readers = [
+        ['getTranscriptionDocuments', () => getTranscriptionDocuments()],
+        ['getTranscriptions', () => getTranscriptions()],
+        ['getTranscriptionsByOwnerId', () => getTranscriptionsByOwnerId('GUEST')],
+    ] as const;
+
+    it.each(readers)('%s は status を読取り、復元 payload と確定処理まで保持する', async (_name, read) => {
+        clientDb.getDocs.mockResolvedValue({
+            forEach: (fn: (snapshot: { id: string; data: () => Record<string, unknown> }) => void) => fn({
+                id: 'doc-1',
+                data: () => ({
+                    ...documentDb.data, fileName: 'synthetic.mp3', promptName: '合成プロンプト',
+                    originalFileType: 'audio', ownerType: 'guest',
+                }),
+            }),
+        });
+        const [document] = await read();
+        expect(document.status).toBe('processing');
+        const source = { ...document, text: 'text' in document ? document.text : document.transcription };
+        documentDb.data = undefined;
+        await restoreTranscription('doc-1', source, { title: '合成の復元文書' });
+        expect(clientDb.tx.set).toHaveBeenCalledWith(documentDb.ref, expect.objectContaining({
+            status: 'processing', title: '合成の復元文書', transcription: '処理中',
+        }), { merge: true });
+        await expect(commitTerminalOutcome({
+            jobId: 'job-1', docId: 'doc-1', expectedOwnerId: 'GUEST',
+            outcome: { kind: 'succeeded', transcription: '復元後の合成本文', generatedByModel: '合成モデル', speakers: 1 },
+        })).resolves.toBe('committed');
+        expect(documentDb.data).toMatchObject({ status: 'completed', transcription: '復元後の合成本文' });
+        expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
+    });
+
+    it.each(readers)('%s は旧文書の status を undefined として読み、復元 payload に追加しない', async (_name, read) => {
+        clientDb.getDocs.mockResolvedValue({
+            forEach: (fn: (snapshot: { id: string; data: () => Record<string, unknown> }) => void) => fn({
+                id: 'doc-1', data: () => ({ title: '合成の旧文書', fileName: 'synthetic.mp3', transcription: '合成本文' }),
+            }),
+        });
+        const [document] = await read();
+        expect(document.status).toBeUndefined();
+        const source = { ...document, text: 'text' in document ? document.text : document.transcription };
+        documentDb.data = undefined;
+        await restoreTranscription('doc-1', source, {});
+        expect(clientDb.tx.set).toHaveBeenCalledTimes(1);
+        expect(clientDb.tx.set.mock.calls[0][1]).not.toHaveProperty('status');
+    });
 });

--- a/src/app/api/transcribe/batch.contract.test.ts
+++ b/src/app/api/transcribe/batch.contract.test.ts
@@ -7,10 +7,27 @@
  *    **実物のまま**通し、「submit が実際に submitBatchJob と文書作成とジョブ作成を呼ぶ」
  *    「status が Succeeded で確定処理を最後まで配線している」ことを錠にする。
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AzureBatchResult } from '@/lib/azureBatchContract';
 
+const documentDb = vi.hoisted(() => ({
+    data: undefined as Record<string, unknown> | undefined,
+    ref: { id: 'doc-1' },
+    tx: { get: vi.fn(), set: vi.fn() },
+    runTransaction: vi.fn(),
+    warn: vi.fn(),
+}));
+
 // --- 外界の I/O だけモック（純関数は実物のまま） ---
+vi.mock('@/server/firebaseAdmin', () => ({
+    getAdminFirestore: () => ({
+        collection: () => ({ doc: () => documentDb.ref }),
+        runTransaction: documentDb.runTransaction,
+    }),
+}));
+vi.mock('@/lib/logger', () => ({
+    createLogger: () => ({ info: vi.fn(), warn: documentDb.warn, error: vi.fn(), debug: vi.fn() }),
+}));
 vi.mock('@/server/auth', () => ({
     GUEST_OWNER_ID: 'GUEST',
     resolveRequestSubject: vi.fn(),
@@ -32,12 +49,18 @@ vi.mock('@/server/azureBatchTranscribe', async (importActual) => ({
     fetchBatchResult: vi.fn(),
     deleteBatchJob: vi.fn(async () => undefined),
 }));
-vi.mock('@/server/transcriptionDocument', () => ({
-    createProcessingDocument: vi.fn(async () => 'doc-1'),
-    completeTranscriptionDocument: vi.fn(async () => undefined),
-    failTranscriptionDocument: vi.fn(async () => undefined),
-}));
+vi.mock('@/server/transcriptionDocument', async (importActual) => {
+    const actual = await importActual<typeof import('@/server/transcriptionDocument')>();
+    return {
+        ...actual,
+        createProcessingDocument: vi.fn(async () => 'doc-1'),
+        completeTranscriptionDocument: vi.fn(actual.completeTranscriptionDocument),
+        failTranscriptionDocument: vi.fn(actual.failTranscriptionDocument),
+    };
+});
 vi.mock('@/server/transcriptionJob', () => ({
+    FINALIZE_LEASE_MS: 3 * 60 * 1000,
+    claimJobForFinalize: vi.fn(),
     createTranscriptionJob: vi.fn(async () => 'job-1'),
     getTranscriptionJob: vi.fn(),
     updateTranscriptionJob: vi.fn(async () => undefined),
@@ -46,9 +69,11 @@ vi.mock('@/server/transcriptionJob', () => ({
 import { POST as submitPOST } from './submit/route';
 import { POST as statusPOST } from './status/route';
 import { resolveRequestSubject } from '@/server/auth';
-import { submitBatchJob, getBatchJob, fetchBatchResult, deleteBatchJob } from '@/server/azureBatchTranscribe';
+import { submitBatchJob, getAzureCredentials, getBatchJob, fetchBatchResult, deleteBatchJob } from '@/server/azureBatchTranscribe';
+import { getSignedReadUrl } from '@/server/mediaSource';
 import { createProcessingDocument, completeTranscriptionDocument, failTranscriptionDocument } from '@/server/transcriptionDocument';
-import { createTranscriptionJob, getTranscriptionJob, updateTranscriptionJob } from '@/server/transcriptionJob';
+import { claimJobForFinalize, FINALIZE_LEASE_MS, createTranscriptionJob, getTranscriptionJob, updateTranscriptionJob } from '@/server/transcriptionJob';
+import * as finalization from '@/server/finalizeTranscription';
 
 const guest = { kind: 'guest' as const };
 const req = (body: unknown) => new Request('http://t/api', { method: 'POST', body: JSON.stringify(body) });
@@ -65,6 +90,20 @@ const sampleAzureResult = (): AzureBatchResult => ({
 beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(resolveRequestSubject).mockResolvedValue(guest);
+    documentDb.data = { ownerId: 'GUEST', status: 'processing', title: '合成の文書', transcription: '処理中' };
+    documentDb.tx.get.mockImplementation(async () => ({
+        exists: documentDb.data !== undefined,
+        data: () => documentDb.data,
+    }));
+    documentDb.tx.set.mockImplementation((_ref, patch) => {
+        documentDb.data = { ...documentDb.data, ...patch };
+    });
+    documentDb.runTransaction.mockImplementation(async (fn) => fn(documentDb.tx));
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
 });
 
 describe('POST /api/transcribe/submit（実ルートの配線）', () => {
@@ -99,6 +138,11 @@ describe('POST /api/transcribe/submit（実ルートの配線）', () => {
         expect(submitBatchJob).not.toHaveBeenCalled();
     });
 
+    it('Azure の待機・再試行中も音源を取得できるよう署名 URL は24時間有効にする', async () => {
+        await submitPOST(req(validBody));
+        expect(getSignedReadUrl).toHaveBeenCalledWith(validBody.storagePath, 24 * 60 * 60 * 1000);
+    });
+
     it('音声長が 240 分超は 400（提出しない）', async () => {
         const res = await submitPOST(req({ ...validBody, audioSec: 241 * 60 }));
         expect(res.status).toBe(400);
@@ -120,12 +164,19 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         promptName: 'p', createdAtMs: 0, updatedAtMs: 0,
     };
 
+    beforeEach(() => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue(runningJob);
+        vi.mocked(claimJobForFinalize).mockResolvedValue({ ...runningJob, status: 'finalizing', updatedAtMs: Date.now() });
+    });
+
     it('Azure が Running のうちは文書を確定しない', async () => {
         vi.mocked(getTranscriptionJob).mockResolvedValue(runningJob);
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Running' });
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect(await res.json()).toEqual({ status: 'running', docId: 'doc-1' });
         expect(completeTranscriptionDocument).not.toHaveBeenCalled();
+        expect(claimJobForFinalize).toHaveBeenCalledWith('job-1');
+        expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'running' });
     });
 
     it('🔴 Succeeded で結果取得→Markdown化→文書完成→ジョブ更新→Azure削除まで貫通する', async () => {
@@ -136,10 +187,12 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
         expect(completeTranscriptionDocument).toHaveBeenCalledTimes(1);
         // 実の buildTranscriptMarkdownFromBatch を通した本文が入る（話者ラベル＋時刻）
-        const [docId, markdown, model] = vi.mocked(completeTranscriptionDocument).mock.calls[0];
+        const [docId, markdown, model, expectedOwnerId] = vi.mocked(completeTranscriptionDocument).mock.calls[0];
         expect(docId).toBe('doc-1');
         expect(markdown).toContain('よろしくお願いします');
         expect(model).toContain('Azure');
+        expect(expectedOwnerId).toBe('GUEST');
+        expect(documentDb.data).toMatchObject({ status: 'completed', transcription: markdown, title: '合成の文書' });
         expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', expect.objectContaining({ status: 'succeeded' }));
         expect(deleteBatchJob).toHaveBeenCalledTimes(1);
     });
@@ -152,7 +205,11 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         expect(body.status).toBe('failed');
         expect(body.error).toContain('AudioLength');
         expect(failTranscriptionDocument).toHaveBeenCalledTimes(1);
+        expect(failTranscriptionDocument).toHaveBeenCalledWith('doc-1', 'AudioLengthLimitExceeded', 'GUEST');
+        expect(documentDb.data).toMatchObject({ status: 'failed', title: '合成の文書' });
+        expect(documentDb.data?.transcription).toContain('AudioLengthLimitExceeded');
         expect(completeTranscriptionDocument).not.toHaveBeenCalled();
+        expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'failed', error: 'AudioLengthLimitExceeded' });
     });
 
     it('🔴 既に succeeded のジョブは Azure を叩かず即返す（冪等・二重確定しない）', async () => {
@@ -161,6 +218,150 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
         expect(getBatchJob).not.toHaveBeenCalled();
         expect(completeTranscriptionDocument).not.toHaveBeenCalled();
+        expect(claimJobForFinalize).not.toHaveBeenCalled();
+    });
+
+    it('既に failed のジョブは理由を返し、再確定も文書削除もしない', async () => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue({ ...runningJob, status: 'failed', error: '合成の失敗理由' });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual({ status: 'failed', docId: 'doc-1', error: '合成の失敗理由' });
+        expect(claimJobForFinalize).not.toHaveBeenCalled();
+        expect(getBatchJob).not.toHaveBeenCalled();
+        expect(documentDb.tx.set).not.toHaveBeenCalled();
+    });
+
+    it('有効な finalizing リースは公開 running として返す', async () => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue({ ...runningJob, status: 'finalizing', updatedAtMs: Date.now() });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual({ status: 'running', docId: 'doc-1' });
+        expect(claimJobForFinalize).not.toHaveBeenCalled();
+        expect(getBatchJob).not.toHaveBeenCalled();
+    });
+
+    it('クラッシュで期限切れの finalizing リースを取り直して確定する', async () => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue({
+            ...runningJob, status: 'finalizing', updatedAtMs: Date.now() - FINALIZE_LEASE_MS - 1,
+        });
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+        vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(claimJobForFinalize).toHaveBeenCalledWith('job-1');
+        expect(completeTranscriptionDocument).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(['running', 'finalizing', 'succeeded', 'failed'] as const)(
+        '確定権を取れなければ最新の %s を読み直して返す', async (status) => {
+            vi.mocked(claimJobForFinalize).mockResolvedValue(null);
+            const error = status === 'failed' ? { error: '合成の失敗理由' } : {};
+            vi.mocked(getTranscriptionJob)
+                .mockResolvedValueOnce(runningJob)
+                .mockResolvedValueOnce({ ...runningJob, status, ...error });
+            const res = await statusPOST(req({ jobId: 'job-1' }));
+            expect(await res.json()).toEqual({ status: status === 'finalizing' ? 'running' : status, docId: 'doc-1', ...error });
+            expect(getTranscriptionJob).toHaveBeenCalledTimes(2);
+            expect(getBatchJob).not.toHaveBeenCalled();
+            expect(documentDb.tx.set).not.toHaveBeenCalled();
+        },
+    );
+
+    it('並行 poll でも確定権を得た1リクエストだけが結果を保存・削除する', async () => {
+        let signalStarted!: () => void;
+        const started = new Promise<void>((resolve) => { signalStarted = resolve; });
+        let releaseAzure!: () => void;
+        vi.mocked(getBatchJob).mockImplementationOnce(() => {
+            signalStarted();
+            return new Promise((resolve) => { releaseAzure = () => resolve({ status: 'Succeeded' }); });
+        });
+        vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
+        vi.mocked(claimJobForFinalize)
+            .mockResolvedValueOnce({ ...runningJob, status: 'finalizing', updatedAtMs: Date.now() })
+            .mockResolvedValueOnce(null);
+        const first = statusPOST(req({ jobId: 'job-1' }));
+        await started;
+        const second = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await second.json()).toEqual({ status: 'running', docId: 'doc-1' });
+        releaseAzure();
+        expect(await (await first).json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(getBatchJob).toHaveBeenCalledTimes(1);
+        expect(fetchBatchResult).toHaveBeenCalledTimes(1);
+        expect(completeTranscriptionDocument).toHaveBeenCalledTimes(1);
+        expect(deleteBatchJob).toHaveBeenCalledTimes(1);
+    });
+
+    it('Azure 設定がなくなっても running に戻して再試行できる', async () => {
+        vi.mocked(getAzureCredentials).mockReturnValueOnce(null);
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual({ status: 'running', docId: 'doc-1' });
+        expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'running' });
+        expect(getBatchJob).not.toHaveBeenCalled();
+    });
+
+    it('Azure 状態照会の通信失敗は確定権を解放してからエラーを返す', async () => {
+        vi.mocked(getBatchJob).mockRejectedValueOnce(new Error('合成の通信障害'));
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(res.status).toBe(502);
+        expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'running' });
+        expect(failTranscriptionDocument).not.toHaveBeenCalled();
+    });
+
+    it.each(['結果一覧取得', '結果 JSON 取得', '結果解析', 'Markdown 化', '文書保存'])(
+        'Succeeded 後の%s失敗は理由付き failed にし、未取り込みの Azure 結果を残す', async (stage) => {
+            vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+            vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
+            if (stage === '結果一覧取得' || stage === '結果 JSON 取得') {
+                const actual = await vi.importActual<typeof import('@/server/azureBatchTranscribe')>('@/server/azureBatchTranscribe');
+                vi.mocked(fetchBatchResult).mockImplementationOnce(actual.fetchBatchResult);
+                const fetchMock = vi.fn();
+                if (stage === '結果一覧取得') {
+                    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 503 }));
+                } else {
+                    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+                        values: [{ kind: 'Transcription', links: { contentUrl: 'https://result.example/synthetic.json' } }],
+                    }), { status: 200 })).mockResolvedValueOnce(new Response('invalid json', { status: 200 }));
+                }
+                vi.stubGlobal('fetch', fetchMock);
+            } else if (stage === '結果解析') {
+                vi.mocked(fetchBatchResult).mockResolvedValueOnce(null as unknown as AzureBatchResult);
+            } else if (stage === 'Markdown 化') {
+                vi.spyOn(finalization, 'buildTranscriptMarkdownFromBatch').mockImplementationOnce(() => {
+                    throw new Error('合成の整形エラー');
+                });
+            } else {
+                documentDb.runTransaction.mockRejectedValueOnce(new Error('合成の保存エラー'));
+            }
+
+            const res = await statusPOST(req({ jobId: 'job-1' }));
+            const reason = '文字起こし結果の取り込みに失敗しました。もう一度お試しください。';
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ status: 'failed', docId: 'doc-1', error: reason });
+            expect(failTranscriptionDocument).toHaveBeenCalledWith('doc-1', reason, 'GUEST');
+            expect(documentDb.data).toMatchObject({ status: 'failed', title: '合成の文書' });
+            expect(documentDb.data?.transcription).toContain(reason);
+            expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'failed', error: reason });
+            expect(deleteBatchJob).not.toHaveBeenCalled();
+        },
+    );
+
+    it('失敗理由の文書保存まで失敗してもジョブの終端化を試み、Azure 結果は削除しない', async () => {
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+        vi.mocked(fetchBatchResult).mockRejectedValueOnce(new Error('合成の取得エラー'));
+        documentDb.runTransaction.mockRejectedValueOnce(new Error('合成の保存エラー'));
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(res.status).toBe(502);
+        expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', expect.objectContaining({ status: 'failed' }));
+        expect(deleteBatchJob).not.toHaveBeenCalled();
+    });
+
+    it.each(['Succeeded', 'Failed'] as const)('利用者が削除した文書を Azure %s で復活させない', async (status) => {
+        documentDb.data = undefined;
+        vi.mocked(getBatchJob).mockResolvedValue({ status });
+        vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect((await res.json()).status).toBe(status === 'Succeeded' ? 'succeeded' : 'failed');
+        expect(documentDb.data).toBeUndefined();
+        expect(documentDb.tx.set).not.toHaveBeenCalled();
+        expect(documentDb.warn).toHaveBeenCalled();
     });
 
     it('他人のジョブは 403', async () => {
@@ -174,4 +375,39 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const res = await statusPOST(req({ jobId: 'nope' }));
         expect(res.status).toBe(404);
     });
+});
+
+describe.each(['completed', 'failed'] as const)('文書を %s にする際のトランザクション', (terminalStatus) => {
+    const finalizeDocument = () => terminalStatus === 'completed'
+        ? completeTranscriptionDocument('doc-1', '合成の文字起こし本文', '合成のモデル', 'GUEST')
+        : failTranscriptionDocument('doc-1', '合成の失敗理由', 'GUEST');
+
+    it('所有者が一致する processing のみ更新し、再確定で本文を上書きしない', async () => {
+        await finalizeDocument();
+        expect(documentDb.runTransaction).toHaveBeenCalledTimes(1);
+        expect(documentDb.tx.get).toHaveBeenCalledWith(documentDb.ref);
+        expect(documentDb.tx.set).toHaveBeenCalledWith(documentDb.ref, expect.objectContaining({
+            status: terminalStatus,
+        }), { merge: true });
+        expect(documentDb.data).toMatchObject({ status: terminalStatus, ownerId: 'GUEST', title: '合成の文書' });
+        const saved = { ...documentDb.data };
+        await finalizeDocument();
+        expect(documentDb.tx.set).toHaveBeenCalledTimes(1);
+        expect(documentDb.data).toEqual(saved);
+    });
+
+    it.each(['deleted', 'other-owner', 'completed', 'failed', 'edited', 'missing-status'])(
+        '%s の文書は変更せず警告する', async (state) => {
+            if (state === 'deleted') documentDb.data = undefined;
+            else if (state === 'other-owner') documentDb.data = { ...documentDb.data, ownerId: 'synthetic-other-owner' };
+            else documentDb.data = { ...documentDb.data, status: state === 'missing-status' ? undefined : state };
+            const before = documentDb.data === undefined ? undefined : { ...documentDb.data };
+            await finalizeDocument();
+            expect(documentDb.runTransaction).toHaveBeenCalledTimes(1);
+            expect(documentDb.tx.get).toHaveBeenCalledWith(documentDb.ref);
+            expect(documentDb.tx.set).not.toHaveBeenCalled();
+            expect(documentDb.data).toEqual(before);
+            expect(documentDb.warn).toHaveBeenCalled();
+        },
+    );
 });

--- a/src/app/api/transcribe/status/route.ts
+++ b/src/app/api/transcribe/status/route.ts
@@ -2,7 +2,7 @@
  * POST /api/transcribe/status — 非同期バッチの**状態確認と確定**（設計 §3.7 改訂・2026-09-05）。
  *
  * クライアントが時々叩く。Azure が完了していれば、この短命関数が**その場で確定処理**する
- * （結果取得 → Markdown 化 → 文書更新 → ジョブ更新 → Azure ジョブ削除）。
+ * （結果取得 → Markdown 化 → 文書とジョブを原子的に更新 → Azure ジョブ削除）。
  * 🔴 webhook が無くても poll だけで完結する（Hobby でも堅牢）。確定は job.status で冪等。
  */
 import { createLogger } from '@/lib/logger';
@@ -23,9 +23,9 @@ import {
     parseBatchResult,
 } from '@/server/azureBatchTranscribe';
 import { buildTranscriptMarkdownFromBatch, describeBatchModel } from '@/server/finalizeTranscription';
-import { completeTranscriptionDocument, failTranscriptionDocument } from '@/server/transcriptionDocument';
 import {
     claimJobForFinalize,
+    commitTerminalOutcome,
     FINALIZE_LEASE_MS,
     getTranscriptionJob,
     updateTranscriptionJob,
@@ -61,8 +61,8 @@ export function validateStatusBody(raw: unknown): TranscribeStatusRequest {
 
 /**
  * Azure が終端に達していれば確定処理（呼び出し側が CAS で確定権を取得済み）。
- * 成功: 結果 → Markdown → 文書完成 → ジョブ succeeded → Azure ジョブ削除。
- * 失敗: 文書に理由を残す → ジョブ failed → Azure ジョブ削除。
+ * 成功: 結果 → Markdown → 文書とジョブを原子的に確定 → Azure ジョブ削除。
+ * 失敗: 文書に理由を残してジョブと原子的に確定。取り込み失敗では Azure の結果を残す。
  * 未完: ジョブを running に戻し、次の poll で再確認する。
  */
 async function finalizeIfTerminal(job: TranscriptionJob): Promise<TranscribeJobPublicStatusInternal> {
@@ -85,31 +85,46 @@ async function finalizeIfTerminal(job: TranscriptionJob): Promise<TranscribeJobP
     }
     if (state.status === 'Failed') {
         const reason = state.error ?? 'Azure 側で処理に失敗しました。';
-        await failTranscriptionDocument(job.docId, reason, job.ownerId);
-        await updateTranscriptionJob(job.id, { status: 'failed', error: reason });
+        const committed = await commitTerminalOutcome({
+            jobId: job.id,
+            docId: job.docId,
+            expectedOwnerId: job.ownerId,
+            outcome: { kind: 'failed', reason },
+        });
+        if (committed === 'not_owner') return getCurrentPublicStatus(job.id);
         await deleteBatchJob(job.azureSelfUrl, credentials);
         return { status: 'failed', docId: job.docId, error: reason };
     }
     // Succeeded
     let parsed: ReturnType<typeof parseBatchResult>;
     let markdown: string;
+    let generatedByModel: string;
     try {
         const result = await fetchBatchResult(job.azureSelfUrl, credentials);
         parsed = parseBatchResult(result);
         markdown = buildTranscriptMarkdownFromBatch(parsed);
-        await completeTranscriptionDocument(job.docId, markdown, describeBatchModel(parsed), job.ownerId);
+        generatedByModel = describeBatchModel(parsed);
     } catch {
         const reason = '文字起こし結果の取り込みに失敗しました。もう一度お試しください。';
         logger.warn('文字起こし結果の取り込みに失敗', { jobId: job.id });
-        try {
-            await failTranscriptionDocument(job.docId, reason, job.ownerId);
-        } finally {
-            await updateTranscriptionJob(job.id, { status: 'failed', error: reason });
-        }
+        const committed = await commitTerminalOutcome({
+            jobId: job.id,
+            docId: job.docId,
+            expectedOwnerId: job.ownerId,
+            outcome: { kind: 'failed', reason },
+        });
+        if (committed === 'not_owner') return getCurrentPublicStatus(job.id);
         // 未取り込みの結果は削除せず、Azure 側の TTL に任せる。
         return { status: 'failed', docId: job.docId, error: reason };
     }
-    await updateTranscriptionJob(job.id, { status: 'succeeded', speakers: parsed.speakers });
+    // 保存失敗は取り込み失敗として確定せず、finalizing のリース切れ後に再試行する。
+    const committed = await commitTerminalOutcome({
+        jobId: job.id,
+        docId: job.docId,
+        expectedOwnerId: job.ownerId,
+        outcome: { kind: 'succeeded', transcription: markdown, generatedByModel, speakers: parsed.speakers },
+    });
+    if (committed === 'not_owner') return getCurrentPublicStatus(job.id);
     await deleteBatchJob(job.azureSelfUrl, credentials);
     logger.info('文字起こしを確定', { jobId: job.id, speakers: parsed.speakers, chars: markdown.length });
     return { status: 'succeeded', docId: job.docId };
@@ -119,6 +134,16 @@ interface TranscribeJobPublicStatusInternal {
     status: 'running' | 'succeeded' | 'failed';
     docId: string;
     error?: string;
+}
+
+async function getCurrentPublicStatus(jobId: string): Promise<TranscribeJobPublicStatusInternal> {
+    const current = await getTranscriptionJob(jobId);
+    if (!current) throw new GenerateApiError('media_not_found', '文字起こしジョブが見つかりません。');
+    return {
+        status: current.status === 'finalizing' ? 'running' : current.status,
+        docId: current.docId,
+        ...(current.error ? { error: current.error } : {}),
+    };
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/src/app/api/transcribe/status/route.ts
+++ b/src/app/api/transcribe/status/route.ts
@@ -1,0 +1,143 @@
+/**
+ * POST /api/transcribe/status — 非同期バッチの**状態確認と確定**（設計 §3.7 改訂・2026-09-05）。
+ *
+ * クライアントが時々叩く。Azure が完了していれば、この短命関数が**その場で確定処理**する
+ * （結果取得 → Markdown 化 → 文書更新 → ジョブ更新 → Azure ジョブ削除）。
+ * 🔴 webhook が無くても poll だけで完結する（Hobby でも堅牢）。確定は job.status で冪等。
+ */
+import { createLogger } from '@/lib/logger';
+import type {
+    TranscribeStatusRequest,
+    TranscribeStatusResponse,
+    TranscribeBatchErrorBody,
+} from '@/lib/transcribeBatchContract';
+import { isTerminalBatchStatus } from '@/lib/azureBatchContract';
+import { resolveRequestSubject } from '@/server/auth';
+import { GenerateApiError } from '@/server/errors';
+import { isOwnedBySubject } from '@/server/mediaSource';
+import {
+    getAzureCredentials,
+    getBatchJob,
+    fetchBatchResult,
+    deleteBatchJob,
+    parseBatchResult,
+} from '@/server/azureBatchTranscribe';
+import { buildTranscriptMarkdownFromBatch, describeBatchModel } from '@/server/finalizeTranscription';
+import { completeTranscriptionDocument, failTranscriptionDocument } from '@/server/transcriptionDocument';
+import {
+    getTranscriptionJob,
+    updateTranscriptionJob,
+    type TranscriptionJob,
+} from '@/server/transcriptionJob';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+export const dynamic = 'force-dynamic';
+
+const logger = createLogger('api/transcribe/status');
+
+const jsonResponse = (body: unknown, status: number): Response =>
+    new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
+    });
+
+const errorResponse = (error: GenerateApiError): Response =>
+    jsonResponse({ error: error.code, message: error.message } satisfies TranscribeBatchErrorBody, error.status);
+
+const invalid = (message: string): GenerateApiError => new GenerateApiError('invalid_request', message);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export function validateStatusBody(raw: unknown): TranscribeStatusRequest {
+    if (!isRecord(raw) || typeof raw.jobId !== 'string' || !raw.jobId) {
+        throw invalid('ジョブ ID がありません。ページを再読み込みしてください。');
+    }
+    return { jobId: raw.jobId };
+}
+
+/**
+ * Azure が終端に達していれば確定処理。冪等（呼び出し側が job.status を running と確認済み）。
+ * 成功: 結果 → Markdown → 文書完成 → ジョブ succeeded → Azure ジョブ削除。
+ * 失敗: 文書に理由を残す → ジョブ failed → Azure ジョブ削除。
+ * 未完: 何もしない。
+ */
+async function finalizeIfTerminal(job: TranscriptionJob): Promise<TranscribeJobPublicStatusInternal> {
+    const credentials = getAzureCredentials();
+    if (!credentials) {
+        // 設定が消えた等。ジョブは running のまま（設定を直せば次の poll で進む）。
+        return { status: 'running', docId: job.docId };
+    }
+    const state = await getBatchJob(job.azureSelfUrl, credentials);
+    if (!isTerminalBatchStatus(state.status)) {
+        return { status: 'running', docId: job.docId };
+    }
+    if (state.status === 'Failed') {
+        const reason = state.error ?? 'Azure 側で処理に失敗しました。';
+        await failTranscriptionDocument(job.docId, reason);
+        await updateTranscriptionJob(job.id, { status: 'failed', error: reason });
+        await deleteBatchJob(job.azureSelfUrl, credentials);
+        return { status: 'failed', docId: job.docId, error: reason };
+    }
+    // Succeeded
+    const result = await fetchBatchResult(job.azureSelfUrl, credentials);
+    const parsed = parseBatchResult(result);
+    const markdown = buildTranscriptMarkdownFromBatch(parsed);
+    await completeTranscriptionDocument(job.docId, markdown, describeBatchModel(parsed));
+    await updateTranscriptionJob(job.id, { status: 'succeeded', speakers: parsed.speakers });
+    await deleteBatchJob(job.azureSelfUrl, credentials);
+    logger.info('文字起こしを確定', { jobId: job.id, speakers: parsed.speakers, chars: markdown.length });
+    return { status: 'succeeded', docId: job.docId };
+}
+
+interface TranscribeJobPublicStatusInternal {
+    status: 'running' | 'succeeded' | 'failed';
+    docId: string;
+    error?: string;
+}
+
+export async function POST(request: Request): Promise<Response> {
+    try {
+        const body = validateStatusBody(await request.json().catch(() => {
+            throw invalid('リクエストの本文を読み取れませんでした。');
+        }));
+        const subject = await resolveRequestSubject(request.headers);
+
+        const job = await getTranscriptionJob(body.jobId);
+        if (!job) throw new GenerateApiError('media_not_found', '文字起こしジョブが見つかりません。');
+        if (!isOwnedBySubject(job.ownerId, subject)) {
+            throw new GenerateApiError('forbidden', 'このジョブを参照する権限がありません。');
+        }
+
+        // 既に確定済みなら Azure を叩かずそのまま返す（冪等・二重確定しない）
+        if (job.status !== 'running') {
+            const response: TranscribeStatusResponse = {
+                status: job.status,
+                docId: job.docId,
+                ...(job.error ? { error: job.error } : {}),
+            };
+            return jsonResponse(response, 200);
+        }
+
+        const outcome = await finalizeIfTerminal(job);
+        const response: TranscribeStatusResponse = {
+            status: outcome.status,
+            docId: outcome.docId,
+            ...(outcome.error ? { error: outcome.error } : {}),
+        };
+        return jsonResponse(response, 200);
+    } catch (error) {
+        if (error instanceof GenerateApiError) {
+            logger.warn('status を拒否/失敗', { code: error.code, status: error.status });
+            return errorResponse(error);
+        }
+        logger.error('status で想定外のエラー', error);
+        return errorResponse(new GenerateApiError('upstream_error',
+            '文字起こしの状態確認でエラーが発生しました。しばらくしてから再試行してください。'));
+    }
+}
+
+export function GET(): Response {
+    return jsonResponse({ error: 'invalid_request', message: 'POST でのみ利用できます。' }, 405);
+}

--- a/src/app/api/transcribe/status/route.ts
+++ b/src/app/api/transcribe/status/route.ts
@@ -25,6 +25,8 @@ import {
 import { buildTranscriptMarkdownFromBatch, describeBatchModel } from '@/server/finalizeTranscription';
 import { completeTranscriptionDocument, failTranscriptionDocument } from '@/server/transcriptionDocument';
 import {
+    claimJobForFinalize,
+    FINALIZE_LEASE_MS,
     getTranscriptionJob,
     updateTranscriptionJob,
     type TranscriptionJob,
@@ -58,33 +60,55 @@ export function validateStatusBody(raw: unknown): TranscribeStatusRequest {
 }
 
 /**
- * Azure が終端に達していれば確定処理。冪等（呼び出し側が job.status を running と確認済み）。
+ * Azure が終端に達していれば確定処理（呼び出し側が CAS で確定権を取得済み）。
  * 成功: 結果 → Markdown → 文書完成 → ジョブ succeeded → Azure ジョブ削除。
  * 失敗: 文書に理由を残す → ジョブ failed → Azure ジョブ削除。
- * 未完: 何もしない。
+ * 未完: ジョブを running に戻し、次の poll で再確認する。
  */
 async function finalizeIfTerminal(job: TranscriptionJob): Promise<TranscribeJobPublicStatusInternal> {
     const credentials = getAzureCredentials();
     if (!credentials) {
-        // 設定が消えた等。ジョブは running のまま（設定を直せば次の poll で進む）。
+        // 設定が消えた等。設定を直せば次の poll で進むよう、確定権を解放する。
+        await updateTranscriptionJob(job.id, { status: 'running' });
         return { status: 'running', docId: job.docId };
     }
-    const state = await getBatchJob(job.azureSelfUrl, credentials);
+    let state: Awaited<ReturnType<typeof getBatchJob>>;
+    try {
+        state = await getBatchJob(job.azureSelfUrl, credentials);
+    } catch (error) {
+        await updateTranscriptionJob(job.id, { status: 'running' });
+        throw error;
+    }
     if (!isTerminalBatchStatus(state.status)) {
+        await updateTranscriptionJob(job.id, { status: 'running' });
         return { status: 'running', docId: job.docId };
     }
     if (state.status === 'Failed') {
         const reason = state.error ?? 'Azure 側で処理に失敗しました。';
-        await failTranscriptionDocument(job.docId, reason);
+        await failTranscriptionDocument(job.docId, reason, job.ownerId);
         await updateTranscriptionJob(job.id, { status: 'failed', error: reason });
         await deleteBatchJob(job.azureSelfUrl, credentials);
         return { status: 'failed', docId: job.docId, error: reason };
     }
     // Succeeded
-    const result = await fetchBatchResult(job.azureSelfUrl, credentials);
-    const parsed = parseBatchResult(result);
-    const markdown = buildTranscriptMarkdownFromBatch(parsed);
-    await completeTranscriptionDocument(job.docId, markdown, describeBatchModel(parsed));
+    let parsed: ReturnType<typeof parseBatchResult>;
+    let markdown: string;
+    try {
+        const result = await fetchBatchResult(job.azureSelfUrl, credentials);
+        parsed = parseBatchResult(result);
+        markdown = buildTranscriptMarkdownFromBatch(parsed);
+        await completeTranscriptionDocument(job.docId, markdown, describeBatchModel(parsed), job.ownerId);
+    } catch {
+        const reason = '文字起こし結果の取り込みに失敗しました。もう一度お試しください。';
+        logger.warn('文字起こし結果の取り込みに失敗', { jobId: job.id });
+        try {
+            await failTranscriptionDocument(job.docId, reason, job.ownerId);
+        } finally {
+            await updateTranscriptionJob(job.id, { status: 'failed', error: reason });
+        }
+        // 未取り込みの結果は削除せず、Azure 側の TTL に任せる。
+        return { status: 'failed', docId: job.docId, error: reason };
+    }
     await updateTranscriptionJob(job.id, { status: 'succeeded', speakers: parsed.speakers });
     await deleteBatchJob(job.azureSelfUrl, credentials);
     logger.info('文字起こしを確定', { jobId: job.id, speakers: parsed.speakers, chars: markdown.length });
@@ -110,17 +134,31 @@ export async function POST(request: Request): Promise<Response> {
             throw new GenerateApiError('forbidden', 'このジョブを参照する権限がありません。');
         }
 
-        // 既に確定済みなら Azure を叩かずそのまま返す（冪等・二重確定しない）
-        if (job.status !== 'running') {
+        // 確定済み/確定中は即返す。クラッシュで期限切れになったリースだけ再取得する。
+        const expiredFinalize = job.status === 'finalizing'
+            && Date.now() - job.updatedAtMs > FINALIZE_LEASE_MS;
+        if (job.status !== 'running' && !expiredFinalize) {
             const response: TranscribeStatusResponse = {
-                status: job.status,
+                status: job.status === 'finalizing' ? 'running' : job.status,
                 docId: job.docId,
                 ...(job.error ? { error: job.error } : {}),
             };
             return jsonResponse(response, 200);
         }
 
-        const outcome = await finalizeIfTerminal(job);
+        const claimedJob = await claimJobForFinalize(job.id);
+        if (!claimedJob) {
+            const current = await getTranscriptionJob(job.id);
+            if (!current) throw new GenerateApiError('media_not_found', '文字起こしジョブが見つかりません。');
+            const response: TranscribeStatusResponse = {
+                status: current.status === 'finalizing' ? 'running' : current.status,
+                docId: current.docId,
+                ...(current.error ? { error: current.error } : {}),
+            };
+            return jsonResponse(response, 200);
+        }
+
+        const outcome = await finalizeIfTerminal(claimedJob);
         const response: TranscribeStatusResponse = {
             status: outcome.status,
             docId: outcome.docId,

--- a/src/app/api/transcribe/submit/route.ts
+++ b/src/app/api/transcribe/submit/route.ts
@@ -1,0 +1,161 @@
+/**
+ * POST /api/transcribe/submit — 非同期バッチ文字起こしの**提出**（設計 §3.7 改訂・2026-09-05）。
+ *
+ * 短命な関数: 音声を分割せず、Azure バッチジョブを 1 本投げ、処理中の文書とジョブ状態を作って即返す。
+ * 完了は /api/transcribe/status（poll）または webhook で拾う。Vercel 300 秒には当たらない。
+ *
+ * 検査順: 本文 → 主体(401) → 所有権(403) → Azure 設定(503) → Storage 存在/サイズ(404/413)
+ *        → 音声長(400) → 時間あたり上限(429) → 署名URL → バッチ提出 → 文書/ジョブ作成 → 200。
+ * 🔴 レートは **1 ジョブ 1 消費**（チャンク方式の最大 36 消費/商談を解消）。
+ */
+import { createLogger } from '@/lib/logger';
+import {
+    AZURE_BATCH_MAX_AUDIO_BYTES,
+    AZURE_BATCH_MAX_AUDIO_SEC,
+} from '@/lib/azureBatchContract';
+import type {
+    TranscribeSubmitRequest,
+    TranscribeSubmitResponse,
+    TranscribeBatchErrorBody,
+} from '@/lib/transcribeBatchContract';
+import { resolveRequestSubject } from '@/server/auth';
+import { GenerateApiError } from '@/server/errors';
+import { getSignedReadUrl, isOwnedBySubject, parseStoragePath, statMedia } from '@/server/mediaSource';
+import { clientIpFromHeaders, enforceRateLimit } from '@/server/rateLimit';
+import { getAzureCredentials, submitBatchJob } from '@/server/azureBatchTranscribe';
+import { createProcessingDocument } from '@/server/transcriptionDocument';
+import { createTranscriptionJob } from '@/server/transcriptionJob';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+export const dynamic = 'force-dynamic';
+
+const logger = createLogger('api/transcribe/submit');
+
+/** 署名 URL の有効期限。ジョブが完了して結果を取り終えるまで持てば十分（余裕をみて） */
+const SIGNED_URL_TTL_MS = 6 * 60 * 60 * 1000;
+
+const jsonResponse = (body: unknown, status: number, extraHeaders: Record<string, string> = {}): Response =>
+    new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', ...extraHeaders },
+    });
+
+const errorResponse = (error: GenerateApiError): Response => {
+    const body: TranscribeBatchErrorBody = {
+        error: error.code,
+        message: error.message,
+        ...(error.retryAfterSec !== undefined && { retryAfterSec: error.retryAfterSec }),
+    };
+    const headers: Record<string, string> = error.retryAfterSec !== undefined
+        ? { 'retry-after': String(error.retryAfterSec) }
+        : {};
+    return jsonResponse(body, error.status, headers);
+};
+
+const invalid = (message: string): GenerateApiError => new GenerateApiError('invalid_request', message);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export function validateSubmitBody(raw: unknown): TranscribeSubmitRequest {
+    const reload = 'ページを再読み込みして、もう一度お試しください。';
+    if (!isRecord(raw)) throw invalid(`リクエストの形式が不正です。${reload}`);
+    const { storagePath, fileName, mimeType, audioSec, promptName, title, originalFileType } = raw;
+    if (typeof storagePath !== 'string' || !storagePath) throw invalid(`アップロード先の情報がありません。${reload}`);
+    if (typeof fileName !== 'string' || !fileName) throw invalid(`ファイル名がありません。${reload}`);
+    if (typeof mimeType !== 'string' || !mimeType) throw invalid(`ファイル種別がありません。${reload}`);
+    if (typeof audioSec !== 'number' || !Number.isFinite(audioSec) || audioSec <= 0) {
+        throw invalid(`音声の長さが取得できませんでした。${reload}`);
+    }
+    if (typeof promptName !== 'string' || !promptName) throw invalid(`プロンプト名がありません。${reload}`);
+    if (typeof originalFileType !== 'string' || !originalFileType) throw invalid(`ファイル種別がありません。${reload}`);
+    return {
+        storagePath,
+        fileName,
+        mimeType,
+        audioSec,
+        promptName,
+        originalFileType,
+        ...(typeof title === 'string' && title ? { title } : {}),
+    };
+}
+
+export async function POST(request: Request): Promise<Response> {
+    const startedAt = Date.now();
+    try {
+        const body = validateSubmitBody(await request.json().catch(() => {
+            throw invalid('リクエストの本文を読み取れませんでした。ページを再読み込みしてください。');
+        }));
+
+        const subject = await resolveRequestSubject(request.headers);
+
+        const parsed = parseStoragePath(body.storagePath);
+        if (!parsed) throw invalid('アップロード先の形式が不正です。ページを再読み込みしてください。');
+        if (!isOwnedBySubject(parsed.ownerId, subject)) {
+            throw new GenerateApiError('forbidden', 'このファイルを処理する権限がありません。');
+        }
+
+        const credentials = getAzureCredentials();
+        if (!credentials) {
+            throw new GenerateApiError('not_configured', '文字起こしが設定されていません。管理者にお問い合わせください。');
+        }
+
+        // 音声長の上限（Azure バッチ・話者分離有効時 240 分）
+        if (body.audioSec > AZURE_BATCH_MAX_AUDIO_SEC) {
+            throw invalid(`音声が長すぎます（上限 ${Math.floor(AZURE_BATCH_MAX_AUDIO_SEC / 60)} 分）。分割してお試しください。`);
+        }
+
+        // Storage 上のサイズ確認（バッチは 1GB まで）
+        await statMedia(body.storagePath, AZURE_BATCH_MAX_AUDIO_BYTES);
+
+        // 🔴 1 ジョブ 1 消費。チャンク方式の「1 試行 1 消費（最大 36/商談）」を解消。
+        const rate = await enforceRateLimit(subject, clientIpFromHeaders(request.headers));
+
+        // Azure が音声を取得するための署名付き URL（音声バイトは Firebase→Azure 直行・Vercel は通らない）
+        const signedUrl = await getSignedReadUrl(body.storagePath, SIGNED_URL_TTL_MS);
+        const { selfUrl } = await submitBatchJob(signedUrl, credentials, `vtd:${parsed.name}`);
+
+        // 文書を先に作り一覧へ即出す → ジョブ状態を残す（タブ非依存）
+        const ownerType = subject.kind === 'user' ? 'user' : 'guest';
+        const docId = await createProcessingDocument({
+            ownerId: parsed.ownerId,
+            ownerType,
+            fileName: body.fileName,
+            promptName: body.promptName,
+            originalFileType: body.originalFileType,
+            audioStoragePath: body.storagePath,
+            ...(body.title ? { title: body.title } : {}),
+        });
+        const jobId = await createTranscriptionJob({
+            ownerId: parsed.ownerId,
+            ownerType,
+            docId,
+            azureSelfUrl: selfUrl,
+            audioSec: body.audioSec,
+            storagePath: body.storagePath,
+            promptName: body.promptName,
+        });
+
+        console.log(JSON.stringify({
+            event: 'transcribe.submit',
+            jobId, docId, audioSec: body.audioSec, subjectKind: subject.kind,
+            rateCount: rate.count, rateLimit: rate.limit, elapsedMs: Date.now() - startedAt,
+        }));
+
+        const response: TranscribeSubmitResponse = { jobId, docId };
+        return jsonResponse(response, 200);
+    } catch (error) {
+        if (error instanceof GenerateApiError) {
+            logger.warn('submit を拒否/失敗', { code: error.code, status: error.status });
+            return errorResponse(error);
+        }
+        logger.error('submit で想定外のエラー', error);
+        return errorResponse(new GenerateApiError('upstream_error',
+            '文字起こしの登録中にエラーが発生しました。しばらくしてから再試行してください。'));
+    }
+}
+
+export function GET(): Response {
+    return jsonResponse({ error: 'invalid_request', message: 'POST でのみ利用できます。' }, 405, { allow: 'POST' });
+}

--- a/src/app/api/transcribe/submit/route.ts
+++ b/src/app/api/transcribe/submit/route.ts
@@ -32,8 +32,8 @@ export const dynamic = 'force-dynamic';
 
 const logger = createLogger('api/transcribe/submit');
 
-/** 署名 URL の有効期限。ジョブが完了して結果を取り終えるまで持てば十分（余裕をみて） */
-const SIGNED_URL_TTL_MS = 6 * 60 * 60 * 1000;
+/** Azure batch は完了まで最大24時間。長尺は内部再試行で音源取得が6時間を超え得るため、24時間有効にする。 */
+const SIGNED_URL_TTL_MS = 24 * 60 * 60 * 1000;
 
 const jsonResponse = (body: unknown, status: number, extraHeaders: Record<string, string> = {}): Response =>
     new Response(JSON.stringify(body), {

--- a/src/app/fontWiring.test.ts
+++ b/src/app/fontWiring.test.ts
@@ -106,10 +106,12 @@ describe('意味トークン (E2)', () => {
     });
 
     it('REQUIRED_TOKENS が実参照と同期している（定義だけの錠にしない）', () => {
+        // 🔴 referencedTokenIds() は src 配下を全走査するため、ソース増で遅くなる。
+        //    既定 5000ms は全体実行時の負荷で超えることがある（単体では約 100ms）。余裕を持たせる。
         for (const token of REQUIRED_TOKENS) {
             expect(referencedTokenIds(), token).toContain(token.replace(/^--/, ''));
         }
-    });
+    }, 20_000);
 
     it('@theme に未参照のトークンを残さない', () => {
         // 使われないトークンは「定義されている」錠だけを緑にして実物を守らない。

--- a/src/hooks/batchTranscriptionClient.test.ts
+++ b/src/hooks/batchTranscriptionClient.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    submitBatchTranscription,
+    pollBatchStatus,
+    runBatchTranscription,
+} from './batchTranscriptionClient';
+import { TRANSCRIBE_SUBMIT_PATH, TRANSCRIBE_STATUS_PATH } from '@/lib/transcribeBatchContract';
+
+// firebase の遅延 import を無害化（Auth 初期化を避ける・ゲスト扱い）
+vi.mock('@/lib/firebase', () => ({ auth: { currentUser: null } }));
+
+const jsonResponse = (body: unknown, ok = true, status = 200) => ({
+    ok, status, json: async () => body,
+}) as unknown as Response;
+
+const noWait = async () => {};
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('submitBatchTranscription', () => {
+    const req = {
+        storagePath: 'audio/GUEST/x.mp3', fileName: 'x.mp3', mimeType: 'audio/mpeg',
+        audioSec: 600, promptName: 'p', originalFileType: 'audio',
+    };
+
+    it('SUBMIT パスへ POST し {jobId,docId} を返す', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ jobId: 'j1', docId: 'd1' }));
+        const res = await submitBatchTranscription(req);
+        expect(res).toEqual({ jobId: 'j1', docId: 'd1' });
+        expect(fetchMock.mock.calls[0][0]).toBe(TRANSCRIBE_SUBMIT_PATH);
+    });
+
+    it('!ok はサーバの message を Error にする', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'rate_limited', message: '上限に達しました' }, false, 429));
+        await expect(submitBatchTranscription(req)).rejects.toThrow('上限に達しました');
+    });
+});
+
+describe('pollBatchStatus', () => {
+    it('running を挟んで succeeded になるまで問い合わせる', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ status: 'running', docId: 'd1' }))
+            .mockResolvedValueOnce(jsonResponse({ status: 'running', docId: 'd1' }))
+            .mockResolvedValueOnce(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        const ticks: string[] = [];
+        const res = await pollBatchStatus('j1', { wait: noWait, onTick: (s) => ticks.push(s.status) });
+        expect(res.status).toBe('succeeded');
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(ticks).toEqual(['running', 'running', 'succeeded']);
+        expect(fetchMock.mock.calls[0][0]).toBe(TRANSCRIBE_STATUS_PATH);
+    });
+
+    it('中止シグナルで例外を投げる（それ以上叩かない）', async () => {
+        const controller = new AbortController();
+        controller.abort(new Error('stopped'));
+        const fetchMock = vi.spyOn(globalThis, 'fetch');
+        await expect(pollBatchStatus('j1', { signal: controller.signal, wait: noWait })).rejects.toThrow('stopped');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('タイムアウトに達したら running のまま返す（諦めるが失敗にしない）', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ status: 'running', docId: 'd1' }));
+        const res = await pollBatchStatus('j1', { wait: noWait, timeoutMs: -1 });
+        expect(res.status).toBe('running');
+    });
+});
+
+describe('runBatchTranscription', () => {
+    const input = {
+        storagePath: 'audio/GUEST/x.mp3', fileName: 'x.mp3', mimeType: 'audio/mpeg',
+        audioSec: 600, promptName: 'p', originalFileType: 'audio', pollIntervalMs: 0,
+    };
+
+    it('提出→ポーリング→成功で {success:true, docId}', async () => {
+        vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ jobId: 'j1', docId: 'd1' }))   // submit
+            .mockResolvedValueOnce(jsonResponse({ status: 'succeeded', docId: 'd1' })); // status
+        const res = await runBatchTranscription(input);
+        expect(res).toEqual({ success: true, docId: 'd1' });
+    });
+
+    it('失敗はサーバの理由を返す（文書は消えない前提）', async () => {
+        vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ jobId: 'j1', docId: 'd1' }))
+            .mockResolvedValueOnce(jsonResponse({ status: 'failed', docId: 'd1', error: '音声が長すぎます' }));
+        const res = await runBatchTranscription(input);
+        expect(res).toEqual({ success: false, docId: 'd1', error: '音声が長すぎます' });
+    });
+});

--- a/src/hooks/batchTranscriptionClient.test.ts
+++ b/src/hooks/batchTranscriptionClient.test.ts
@@ -67,6 +67,34 @@ describe('pollBatchStatus', () => {
         const res = await pollBatchStatus('j1', { wait: noWait, timeoutMs: -1 });
         expect(res.status).toBe('running');
     });
+
+    it('🔴 一時的な状態確認エラー（502）で止まらず、次の周回で確定を拾う', async () => {
+        // 1回目 502（サーバの確定 commit が transient で落ちた等）→ 飲み込んで再試行 → 2回目 succeeded。
+        // これで止まると、サーバのリース切れ再確定に永遠に到達せず文書が processing で固まる（再レビュー major）。
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502))
+            .mockResolvedValueOnce(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        const res = await pollBatchStatus('j1', { wait: noWait });
+        expect(res.status).toBe('succeeded');
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('🔴 一時エラーが続いてもタイムアウトまで諦めない', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502));
+        const res = await pollBatchStatus('j1', { wait: noWait, timeoutMs: -1 });
+        expect(res.status).toBe('running'); // 諦めるが「失敗」にはしない
+    });
+
+    it('中止は一時エラーとして飲み込まず、即座に投げる', async () => {
+        const controller = new AbortController();
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+            controller.abort(new Error('aborted-mid-flight'));
+            throw new Error('The operation was aborted');
+        });
+        await expect(pollBatchStatus('j1', { signal: controller.signal, wait: noWait }))
+            .rejects.toThrow('aborted-mid-flight');
+    });
 });
 
 describe('runBatchTranscription', () => {

--- a/src/hooks/batchTranscriptionClient.ts
+++ b/src/hooks/batchTranscriptionClient.ts
@@ -84,18 +84,35 @@ export interface PollOptions {
 
 const defaultWait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-/** 終端（succeeded/failed）になるまでポーリングする。中止は例外を投げる。 */
+/**
+ * 終端（succeeded/failed）になるまでポーリングする。中止は例外を投げる。
+ *
+ * 🔴 一時的な状態確認エラー（サーバの 502・回線断）でポーリングを止めない。
+ *    サーバ側は確定処理が途中で落ちても finalizing のリース切れ後に**次の poll で再確定**できる設計
+ *    （commitTerminalOutcome）。ここで一度の失敗で抜けると、その回復経路に永遠に到達せず、
+ *    文書が「処理中」のまま固まり、利用者が別ジョブを再提出して二重課金になる（再レビュー major）。
+ *    だから状態確認の失敗は飲み込んで待ち、次の周回で再試行する。中止（abort）は即座に投げる。
+ */
 export async function pollBatchStatus(jobId: string, options: PollOptions = {}): Promise<TranscribeStatusResponse> {
     const { signal, intervalMs = 15_000, timeoutMs = 90 * 60_000, onTick, wait = defaultWait } = options;
     const startedAt = Date.now();
     for (;;) {
         if (signal?.aborted) throw signal.reason ?? new Error('中止しました');
-        const status = await fetchBatchStatus(jobId, signal);
-        onTick?.(status);
-        if (status.status !== 'running') return status;
+        let status: TranscribeStatusResponse | null = null;
+        try {
+            status = await fetchBatchStatus(jobId, signal);
+        } catch (error) {
+            // 中止はそのまま伝える。それ以外（502・回線断）は一時障害として次の周回で再試行。
+            if (signal?.aborted) throw signal.reason ?? error;
+            status = null;
+        }
+        if (status) {
+            onTick?.(status);
+            if (status.status !== 'running') return status;
+        }
         if (Date.now() - startedAt > timeoutMs) {
             // ジョブは Azure 側で継続中。文書は「処理中」のまま残り、後で開けば確定できる。
-            return status;
+            return status ?? { status: 'running', docId: '' };
         }
         await wait(intervalMs);
     }

--- a/src/hooks/batchTranscriptionClient.ts
+++ b/src/hooks/batchTranscriptionClient.ts
@@ -1,0 +1,150 @@
+/**
+ * 非同期バッチ文字起こしのクライアント側（設計 §3.7 改訂・2026-09-05）。
+ *
+ * 流れ: 既にアップロード済みの音声パスで **提出** → **状態確認をポーリング** → 完了。
+ * 🔴 文書はサーバが作って完成させる（タブ非依存）。クライアントは saveTranscription を呼ばない。
+ * 🔴 認証は既存の生成 API と同じ形（firebase は遅延 import。モジュール先頭で読むと鍵の無い
+ *    環境で Auth 初期化が落ちる）。未ログイン（ゲスト）はヘッダを付けない。
+ */
+import { GENERATE_AUTH_HEADER } from '@/lib/generateApiContract';
+import {
+    TRANSCRIBE_SUBMIT_PATH,
+    TRANSCRIBE_STATUS_PATH,
+    type TranscribeSubmitRequest,
+    type TranscribeSubmitResponse,
+    type TranscribeStatusResponse,
+    type TranscribeBatchErrorBody,
+} from '@/lib/transcribeBatchContract';
+
+async function authHeaders(): Promise<Record<string, string>> {
+    let token: string | null = null;
+    try {
+        const { auth } = await import('@/lib/firebase');
+        token = (await auth.currentUser?.getIdToken()) ?? null;
+    } catch {
+        token = null;
+    }
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (token) headers[GENERATE_AUTH_HEADER] = `Bearer ${token}`;
+    return headers;
+}
+
+const messageFrom = (json: unknown, fallback: string): string => {
+    const body = json as Partial<TranscribeBatchErrorBody> | null;
+    return (body && typeof body.message === 'string' && body.message) || fallback;
+};
+
+/** ジョブを提出。音声は既に Storage にある前提。短命に {jobId, docId} が返る。 */
+export async function submitBatchTranscription(
+    req: TranscribeSubmitRequest,
+    signal?: AbortSignal,
+): Promise<TranscribeSubmitResponse> {
+    const response = await fetch(TRANSCRIBE_SUBMIT_PATH, {
+        method: 'POST',
+        headers: await authHeaders(),
+        body: JSON.stringify(req),
+        ...(signal ? { signal } : {}),
+    });
+    const json = await response.json().catch(() => null);
+    if (!response.ok) {
+        throw new Error(messageFrom(json, `文字起こしの登録に失敗しました (${response.status})`));
+    }
+    return json as TranscribeSubmitResponse;
+}
+
+/** ジョブの状態を 1 回問い合わせる。完了していればサーバがその場で文書を確定する。 */
+export async function fetchBatchStatus(
+    jobId: string,
+    signal?: AbortSignal,
+): Promise<TranscribeStatusResponse> {
+    const response = await fetch(TRANSCRIBE_STATUS_PATH, {
+        method: 'POST',
+        headers: await authHeaders(),
+        body: JSON.stringify({ jobId }),
+        ...(signal ? { signal } : {}),
+    });
+    const json = await response.json().catch(() => null);
+    if (!response.ok) {
+        throw new Error(messageFrom(json, `状態の確認に失敗しました (${response.status})`));
+    }
+    return json as TranscribeStatusResponse;
+}
+
+export interface PollOptions {
+    signal?: AbortSignal;
+    /** 問い合わせ間隔（既定 15 秒。バッチは分単位なので細かく叩かない） */
+    intervalMs?: number;
+    /** 全体の待ち上限（既定 90 分）。超えたらポーリングを諦める（ジョブ自体は生きている） */
+    timeoutMs?: number;
+    /** 毎回の状態を UI に伝える */
+    onTick?: (status: TranscribeStatusResponse) => void;
+    /** テスト用: 待ちを差し替える */
+    wait?: (ms: number) => Promise<void>;
+}
+
+const defaultWait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** 終端（succeeded/failed）になるまでポーリングする。中止は例外を投げる。 */
+export async function pollBatchStatus(jobId: string, options: PollOptions = {}): Promise<TranscribeStatusResponse> {
+    const { signal, intervalMs = 15_000, timeoutMs = 90 * 60_000, onTick, wait = defaultWait } = options;
+    const startedAt = Date.now();
+    for (;;) {
+        if (signal?.aborted) throw signal.reason ?? new Error('中止しました');
+        const status = await fetchBatchStatus(jobId, signal);
+        onTick?.(status);
+        if (status.status !== 'running') return status;
+        if (Date.now() - startedAt > timeoutMs) {
+            // ジョブは Azure 側で継続中。文書は「処理中」のまま残り、後で開けば確定できる。
+            return status;
+        }
+        await wait(intervalMs);
+    }
+}
+
+export interface RunBatchTranscriptionInput {
+    storagePath: string;
+    fileName: string;
+    mimeType: string;
+    audioSec: number;
+    promptName: string;
+    originalFileType: string;
+    title?: string;
+    signal?: AbortSignal;
+    onTick?: (status: TranscribeStatusResponse) => void;
+    pollIntervalMs?: number;
+}
+
+export interface RunBatchTranscriptionResult {
+    success: boolean;
+    docId: string;
+    /** まだ処理中（ポーリング上限に達した）。文書は「処理中」のまま */
+    pending?: boolean;
+    error?: string;
+}
+
+/** 提出 → ポーリング → 結果。文書はサーバが保存済み。 */
+export async function runBatchTranscription(
+    input: RunBatchTranscriptionInput,
+): Promise<RunBatchTranscriptionResult> {
+    const { jobId, docId } = await submitBatchTranscription(
+        {
+            storagePath: input.storagePath,
+            fileName: input.fileName,
+            mimeType: input.mimeType,
+            audioSec: input.audioSec,
+            promptName: input.promptName,
+            originalFileType: input.originalFileType,
+            ...(input.title ? { title: input.title } : {}),
+        },
+        input.signal,
+    );
+    const final = await pollBatchStatus(jobId, {
+        ...(input.signal ? { signal: input.signal } : {}),
+        ...(input.pollIntervalMs ? { intervalMs: input.pollIntervalMs } : {}),
+        ...(input.onTick ? { onTick: input.onTick } : {}),
+    });
+    if (final.status === 'succeeded') return { success: true, docId };
+    if (final.status === 'failed') return { success: false, docId, ...(final.error ? { error: final.error } : {}) };
+    // running のまま上限に達した: 失敗ではない。文書は処理中で残る。
+    return { success: false, docId, pending: true };
+}

--- a/src/hooks/useProcessingWorkflow.test.ts
+++ b/src/hooks/useProcessingWorkflow.test.ts
@@ -496,7 +496,9 @@ describe('conversion queue wait limit (V8)', () => {
         } finally {
             vi.useRealTimers();
         }
-    });
+    // 🔴 フェイクタイマー間の実マイクロタスクが全体実行時の並列負荷で遅延する。
+    //    既定 5000ms は超えることがある（単体では約 1s）。余裕を持たせる。
+    }, 20_000);
 });
 
 

--- a/src/hooks/useProcessingWorkflow.test.ts
+++ b/src/hooks/useProcessingWorkflow.test.ts
@@ -14,6 +14,26 @@ const serviceMocks = vi.hoisted(() => ({
     ffmpegLoad: vi.fn(),
 }));
 
+const ffmpegMocks = vi.hoisted(() => ({
+    exec: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('@ffmpeg/ffmpeg', () => ({
+    FFmpeg: class FFmpeg {
+        load = vi.fn().mockResolvedValue(undefined);
+        exec = ffmpegMocks.exec;
+        writeFile = vi.fn().mockResolvedValue(undefined);
+        readFile = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+        deleteFile = vi.fn().mockResolvedValue(undefined);
+        on = vi.fn();
+        off = vi.fn();
+    },
+}));
+vi.mock('@ffmpeg/util', () => ({
+    fetchFile: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+    toBlobURL: vi.fn().mockResolvedValue('blob:synthetic-ffmpeg'),
+}));
+
 vi.mock('react', () => ({
     useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback,
     useState: <T>(initialValue: T) => {
@@ -180,6 +200,33 @@ beforeEach(() => {
     serviceMocks.ffmpegLoad.mockResolvedValue(undefined);
 });
 
+describe('Azure batch 用の MP3 変換', () => {
+    it.each(['whole', 'segment'] as const)('%s 変換は指定した bitrate / sampleRate を保ち mono を出力する', async (mode) => {
+        const { VideoConverter } = await vi.importActual<typeof import('@/lib/ffmpeg')>('@/lib/ffmpeg');
+        const converter = new VideoConverter();
+        const file = createFile('synthetic.mp4', 'video/mp4').file;
+        const options = { bitrate: '96k', sampleRate: 16000 };
+
+        const result = mode === 'segment'
+            ? await converter.convertSegmentToMp3(file, 5, 20, 0, options)
+            : await converter.convertToMp3(file, options);
+
+        expect(result.success).toBe(true);
+        expect(result.outputBlob?.type).toBe('audio/mpeg');
+        expect(ffmpegMocks.exec).toHaveBeenCalledOnce();
+        expect(ffmpegMocks.exec).toHaveBeenCalledWith([
+            ...(mode === 'segment' ? ['-ss', '5', '-to', '20'] : []),
+            '-i', expect.stringMatching(/^input_.*\.mp4$/),
+            '-vn',
+            '-acodec', 'libmp3lame',
+            '-ac', '1',
+            '-ab', '96k',
+            '-ar', '16000',
+            '-y', expect.stringMatching(/^output_.*\.mp3$/),
+        ]);
+    });
+});
+
 describe('handleStartProcessing cancellation', () => {
     it('writes a terminal status for files still waiting when the run is canceled', async () => {
         const harness = useWorkflowHarness();
@@ -256,19 +303,21 @@ describe('handleStartProcessing failure reporting', () => {
         expect(serviceMocks.convertVideoToAudioSegments).not.toHaveBeenCalled();
     });
 
-    it('🔴 全文文字起こしを選んだら、入力が音声でも FFmpeg を読み込む', async () => {
-        // 実害 (2026-09-04): 本番で mp3 を上げると converter が null のまま分割パイプラインが
-        // 呼ばれ、「音声変換の準備ができていません」で必ず失敗していた。
-        // 分割パイプラインは入力が音声でもチャンクの切り出しと無音走査に FFmpeg を使う。
+    it('全文文字起こしでも、そのまま送れる音声には FFmpeg を読み込まない', async () => {
+        // バッチ経路では分割・無音走査をせず、元の音声をそのままアップロードする。
         const harness = useWorkflowHarness();
         const file = createFile('talk.mp3', 'audio/mpeg');
         file.selectedPromptIds = [TRANSCRIPT_PROMPT_ID];
+        serviceMocks.ffmpegLoad.mockRejectedValue(new Error('wasm unavailable'));
 
-        await harness.workflow.handleStartProcessing([file], ['f1'], BITRATE, SAMPLE_RATE);
+        const result = await harness.workflow.handleStartProcessing([file], ['f1'], BITRATE, SAMPLE_RATE);
 
-        expect(serviceMocks.ffmpegLoad).toHaveBeenCalled();
-        // 変換自体は要らない（そのまま送れる音声なので）
+        expect(result.ok).toBe(true);
+        expect(serviceMocks.ffmpegLoad).not.toHaveBeenCalled();
         expect(serviceMocks.convertVideoToAudioSegments).not.toHaveBeenCalled();
+        expect(harness.processTranscription).toHaveBeenCalledWith(
+            expect.objectContaining({ file }), file.file, BITRATE, SAMPLE_RATE
+        );
     });
 
     it('does not load FFmpeg when every input is audio', async () => {

--- a/src/hooks/useProcessingWorkflow.ts
+++ b/src/hooks/useProcessingWorkflow.ts
@@ -4,7 +4,6 @@ import { GeminiClient } from '@/lib/gemini';
 import { FileWithPrompts, FileProcessingStatus, DebugErrorMode } from '@/types/processing';
 import { convertVideoToAudioSegments, resumeVideoConversion } from '@/lib/videoConversionService';
 import { canSendAudioAsIs } from '@/lib/mediaInput';
-import { TRANSCRIPT_PROMPT_ID } from '@/lib/transcriptPrompt';
 import type { JobClaim, TranscriptionJobRef } from '@/hooks/useVideoProcessing';
 import { createLogger } from '@/lib/logger';
 
@@ -161,18 +160,11 @@ export const useProcessingWorkflow = ({
         const releaseAll = () => claims.forEach(claim => claim.release());
 
         try {
-            // H6: エンジンの初期化も失敗を捕捉できる位置に置き、
-            //     音声のみの場合は FFmpeg を読み込まない
-            // 🔴 FFmpeg が要る条件は 2 つあり、**どちらか一方でも当てはまれば読み込む**。
-            //  (1) 変換が要る入力（動画、または上限を超える音声）
-            //  (2) 🔴 **全文文字起こしを選んでいる**。分割パイプラインは入力が音声でも
-            //      チャンクの切り出しと無音走査に FFmpeg を使う（設計 §3.1）。
-            //      ここを (1) だけにすると、mp3 を上げたときに converter が null のまま
-            //      呼ばれ、「音声変換の準備ができていません」で必ず失敗する。
-            //      実害 (2026-09-04): 本番で音声入力の全文文字起こしが一度も動いていなかった。
+            // H6: エンジンの初期化も失敗を捕捉できる位置に置く。
+            // バッチ経路は音声を分割せず、そのまま送れる入力に FFmpeg は不要。
+            // 動画や上限を超える音声など、実際に MP3 変換する入力だけ読み込む。
             const needsFfmpeg = !sendVideoDirectly
-                && selectedFiles.some(file =>
-                    !canSendAudioAsIs(file.file) || file.selectedPromptIds.includes(TRANSCRIPT_PROMPT_ID));
+                && selectedFiles.some(file => !canSendAudioAsIs(file.file));
 
             try {
                 await prepareEngines(needsFfmpeg);

--- a/src/hooks/useVideoProcessing.ts
+++ b/src/hooks/useVideoProcessing.ts
@@ -14,7 +14,7 @@ import {
 } from '@/types/processing';
 import { Prompt } from '@/lib/prompts';
 import { isTranscriptPrompt } from '@/lib/transcriptPrompt';
-import { runTranscriptPipeline } from '@/hooks/transcriptPipelineAdapter';
+import { runBatchTranscription } from '@/hooks/batchTranscriptionClient';
 import { validatePromptPermission } from '@/lib/promptPermissions';
 import { getCurrentUserId } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
@@ -62,6 +62,19 @@ export const resolveMediaMimeType = (
     blobType: string,
     originalFileType: 'video' | 'audio',
 ): string => blobType || (originalFileType === 'video' ? 'video/mp4' : 'audio/mpeg');
+
+/**
+ * 音声長（秒）の見積り。ffmpeg も Audio API も使わず、**サイズ ÷ ビットレート**で出す。
+ * 🔴 これは非同期バッチ提出時の「240 分上限」判定と記録のためだけの概算。
+ *    正確な長さは Azure の結果（durationMilliseconds）が正で、文書側はそちらを使う。
+ * bitrate は '96k' のような表記。読めなければ 96k とみなす（保守的に長めに出る側）。
+ */
+export const estimateAudioSec = (blob: Blob | null, bitrate: string | undefined): number => {
+    if (!blob || blob.size <= 0) return 0;
+    const kbps = Number.parseInt(bitrate ?? '', 10);
+    const bitsPerSec = (Number.isFinite(kbps) && kbps > 0 ? kbps : 96) * 1000;
+    return Math.round((blob.size * 8) / bitsPerSec);
+};
 
 export interface JobClaim {
     signal: AbortSignal;
@@ -585,6 +598,55 @@ export const useVideoProcessing = (
             const runPrompt = async (prompt: Prompt) => {
                 const promptId = prompt.id!;
                 const idempotencyKey = `${fileId}::${promptId}`;
+
+                // 🔴 全文文字起こしは**非同期バッチ経路**（設計 §3.7 改訂・2026-09-05）。
+                //    音声を分割せず Azure バッチへ 1 本投げ、状態確認で完了を拾う。
+                //    文書はサーバが作って完成させる（タブ非依存）ので、ここでは saveTranscription を呼ばない。
+                //    従来の同期チャンク方式（runTranscriptPipeline）が抱えていたタイムアウト・分割・
+                //    無音での全滅・部分結果破棄は、この経路では構造的に起きない。
+                if (isTranscriptPrompt(prompt)) {
+                    if (!savedKeysRef.current.has(idempotencyKey)) {
+                        throwIfAborted();
+                        const media = uploadedMedia;
+                        if (!media) {
+                            throw new PromptPhaseError(
+                                'upload',
+                                '送信用の音声データが準備されていません。音声変換からやり直してください。'
+                            );
+                        }
+                        markPromptState(fileId, promptId, 'generating');
+                        const result = await runBatchTranscription({
+                            storagePath: media.storagePath,
+                            fileName: file.file.name,
+                            mimeType: media.mimeType,
+                            audioSec: estimateAudioSec(audioBlob, bitrate),
+                            promptName: prompt.name,
+                            originalFileType,
+                            signal,
+                        });
+                        if (!result.success) {
+                            // 🔴 失敗しても文書は消えない（サーバが理由つきで残す）。ここでは経過を伝える。
+                            throw new PromptPhaseError(
+                                'text_generation',
+                                result.pending
+                                    ? '文字起こしがまだ完了していません。しばらくしてから文書一覧でご確認ください。'
+                                    : (result.error || '文字起こしに失敗しました。')
+                            );
+                        }
+                        savedKeysRef.current.add(idempotencyKey);
+                    }
+                    savedPromptIds.push(promptId);
+                    updateStatus(fileId, status => ({
+                        ...withPromptStates(status, { ...status.promptStates, [promptId]: 'saved' }),
+                        transcriptionCount: status.transcriptionCount + 1,
+                        completedPromptIds: status.completedPromptIds.includes(promptId)
+                            ? status.completedPromptIds
+                            : [...status.completedPromptIds, promptId],
+                    }));
+                    onDocumentSaved?.();
+                    return;
+                }
+
                 let draft = draftsRef.current.get(idempotencyKey);
 
                 if (!draft) {
@@ -602,24 +664,19 @@ export const useVideoProcessing = (
                     //    ここで分けると、**下流の下書き・保存・冪等・中断はすべて既存のまま効く**。
                     //    戻り値を TranscriptionResult に揃えてあるので、以降の処理は分岐を知らない。
                     //    中止は fetch に渡して切る。サーバ側の処理は継続し得る (仕様として許容)
-                    const transcriptionResult = isTranscriptPrompt(prompt)
-                        ? await runTranscriptPipeline({
-                            file: file.file,
-                            converter: converterRef.current,
-                            signal,
-                        })
-                        : await geminiClientRef.current!.generateDocument({
-                            storagePath: media.storagePath,
-                            fileName: file.file.name,
-                            mimeType: media.mimeType,
-                            prompt: {
-                                name: prompt.name,
-                                content: prompt.content,
-                                model: prompt.model,
-                                thinkingLevel: prompt.thinkingLevel,
-                            },
-                            signal,
-                        });
+                    // 全文文字起こしは上の非同期バッチ経路で処理済み。ここは通常の文書生成のみ。
+                    const transcriptionResult = await geminiClientRef.current!.generateDocument({
+                        storagePath: media.storagePath,
+                        fileName: file.file.name,
+                        mimeType: media.mimeType,
+                        prompt: {
+                            name: prompt.name,
+                            content: prompt.content,
+                            model: prompt.model,
+                            thinkingLevel: prompt.thinkingLevel,
+                        },
+                        signal,
+                    });
 
                     videoProcessingLogger.info('文書生成 API の応答', {
                         fileId,

--- a/src/lib/azureBatchContract.ts
+++ b/src/lib/azureBatchContract.ts
@@ -1,0 +1,97 @@
+/**
+ * Azure Speech **Batch transcription** (`transcriptions:submit`) の定数と応答の形。
+ *
+ * 🔴 なぜバッチか（2026-09-05 裁定）: 同期方式（MAI/Gemini をチャンク毎に 300 秒以内で回す）は、
+ *    タイムアウト予算 595 秒 > Vercel 300 秒・MAI が 10 分チャンクで 0/3・無音チャンクで全滅・
+ *    ブラウザ分割の ffmpeg メモリ肥大と並走クロストークなど、土台そのものに由来する障害が重なっていた。
+ *    バッチは音声を**分割せず丸ごと**非同期で投げるので、これらがまとめて消える。
+ *
+ * ⚠️ トレードオフ（一次ソースで確認済み・L3 調査）:
+ * - バッチは **標準モデル**のみ。`MAI-Transcribe-2` も Gemini も指定できない（Submit の要求本文に
+ *   `enhancedMode` プロパティが無い）。用語集(phraseList)も無い（結合後の表記統一で代替・設計 §5.1）。
+ * - "The service schedules batch transcription jobs on a best-effort basis. At peak hours, it might take
+ *    up to 30 minutes for a transcription job to start processing and up to 24 hours to complete."
+ *   実測（合成 23 分・2026-09-05）は提出→完了 9 分（実時間の 0.39 倍）。1〜2 時間で 20〜50 分の見込み。
+ *   → **対話的に「その場で待つ」UX ではなく、「完了後に反映」型**にする。
+ */
+
+/** 非同期バッチの提出エンドポイント。`{endpoint}` はリソースのカスタムドメイン */
+export const AZURE_BATCH_SUBMIT_PATH = '/speechtotext/transcriptions:submit';
+
+/**
+ * 🔴 Speech CLI は v3.2 のみだが REST は 2024-11-15 以降が正。料金ページ逐語:
+ * "To take advantage of this new Batch Transcription pricing you need to use Speech to text REST API
+ *  V3.2 or later versions." 2024-11-15 は `diarization`(enabled/maxSpeakers) を受け付ける新系。
+ */
+export const AZURE_BATCH_API_VERSION = '2024-11-15';
+
+export const AZURE_BATCH_API_KEY_HEADER = 'Ocp-Apim-Subscription-Key';
+
+/** バッチは BCP-47（`ja-JP`）。同期 MAI の 2 文字コードとは別。 */
+export const AZURE_BATCH_LOCALE = 'ja-JP';
+
+/** 話者分離の上限。商談は通常 2〜4 名。多すぎると過分割するので控えめに。 */
+export const AZURE_BATCH_MAX_SPEAKERS = 4;
+
+/**
+ * 🔴 `timeToLiveHours` は **6 以上が必須**（実測: 未指定/6 未満は 400
+ * "'properties.timeToLiveHours' must be greater than or equal to '6'"）。
+ * 結果を取り終えたらこちらから削除するので長くは要らない。取り逃しの保険で 12。
+ */
+export const AZURE_BATCH_TTL_HOURS = 12;
+
+/**
+ * 音声の上限（話者分離有効時）。逐語: "When this property is selected, source audio length can't
+ * exceed 240 minutes per file." サイズは 1 GB（Quotas 表）。
+ */
+export const AZURE_BATCH_MAX_AUDIO_SEC = 240 * 60;
+export const AZURE_BATCH_MAX_AUDIO_BYTES = 1024 * 1024 * 1024;
+
+/** ジョブの終端状態。`NotStarted`/`Running` は継続、`Succeeded`/`Failed` で確定。 */
+export type AzureBatchStatus = 'NotStarted' | 'Running' | 'Succeeded' | 'Failed';
+
+export const isTerminalBatchStatus = (s: string | undefined): s is 'Succeeded' | 'Failed' =>
+    s === 'Succeeded' || s === 'Failed';
+
+/** 提出時に組み立てる `properties`。1 か所でしか作らない（リテラルを散らさない）。 */
+export const buildBatchProperties = (): Record<string, unknown> => ({
+    diarization: { enabled: true, maxSpeakers: AZURE_BATCH_MAX_SPEAKERS },
+    wordLevelTimestampsEnabled: true,
+    displayFormWordLevelTimestampsEnabled: true,
+    // 相槌・言い直しを落とさない。同期側の verbatim と揃える意図。
+    punctuationMode: 'DictatedAndAutomatic',
+    profanityFilterMode: 'None',
+    timeToLiveHours: AZURE_BATCH_TTL_HOURS,
+});
+
+// --- 応答の形（緩く受ける。欠けたフィールドは読めなかったものとして扱う） ---
+
+/** `recognizedPhrases[].nBest[].displayWords[]` の 1 語 */
+export interface AzureBatchWord {
+    displayText?: unknown;
+    offsetMilliseconds?: unknown;
+    durationMilliseconds?: unknown;
+}
+
+/** `recognizedPhrases[].nBest[]` の候補（先頭だけ使う） */
+export interface AzureBatchNBest {
+    display?: unknown;
+    confidence?: unknown;
+    displayWords?: unknown;
+}
+
+/** `recognizedPhrases[]` の 1 句 */
+export interface AzureBatchPhrase {
+    offsetMilliseconds?: unknown;
+    durationMilliseconds?: unknown;
+    speaker?: unknown;
+    recognitionStatus?: unknown;
+    nBest?: unknown;
+}
+
+/** 結果ファイル（`links.files` の kind==='Transcription'） */
+export interface AzureBatchResult {
+    durationMilliseconds?: unknown;
+    combinedRecognizedPhrases?: unknown;
+    recognizedPhrases?: unknown;
+}

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -282,6 +282,8 @@ export class VideoConverter {
                     '-i', inputFileName,
                     '-vn', // ビデオストリームを無効化
                     '-acodec', 'libmp3lame',
+                    // Azure batch の diarization は mono 音声でのみ有効。stereo だと話者ラベルが付かない
+                    '-ac', '1',
                     '-ab', bitrate,
                     '-ar', sampleRate.toString(),
                     '-y', // 出力ファイルを上書き
@@ -507,6 +509,8 @@ export class VideoConverter {
                     '-i', inputFileName,
                     '-vn', // ビデオストリームを無効化
                     '-acodec', 'libmp3lame',
+                    // Azure batch の diarization は mono 音声でのみ有効。stereo だと話者ラベルが付かない
+                    '-ac', '1',
                     '-ab', bitrate,
                     '-ar', sampleRate.toString(),
                     '-y', // 出力ファイルを上書き

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -30,6 +30,7 @@ export interface TranscriptionDocument {
     fileName: string;
     originalFileType: string; // 'video' or 'audio'
     transcription: string;
+    status?: string;
     promptName: string; // 使用したプロンプト名
     generatedByModel?: string;
     generatedByThinkingLevel?: string;
@@ -50,6 +51,7 @@ export interface Transcription {
     title: string; // 文書タイトル（デフォルトはfileName）
     fileName: string;
     text: string; // transcription のエイリアス
+    status?: string;
     promptName: string;
     originalFileType?: string;
     generatedByModel?: string;
@@ -266,6 +268,7 @@ export async function getTranscriptionDocuments(limitCount: number = 20): Promis
                 fileName: data.fileName,
                 originalFileType: data.originalFileType,
                 transcription: data.transcription ?? data.text ?? '',
+                status: data.status,
                 promptName: data.promptName || '不明',
                 generatedByModel: data.generatedByModel,
                 generatedByThinkingLevel: data.generatedByThinkingLevel,
@@ -347,6 +350,7 @@ export async function getTranscriptions(
                 title: data.title || data.fileName, // 既存データの後方互換性
                 fileName: data.fileName,
                 text: data.transcription ?? data.text ?? '', // transcription を text にマッピング
+                status: data.status,
                 promptName: data.promptName || '不明',
                 originalFileType: data.originalFileType,
                 generatedByModel: data.generatedByModel,
@@ -391,6 +395,7 @@ export async function getTranscriptionsByOwnerId(ownerId: string, limitCount: nu
                 title: data.title || data.fileName,
                 fileName: data.fileName,
                 text: data.transcription ?? data.text ?? '',
+                status: data.status,
                 promptName: data.promptName || '不明',
                 originalFileType: data.originalFileType,
                 generatedByModel: data.generatedByModel,
@@ -609,6 +614,7 @@ export async function restoreTranscription(
         createdBy: source.createdBy ?? sourceOwnerId,
         createdAt: source.createdAt,
         updatedAt: serverTimestamp(),
+        ...(source.status !== undefined && { status: source.status }),
         ...(source.generatedByModel !== undefined && {
             generatedByModel: source.generatedByModel,
         }),

--- a/src/lib/transcribeBatchContract.ts
+++ b/src/lib/transcribeBatchContract.ts
@@ -1,0 +1,45 @@
+/**
+ * クライアント ⇄ サーバの契約（非同期バッチ文字起こし）。
+ * 提出は短命に返り、状態確認で完了を拾う。同期チャンク方式の `/api/transcribe/chunk` を置き換える。
+ */
+
+export const TRANSCRIBE_SUBMIT_PATH = '/api/transcribe/submit';
+export const TRANSCRIBE_STATUS_PATH = '/api/transcribe/status';
+
+/** 提出。音声は既に Storage にある前提（storagePath）。分割しない。 */
+export interface TranscribeSubmitRequest {
+    storagePath: string;
+    fileName: string;
+    mimeType: string;
+    /** 音声長（秒）。クライアントの実測。Azure 上限（240分）判定に使う */
+    audioSec: number;
+    promptName: string;
+    title?: string;
+    /** 'audio' | 'video' */
+    originalFileType: string;
+}
+
+export interface TranscribeSubmitResponse {
+    jobId: string;
+    /** 先に作られた「処理中」文書の ID。一覧に即出る */
+    docId: string;
+}
+
+export interface TranscribeStatusRequest {
+    jobId: string;
+}
+
+export type TranscribeJobPublicStatus = 'running' | 'succeeded' | 'failed';
+
+export interface TranscribeStatusResponse {
+    status: TranscribeJobPublicStatus;
+    docId: string;
+    /** 失敗時のみ。利用者向けの短い理由 */
+    error?: string;
+}
+
+export interface TranscribeBatchErrorBody {
+    error: string;
+    message: string;
+    retryAfterSec?: number;
+}

--- a/src/server/azureBatchTranscribe.test.ts
+++ b/src/server/azureBatchTranscribe.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { parseBatchResult, getAzureCredentials } from './azureBatchTranscribe';
+import type { AzureBatchResult } from '@/lib/azureBatchContract';
+
+/**
+ * 合成データのみ（架空・実顧客の発話は置かない）。バッチ結果の実際の形（recognizedPhrases /
+ * nBest[0].display / offsetMilliseconds / speaker / combinedRecognizedPhrases）を写している。
+ */
+const sampleResult = (): AzureBatchResult => ({
+    durationMilliseconds: 120_000,
+    combinedRecognizedPhrases: [{ display: 'こんにちは。よろしくお願いします。' }],
+    recognizedPhrases: [
+        {
+            offsetMilliseconds: 500,
+            durationMilliseconds: 3000,
+            speaker: 1,
+            recognitionStatus: 'Success',
+            nBest: [{ display: 'こんにちは。', confidence: 0.9, displayWords: [] }],
+        },
+        {
+            offsetMilliseconds: 4000,
+            durationMilliseconds: 2500,
+            speaker: 2,
+            recognitionStatus: 'Success',
+            nBest: [{ display: 'よろしくお願いします。', confidence: 0.88, displayWords: [] }],
+        },
+    ],
+});
+
+describe('parseBatchResult', () => {
+    it('句単位で注釈へ変換し、話者ラベルと秒を付ける', () => {
+        const parsed = parseBatchResult(sampleResult());
+        expect(parsed.status).toBe('completed');
+        expect(parsed.audioSec).toBe(120);
+        expect(parsed.annotations).toHaveLength(2);
+        expect(parsed.annotations[0]).toMatchObject({
+            startSec: 0.5,
+            endSec: 3.5,
+            speaker: 'spk:1',
+        });
+        expect(parsed.annotations[1]).toMatchObject({
+            startSec: 4,
+            endSec: 6.5,
+            speaker: 'spk:2',
+        });
+        expect(parsed.speakers).toBe(2);
+        expect(parsed.droppedPhrases).toBe(0);
+    });
+
+    it('本文は combinedRecognizedPhrases を優先する', () => {
+        const parsed = parseBatchResult(sampleResult());
+        expect(parsed.text).toContain('よろしくお願いします');
+    });
+
+    it('combined が無ければ句を連結して本文にする', () => {
+        const r = sampleResult();
+        delete (r as { combinedRecognizedPhrases?: unknown }).combinedRecognizedPhrases;
+        const parsed = parseBatchResult(r);
+        expect(parsed.text.split('\n')).toHaveLength(2);
+        expect(parsed.text).toContain('こんにちは');
+    });
+
+    it('🔴 時刻が読めない句は落とし、件数を返す（0 埋めしない）', () => {
+        const r = sampleResult();
+        (r.recognizedPhrases as unknown[]).push({
+            // offsetMilliseconds 欠落
+            durationMilliseconds: 1000,
+            speaker: 1,
+            nBest: [{ display: '欠けた句' }],
+        });
+        const parsed = parseBatchResult(r);
+        expect(parsed.annotations).toHaveLength(2); // 落ちた 1 句は入らない
+        expect(parsed.droppedPhrases).toBe(1);
+    });
+
+    it('話者が付かない句は speaker=null（本文は残す）', () => {
+        const r: AzureBatchResult = {
+            durationMilliseconds: 10_000,
+            recognizedPhrases: [
+                { offsetMilliseconds: 0, durationMilliseconds: 2000, nBest: [{ display: '話者なし' }] },
+            ],
+        };
+        const parsed = parseBatchResult(r);
+        expect(parsed.annotations[0].speaker).toBeNull();
+        expect(parsed.annotations[0].text).toBe('話者なし');
+        expect(parsed.speakers).toBe(0);
+    });
+
+    it('空の結果でも落ちない', () => {
+        const parsed = parseBatchResult({});
+        expect(parsed.annotations).toHaveLength(0);
+        expect(parsed.audioSec).toBe(0);
+        expect(parsed.text).toBe('');
+    });
+});
+
+describe('getAzureCredentials', () => {
+    const saved = { ep: process.env.AZURE_SPEECH_ENDPOINT, key: process.env.AZURE_SPEECH_KEY };
+    afterEach(() => {
+        process.env.AZURE_SPEECH_ENDPOINT = saved.ep;
+        process.env.AZURE_SPEECH_KEY = saved.key;
+    });
+
+    it('未設定なら null（設定漏れと障害を混同しない）', () => {
+        delete process.env.AZURE_SPEECH_ENDPOINT;
+        delete process.env.AZURE_SPEECH_KEY;
+        expect(getAzureCredentials()).toBeNull();
+    });
+
+    it('設定されていれば末尾スラッシュを落として返す', () => {
+        process.env.AZURE_SPEECH_ENDPOINT = 'https://example.cognitiveservices.azure.com/';
+        process.env.AZURE_SPEECH_KEY = 'k';
+        expect(getAzureCredentials()).toEqual({
+            endpoint: 'https://example.cognitiveservices.azure.com',
+            apiKey: 'k',
+        });
+    });
+});

--- a/src/server/azureBatchTranscribe.test.ts
+++ b/src/server/azureBatchTranscribe.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { parseBatchResult, getAzureCredentials } from './azureBatchTranscribe';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { parseBatchResult, getAzureCredentials, deleteBatchJob } from './azureBatchTranscribe';
 import type { AzureBatchResult } from '@/lib/azureBatchContract';
+
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
+vi.mock('@/lib/logger', () => ({ createLogger: () => ({ warn: warnMock }) }));
 
 /**
  * 合成データのみ（架空・実顧客の発話は置かない）。バッチ結果の実際の形（recognizedPhrases /
@@ -52,6 +55,51 @@ describe('parseBatchResult', () => {
         expect(parsed.text).toContain('よろしくお願いします');
     });
 
+    it('ticks のみの句も ms に変換して注釈へ残す', () => {
+        const parsed = parseBatchResult({
+            recognizedPhrases: [{
+                offsetInTicks: 5_000_000,
+                durationInTicks: 30_000_000,
+                speaker: 1,
+                nBest: [{ display: '合成の発話です。' }],
+            }],
+        });
+        expect(parsed.annotations).toEqual([{
+            text: '合成の発話です。',
+            startSec: 0.5,
+            endSec: 3.5,
+            speaker: 'spk:1',
+        }]);
+        expect(parsed.droppedPhrases).toBe(0);
+    });
+
+    it('ms が数値でなければ ticks を使い、数値の ms は ticks より優先する', () => {
+        const parsed = parseBatchResult({
+            recognizedPhrases: [{
+                offsetMilliseconds: 'invalid',
+                durationMilliseconds: 2000,
+                offsetInTicks: 10_000_000,
+                durationInTicks: 90_000_000,
+                nBest: [{ display: '時刻の補完です。' }],
+            }],
+        });
+        expect(parsed.annotations[0]).toMatchObject({ startSec: 1, endSec: 3 });
+        expect(parsed.droppedPhrases).toBe(0);
+    });
+
+    it('ms と ticks の両方が読めない句は落とす', () => {
+        const parsed = parseBatchResult({
+            recognizedPhrases: [{
+                offsetMilliseconds: 'invalid',
+                offsetInTicks: 'invalid',
+                durationInTicks: 10_000_000,
+                nBest: [{ display: '時刻不明の句です。' }],
+            }],
+        });
+        expect(parsed.annotations).toHaveLength(0);
+        expect(parsed.droppedPhrases).toBe(1);
+    });
+
     it('combined が無ければ句を連結して本文にする', () => {
         const r = sampleResult();
         delete (r as { combinedRecognizedPhrases?: unknown }).combinedRecognizedPhrases;
@@ -91,6 +139,47 @@ describe('parseBatchResult', () => {
         expect(parsed.annotations).toHaveLength(0);
         expect(parsed.audioSec).toBe(0);
         expect(parsed.text).toBe('');
+    });
+});
+
+describe('deleteBatchJob', () => {
+    const credentials = { endpoint: 'https://example.invalid', apiKey: 'synthetic-api-key' };
+    const selfUrl = 'https://example.invalid/transcriptions/synthetic-job';
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it.each([200, 202, 204, 299, 404])('status %i は削除成功として警告しない', async (status) => {
+        const fetchMock = vi.fn().mockResolvedValue({ status, text: async () => '' });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(deleteBatchJob(selfUrl, credentials)).resolves.toBeUndefined();
+
+        expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ method: 'DELETE' }));
+        expect(warnMock).not.toHaveBeenCalled();
+    });
+
+    it.each([199, 301, 401, 429, 500, 503])('status %i は警告しても例外を投げない', async (status) => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            status,
+            text: async () => JSON.stringify({ error: { message: 'synthetic upstream error' } }),
+        }));
+
+        await expect(deleteBatchJob(selfUrl, credentials)).resolves.toBeUndefined();
+
+        expect(warnMock).toHaveBeenCalledExactlyOnceWith('バッチジョブの削除に失敗（TTL に任せる）', { status });
+    });
+
+    it('通信例外でも警告に留めて確定処理を止めない', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('synthetic network failure')));
+
+        await expect(deleteBatchJob(selfUrl, credentials)).resolves.toBeUndefined();
+
+        expect(warnMock).toHaveBeenCalledExactlyOnceWith('バッチジョブの削除に失敗（TTL に任せる）', {
+            reason: 'synthetic network failure',
+        });
     });
 });
 

--- a/src/server/azureBatchTranscribe.ts
+++ b/src/server/azureBatchTranscribe.ts
@@ -1,0 +1,231 @@
+/**
+ * Azure Speech **Batch transcription** クライアント（非同期・設計 §3.7 改訂／2026-09-05 裁定）。
+ *
+ * 使い方は 3 手:
+ *   1. `submitBatchJob(signedAudioUrl)` → `selfUrl`（ジョブの参照 URL）
+ *   2. `getBatchJob(selfUrl)` を時々叩いて `status` を見る（`Succeeded`/`Failed` で確定）
+ *   3. `fetchBatchResult(selfUrl)` → `parseBatchResult()` で注釈へ
+ *
+ * 🔴 Vercel の関数はこのファイルの各呼び出し**単位**で短命（提出も照会も数秒）。同期方式のように
+ *    1 リクエストで 300 秒粘らない。だから Hobby の 300 秒上限に当たらない。
+ * 🔴 実顧客の音声を扱う。ログにファイル名・本文・URL を残さない（件数・秒・status のみ）。
+ */
+import {
+    AZURE_BATCH_SUBMIT_PATH,
+    AZURE_BATCH_API_VERSION,
+    AZURE_BATCH_API_KEY_HEADER,
+    AZURE_BATCH_LOCALE,
+    buildBatchProperties,
+    type AzureBatchResult,
+    type AzureBatchPhrase,
+    type AzureBatchNBest,
+} from '@/lib/azureBatchContract';
+import type { TranscriptAnnotation } from '@/lib/transcribeApiContract';
+import { GenerateApiError } from './errors';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('server/azureBatchTranscribe');
+
+export interface AzureCredentials {
+    endpoint: string;
+    apiKey: string;
+}
+
+/** MAI 同期側と同じ環境変数を読む。無ければ null（設定漏れと障害を混同しない）。 */
+export function getAzureCredentials(): AzureCredentials | null {
+    const endpoint = process.env.AZURE_SPEECH_ENDPOINT?.trim();
+    const apiKey = process.env.AZURE_SPEECH_KEY?.trim();
+    if (!endpoint || !apiKey) return null;
+    return { endpoint: endpoint.replace(/\/+$/, ''), apiKey };
+}
+
+const asRecord = (v: unknown): Record<string, unknown> | null =>
+    v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+
+const num = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
+
+/**
+ * self URL は提出応答から来る（`?api-version=...` を**既に含む**ことがある）。
+ * 🔴 二重に付けると 400/None になる（実測で poller が status=None を返し続けた原因）。
+ * base（クエリ無し）から必要な派生 URL を組み立てる。
+ */
+const baseOf = (selfUrl: string): string => selfUrl.split('?')[0];
+const withApiVersion = (url: string): string =>
+    url.includes('api-version=') ? url : `${url}${url.includes('?') ? '&' : '?'}api-version=${AZURE_BATCH_API_VERSION}`;
+
+async function azureFetch(
+    url: string,
+    credentials: AzureCredentials,
+    init: { method?: string; body?: unknown } = {},
+): Promise<{ status: number; json: unknown }> {
+    const headers: Record<string, string> = { [AZURE_BATCH_API_KEY_HEADER]: credentials.apiKey };
+    if (init.body !== undefined) headers['content-type'] = 'application/json';
+    const res = await fetch(url, {
+        method: init.method ?? 'GET',
+        headers,
+        ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
+    });
+    const text = await res.text();
+    let json: unknown = null;
+    try {
+        json = text ? JSON.parse(text) : null;
+    } catch {
+        json = { raw: text.slice(0, 400) };
+    }
+    return { status: res.status, json };
+}
+
+export interface SubmitResult {
+    /** ジョブの参照 URL。以後の照会・結果取得はここから派生させる */
+    selfUrl: string;
+}
+
+/**
+ * 音声（署名付き URL）を 1 本のバッチジョブとして投げる。**分割しない**。
+ * 成功は 201 Created。返る `self` を保存すること。
+ */
+export async function submitBatchJob(
+    signedAudioUrl: string,
+    credentials: AzureCredentials,
+    displayName = 'vtd-transcript',
+): Promise<SubmitResult> {
+    const url = `${credentials.endpoint}${AZURE_BATCH_SUBMIT_PATH}?api-version=${AZURE_BATCH_API_VERSION}`;
+    const body = {
+        contentUrls: [signedAudioUrl],
+        locale: AZURE_BATCH_LOCALE,
+        displayName,
+        properties: buildBatchProperties(),
+    };
+    const { status, json } = await azureFetch(url, credentials, { method: 'POST', body });
+    if (status !== 200 && status !== 201) {
+        const rec = asRecord(json);
+        const msg = str(asRecord(rec?.error)?.message) ?? str(rec?.message) ?? '';
+        logger.warn('バッチ提出に失敗', { status, msg: msg.slice(0, 200) });
+        throw new GenerateApiError('upstream_error', `文字起こしジョブの登録に失敗しました (${status})。`);
+    }
+    const selfUrl = str(asRecord(json)?.self);
+    if (!selfUrl) throw new GenerateApiError('upstream_error', '文字起こしジョブの参照が取得できませんでした。');
+    return { selfUrl };
+}
+
+export interface BatchJobState {
+    status: string; // NotStarted | Running | Succeeded | Failed | (unknown)
+    error?: string;
+}
+
+/** ジョブの現在状態を返す。🔴 self URL をそのまま使う（api-version を二重に付けない）。 */
+export async function getBatchJob(selfUrl: string, credentials: AzureCredentials): Promise<BatchJobState> {
+    const { status, json } = await azureFetch(withApiVersion(selfUrl), credentials);
+    if (status !== 200) {
+        throw new GenerateApiError('upstream_error', `文字起こしジョブの状態を取得できませんでした (${status})。`);
+    }
+    const rec = asRecord(json);
+    const jobStatus = str(rec?.status) ?? 'unknown';
+    const err = asRecord(rec?.properties)?.error;
+    return {
+        status: jobStatus,
+        ...(err ? { error: JSON.stringify(err).slice(0, 300) } : {}),
+    };
+}
+
+/** 成功したジョブの結果ファイル（kind==='Transcription'）を取得する。 */
+export async function fetchBatchResult(selfUrl: string, credentials: AzureCredentials): Promise<AzureBatchResult> {
+    const filesUrl = `${baseOf(selfUrl)}/files?api-version=${AZURE_BATCH_API_VERSION}`;
+    const { status, json } = await azureFetch(filesUrl, credentials);
+    if (status !== 200) {
+        throw new GenerateApiError('upstream_error', `文字起こし結果の一覧を取得できませんでした (${status})。`);
+    }
+    const values = asRecord(json)?.values;
+    const list = Array.isArray(values) ? values : [];
+    let contentUrl: string | undefined;
+    for (const f of list) {
+        const rec = asRecord(f);
+        if (str(rec?.kind) === 'Transcription') {
+            contentUrl = str(asRecord(rec?.links)?.contentUrl);
+            break;
+        }
+    }
+    if (!contentUrl) throw new GenerateApiError('upstream_error', '文字起こし結果ファイルが見つかりませんでした。');
+    // 結果ファイルは SAS 付きの一時 URL。鍵ヘッダは不要。
+    const res = await fetch(contentUrl);
+    if (!res.ok) throw new GenerateApiError('upstream_error', `文字起こし結果を取得できませんでした (${res.status})。`);
+    return (await res.json()) as AzureBatchResult;
+}
+
+/** ジョブと結果ファイルを削除する（TTL でも消えるが、取り終えたら即消す）。失敗は無視。 */
+export async function deleteBatchJob(selfUrl: string, credentials: AzureCredentials): Promise<void> {
+    try {
+        await azureFetch(withApiVersion(selfUrl), credentials, { method: 'DELETE' });
+    } catch (error) {
+        logger.warn('バッチジョブの削除に失敗（TTL に任せる）', {
+            reason: error instanceof Error ? error.message : String(error),
+        });
+    }
+}
+
+export interface ParsedBatch {
+    status: 'completed';
+    text: string;
+    annotations: TranscriptAnnotation[];
+    audioSec: number;
+    speakers: number;
+    /** 単語時刻は落とした語も数える（黙って減らさない） */
+    droppedPhrases: number;
+}
+
+/**
+ * バッチ結果を注釈モデルへ。**句（recognizedPhrases）単位**で 1 注釈にする。
+ * 🔴 単語全部を注釈にすると 2 時間で ~15,000 語になり Firestore の 1 MiB ドキュメント上限に当たる。
+ *    UI は段落先頭に時刻リンクを張る方式なので、句単位で十分（設計 §6.4・データモデルの注意）。
+ * 🔴 時刻が読めなかった句は落とし、件数を返す（0 埋めでカバレッジを偽らない）。
+ */
+export function parseBatchResult(result: AzureBatchResult): ParsedBatch {
+    const audioSec = (num(result.durationMilliseconds) ?? 0) / 1000;
+    const phrases = Array.isArray(result.recognizedPhrases)
+        ? (result.recognizedPhrases as AzureBatchPhrase[])
+        : [];
+
+    const annotations: TranscriptAnnotation[] = [];
+    const speakerSet = new Set<string>();
+    let droppedPhrases = 0;
+
+    for (const phrase of phrases) {
+        const offsetMs = num(phrase.offsetMilliseconds);
+        const durationMs = num(phrase.durationMilliseconds);
+        if (offsetMs === undefined || durationMs === undefined) {
+            droppedPhrases += 1;
+            continue;
+        }
+        const nBest = Array.isArray(phrase.nBest) ? (phrase.nBest[0] as AzureBatchNBest | undefined) : undefined;
+        const text = str(nBest?.display) ?? '';
+        const speaker = num(phrase.speaker);
+        const speakerLabel = speaker !== undefined ? `spk:${speaker}` : null;
+        if (speakerLabel) speakerSet.add(speakerLabel);
+        annotations.push({
+            text,
+            startSec: offsetMs / 1000,
+            endSec: (offsetMs + durationMs) / 1000,
+            speaker: speakerLabel,
+        });
+    }
+
+    // 本文は combinedRecognizedPhrases があればそれ、無ければ句を連結
+    const combined = Array.isArray(result.combinedRecognizedPhrases)
+        ? (result.combinedRecognizedPhrases as unknown[])
+        : [];
+    const combinedText = combined
+        .map((c) => str(asRecord(c)?.display))
+        .filter((t): t is string => typeof t === 'string')
+        .join('\n');
+    const text = combinedText || annotations.map((a) => a.text ?? '').join('\n');
+
+    return {
+        status: 'completed',
+        text,
+        annotations,
+        audioSec,
+        speakers: speakerSet.size,
+        droppedPhrases,
+    };
+}

--- a/src/server/azureBatchTranscribe.ts
+++ b/src/server/azureBatchTranscribe.ts
@@ -156,7 +156,10 @@ export async function fetchBatchResult(selfUrl: string, credentials: AzureCreden
 /** ジョブと結果ファイルを削除する（TTL でも消えるが、取り終えたら即消す）。失敗は無視。 */
 export async function deleteBatchJob(selfUrl: string, credentials: AzureCredentials): Promise<void> {
     try {
-        await azureFetch(withApiVersion(selfUrl), credentials, { method: 'DELETE' });
+        const { status } = await azureFetch(withApiVersion(selfUrl), credentials, { method: 'DELETE' });
+        if ((status < 200 || status >= 300) && status !== 404) {
+            logger.warn('バッチジョブの削除に失敗（TTL に任せる）', { status });
+        }
     } catch (error) {
         logger.warn('バッチジョブの削除に失敗（TTL に任せる）', {
             reason: error instanceof Error ? error.message : String(error),
@@ -191,8 +194,13 @@ export function parseBatchResult(result: AzureBatchResult): ParsedBatch {
     let droppedPhrases = 0;
 
     for (const phrase of phrases) {
-        const offsetMs = num(phrase.offsetMilliseconds);
-        const durationMs = num(phrase.durationMilliseconds);
+        const offsetTicks = num(asRecord(phrase)?.offsetInTicks);
+        const durationTicks = num(asRecord(phrase)?.durationInTicks);
+        // Azure の ticks は 100 ns 単位。ms が読めなければ ticks から補う。
+        const offsetMs = num(phrase.offsetMilliseconds)
+            ?? (offsetTicks !== undefined ? offsetTicks / 10_000 : undefined);
+        const durationMs = num(phrase.durationMilliseconds)
+            ?? (durationTicks !== undefined ? durationTicks / 10_000 : undefined);
         if (offsetMs === undefined || durationMs === undefined) {
             droppedPhrases += 1;
             continue;

--- a/src/server/finalizeTranscription.ts
+++ b/src/server/finalizeTranscription.ts
@@ -1,0 +1,39 @@
+/**
+ * バッチ結果 → 既存の文書と同じ Markdown。
+ *
+ * 🔴 既存の結合・整形（mergeTranscriptChunks / toTranscriptMarkdown）を**そのまま再利用**する。
+ *    バッチは 1 ファイル = 1 結果なのでチャンクは 1 本。出力の見た目（段落・時刻リンク・話者ラベル）は
+ *    同期チャンク方式のときと変わらない（時刻シーク再生・PDF・編集の回帰の錠がそのまま効く）。
+ * 🔴 バッチは単一エンジン（Azure 標準モデル）なので、フォールバック注記は付かない。
+ */
+import { mergeTranscriptChunks, toTranscriptMarkdown, type MergeChunk } from '@/lib/transcriptMerge';
+import type { ParsedBatch } from './azureBatchTranscribe';
+
+/** バッチ結果 1 本を、文書へ保存できる Markdown にする。 */
+export function buildTranscriptMarkdownFromBatch(parsed: ParsedBatch): string {
+    const chunk: MergeChunk = {
+        index: 0,
+        startSec: 0,
+        prefixSec: 0,
+        endSec: parsed.audioSec,
+        failed: false,
+        // 句単位の注釈。チャンク開始が 0 なので、区間内オフセット = 元音声の絶対秒。
+        annotations: parsed.annotations.map((a) => ({
+            text: a.text ?? '',
+            startOffsetSec: a.startSec ?? 0,
+            endOffsetSec: a.endSec ?? a.startSec ?? 0,
+            speaker: a.speaker ?? null,
+        })),
+    };
+    const merged = mergeTranscriptChunks([chunk]);
+    return toTranscriptMarkdown(merged);
+}
+
+/**
+ * 完成した文書に載せる「使用モデル」表示。バッチは Azure 標準モデル。
+ * 話者が付かなかった場合はその旨を添える（利用者が「話者が出ない」と混乱しないように）。
+ */
+export function describeBatchModel(parsed: ParsedBatch): string {
+    const base = 'Azure 音声認識（バッチ）';
+    return parsed.speakers >= 2 ? base : `${base}・話者分離なし`;
+}

--- a/src/server/mediaSource.ts
+++ b/src/server/mediaSource.ts
@@ -65,8 +65,15 @@ const toSizeBytes = (value: unknown): number => {
     return Number.isFinite(n) && n >= 0 ? n : 0;
 };
 
-/** 存在とサイズだけ確認する (本文は取らない)。無ければ 404、上限超なら 413 */
-export async function statMedia(storagePath: string): Promise<MediaObjectInfo> {
+/**
+ * 存在とサイズだけ確認する (本文は取らない)。無ければ 404、上限超なら 413。
+ * 🔴 `maxBytes` を渡せる。同期経路は 100MB (GENERATE_MAX_MEDIA_BYTES)、
+ *    非同期バッチ経路は Azure の 1GB (AZURE_BATCH_MAX_AUDIO_BYTES) と、上限が違うため。
+ */
+export async function statMedia(
+    storagePath: string,
+    maxBytes: number = GENERATE_MAX_MEDIA_BYTES,
+): Promise<MediaObjectInfo> {
     const file = getAdminBucket().file(storagePath);
     const [exists] = await file.exists();
     if (!exists) {
@@ -76,11 +83,27 @@ export async function statMedia(storagePath: string): Promise<MediaObjectInfo> {
     const [metadata] = await file.getMetadata();
     const sizeBytes = toSizeBytes(metadata?.size);
     const contentType = typeof metadata?.contentType === 'string' ? metadata.contentType : undefined;
-    if (sizeBytes > GENERATE_MAX_MEDIA_BYTES) {
-        logger.warn('Storage 上のファイルが上限超', { storagePath, sizeBytes, limit: GENERATE_MAX_MEDIA_BYTES });
-        throw new GenerateApiError('media_too_large', TOO_LARGE_MESSAGE);
+    if (sizeBytes > maxBytes) {
+        logger.warn('Storage 上のファイルが上限超', { storagePath, sizeBytes, limit: maxBytes });
+        throw new GenerateApiError('media_too_large',
+            `ファイルが大きすぎます (上限 ${Math.floor(maxBytes / 1024 / 1024)}MB)。`);
     }
     return { storagePath, sizeBytes, contentType };
+}
+
+/**
+ * Azure が音声を取得するための **署名付き読み取り URL** を作る（v4）。
+ * 🔴 非同期バッチは音声を URL で受け取る。Firebase Storage の署名 URL を Azure が fetch する。
+ *    鍵ではなく期限つきの URL なので、TTL を短く保つ（ジョブ完了までの数十分で十分）。
+ */
+export async function getSignedReadUrl(storagePath: string, ttlMs: number): Promise<string> {
+    const file = getAdminBucket().file(storagePath);
+    const [url] = await file.getSignedUrl({
+        version: 'v4',
+        action: 'read',
+        expires: Date.now() + ttlMs,
+    });
+    return url;
 }
 
 /** 本文を Buffer で取る。ダウンロード後のサイズも再検査する (メタと実体がずれた時の保険) */

--- a/src/server/transcriptionDocument.ts
+++ b/src/server/transcriptionDocument.ts
@@ -55,31 +55,64 @@ export async function completeTranscriptionDocument(
     docId: string,
     transcription: string,
     generatedByModel: string,
+    expectedOwnerId: string,
 ): Promise<void> {
-    await getAdminFirestore().collection(TRANSCRIPTIONS_COLLECTION).doc(docId).set(
-        {
+    const db = getAdminFirestore();
+    const ref = db.collection(TRANSCRIPTIONS_COLLECTION).doc(docId);
+    const completed = await db.runTransaction(async (tx) => {
+        const snap = await tx.get(ref);
+        if (!snap.exists) {
+            logger.warn('削除済みの文書の完成をスキップ', { docId });
+            return false;
+        }
+        const doc = snap.data();
+        if (doc?.ownerId !== expectedOwnerId) {
+            logger.warn('所有者が異なる文書の完成をスキップ', { docId });
+            return false;
+        }
+        if (doc.status !== 'processing') {
+            logger.warn('処理中でない文書の完成をスキップ', { docId });
+            return false;
+        }
+        tx.set(ref, {
             transcription,
             generatedByModel,
             status: 'completed' satisfies TranscriptionDocStatus,
             updatedAt: FieldValue.serverTimestamp(),
-        },
-        { merge: true },
-    );
-    logger.info('文書を完成', { docId, chars: transcription.length });
+        }, { merge: true });
+        return true;
+    });
+    if (completed) logger.info('文書を完成', { docId, chars: transcription.length });
 }
 
 /**
  * 失敗: 文書は消さず、理由を本文に残して status を failed にする（件数だけの警報にしない）。
  * 🔴 「何も無い」より「なぜ失敗したかが読める」方が利用者にとって良い（L2-D1・設計 §4.4）。
  */
-export async function failTranscriptionDocument(docId: string, reason: string): Promise<void> {
-    await getAdminFirestore().collection(TRANSCRIPTIONS_COLLECTION).doc(docId).set(
-        {
+export async function failTranscriptionDocument(docId: string, reason: string, expectedOwnerId: string): Promise<void> {
+    const db = getAdminFirestore();
+    const ref = db.collection(TRANSCRIPTIONS_COLLECTION).doc(docId);
+    const failed = await db.runTransaction(async (tx) => {
+        const snap = await tx.get(ref);
+        if (!snap.exists) {
+            logger.warn('削除済みの文書の失敗更新をスキップ', { docId });
+            return false;
+        }
+        const doc = snap.data();
+        if (doc?.ownerId !== expectedOwnerId) {
+            logger.warn('所有者が異なる文書の失敗更新をスキップ', { docId });
+            return false;
+        }
+        if (doc.status !== 'processing') {
+            logger.warn('処理中でない文書の失敗更新をスキップ', { docId });
+            return false;
+        }
+        tx.set(ref, {
             transcription: `文字起こしに失敗しました。\n\n理由: ${reason}\n\nお手数ですが、もう一度お試しください。`,
             status: 'failed' satisfies TranscriptionDocStatus,
             updatedAt: FieldValue.serverTimestamp(),
-        },
-        { merge: true },
-    );
-    logger.warn('文書を失敗として記録', { docId, reason: reason.slice(0, 200) });
+        }, { merge: true });
+        return true;
+    });
+    if (failed) logger.warn('文書を失敗として記録', { docId, reason: reason.slice(0, 200) });
 }

--- a/src/server/transcriptionDocument.ts
+++ b/src/server/transcriptionDocument.ts
@@ -1,0 +1,85 @@
+/**
+ * 非同期バッチ用の**サーバ側（Admin SDK）文書書き込み**。
+ *
+ * 🔴 なぜサーバが書くか: バッチはブラウザのタブと無関係に Azure 側で走る。完了を webhook / poll の
+ *    どちらで受けても、**タブが閉じていても文書へ書けるように**サーバが所有する（設計 §7.3）。
+ * 🔴 クライアントが一覧で読む `transcriptions` コレクションに、同じ形で書く（追加フィールドは `status`）。
+ *    既存の読み取りは未知フィールドを無視するので後方互換。
+ * 🔴 失敗しても文書は消さない（設計 §4.4・L2-D1 の是正）。理由を本文に残す。
+ */
+import { FieldValue } from 'firebase-admin/firestore';
+import { getAdminFirestore } from './firebaseAdmin';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('server/transcriptionDocument');
+
+export const TRANSCRIPTIONS_COLLECTION = 'transcriptions';
+
+export type TranscriptionDocStatus = 'processing' | 'completed' | 'failed';
+
+export interface CreateProcessingDocInput {
+    ownerId: string;
+    ownerType: 'guest' | 'user';
+    fileName: string;
+    promptName: string;
+    title?: string;
+    originalFileType: string; // 'audio' | 'video'
+    audioStoragePath?: string;
+}
+
+const PROCESSING_PLACEHOLDER = '（文字起こしを実行しています。完了すると自動で反映されます。数分〜十数分かかることがあります。）';
+
+/** 文書を 'processing' で先に作り、一覧へ即出す。返り値は docId。 */
+export async function createProcessingDocument(input: CreateProcessingDocInput): Promise<string> {
+    const ref = getAdminFirestore().collection(TRANSCRIPTIONS_COLLECTION).doc();
+    await ref.set({
+        title: input.title || input.fileName,
+        fileName: input.fileName,
+        originalFileType: input.originalFileType,
+        transcription: PROCESSING_PLACEHOLDER,
+        promptName: input.promptName,
+        ownerType: input.ownerType,
+        ownerId: input.ownerId,
+        createdBy: input.ownerId,
+        status: 'processing' satisfies TranscriptionDocStatus,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        ...(input.audioStoragePath && { audioStoragePath: input.audioStoragePath }),
+    });
+    logger.info('処理中の文書を作成', { docId: ref.id, ownerType: input.ownerType });
+    return ref.id;
+}
+
+/** 完了: 本文を書き込み、status を completed にする。 */
+export async function completeTranscriptionDocument(
+    docId: string,
+    transcription: string,
+    generatedByModel: string,
+): Promise<void> {
+    await getAdminFirestore().collection(TRANSCRIPTIONS_COLLECTION).doc(docId).set(
+        {
+            transcription,
+            generatedByModel,
+            status: 'completed' satisfies TranscriptionDocStatus,
+            updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+    );
+    logger.info('文書を完成', { docId, chars: transcription.length });
+}
+
+/**
+ * 失敗: 文書は消さず、理由を本文に残して status を failed にする（件数だけの警報にしない）。
+ * 🔴 「何も無い」より「なぜ失敗したかが読める」方が利用者にとって良い（L2-D1・設計 §4.4）。
+ */
+export async function failTranscriptionDocument(docId: string, reason: string): Promise<void> {
+    await getAdminFirestore().collection(TRANSCRIPTIONS_COLLECTION).doc(docId).set(
+        {
+            transcription: `文字起こしに失敗しました。\n\n理由: ${reason}\n\nお手数ですが、もう一度お試しください。`,
+            status: 'failed' satisfies TranscriptionDocStatus,
+            updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+    );
+    logger.warn('文書を失敗として記録', { docId, reason: reason.slice(0, 200) });
+}

--- a/src/server/transcriptionJob.test.ts
+++ b/src/server/transcriptionJob.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type JobRef = { id: string };
+type JobData = Record<string, unknown>;
+type Transaction = {
+    get: (ref: JobRef) => Promise<{ exists: boolean; data: () => JobData | undefined }>;
+    update: (ref: JobRef, patch: JobData) => void;
+};
+
+const doubles = vi.hoisted(() => ({
+    jobs: new Map<string, JobData>(),
+    transactionTail: Promise.resolve() as Promise<unknown>,
+    update: vi.fn(),
+    runTransaction: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: { serverTimestamp: () => 'SERVER_TS' },
+}));
+vi.mock('./firebaseAdmin', () => ({
+    getAdminFirestore: () => ({
+        collection: (name: string) => ({ doc: (id: string) => ({ id: `${name}/${id}` }) }),
+        runTransaction: doubles.runTransaction,
+    }),
+}));
+
+import { claimJobForFinalize, FINALIZE_LEASE_MS } from './transcriptionJob';
+
+const NOW_MS = 1_800_000_000_000;
+const JOB_ID = 'synthetic-job';
+const JOB_PATH = `transcriptionJobs/${JOB_ID}`;
+
+const makeJob = (patch: JobData = {}): JobData => ({
+    ownerId: 'synthetic-owner',
+    ownerType: 'user',
+    docId: 'synthetic-document',
+    azureSelfUrl: 'https://example.invalid/transcriptions/synthetic-job',
+    status: 'running',
+    audioSec: 120,
+    storagePath: 'synthetic-owner/audio.mp3',
+    promptName: '全文文字起こし',
+    createdAt: { toMillis: () => NOW_MS - 60_000 },
+    updatedAt: { toMillis: () => NOW_MS - 30_000 },
+    ...patch,
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(Date, 'now').mockReturnValue(NOW_MS);
+    doubles.jobs.clear();
+    doubles.transactionTail = Promise.resolve();
+    // Firestore の同じ文書に対するトランザクションを直列化し、確定した更新を次の読取へ渡す。
+    doubles.runTransaction.mockImplementation((fn: (tx: Transaction) => Promise<unknown>) => {
+        const result = doubles.transactionTail.then(async () => {
+            const pendingUpdates: Array<{ ref: JobRef; patch: JobData }> = [];
+            const value = await fn({
+                get: async ref => {
+                    const data = doubles.jobs.get(ref.id);
+                    return { exists: data !== undefined, data: () => data };
+                },
+                update: (ref, patch) => {
+                    doubles.update(ref, patch);
+                    pendingUpdates.push({ ref, patch });
+                },
+            });
+            for (const { ref, patch } of pendingUpdates) {
+                doubles.jobs.set(ref.id, {
+                    ...doubles.jobs.get(ref.id),
+                    ...patch,
+                    updatedAt: patch.updatedAt === 'SERVER_TS' ? { toMillis: () => NOW_MS } : patch.updatedAt,
+                });
+            }
+            return value;
+        });
+        doubles.transactionTail = result.catch(() => undefined);
+        return result;
+    });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('claimJobForFinalize', () => {
+    it('存在しないジョブを作らず null を返す', async () => {
+        await expect(claimJobForFinalize(JOB_ID)).resolves.toBeNull();
+        expect(doubles.update).not.toHaveBeenCalled();
+        expect(doubles.jobs.size).toBe(0);
+    });
+
+    it.each(['succeeded', 'failed'])('終端 %s は再確定しない', async status => {
+        doubles.jobs.set(JOB_PATH, makeJob({ status }));
+        await expect(claimJobForFinalize(JOB_ID)).resolves.toBeNull();
+        expect(doubles.update).not.toHaveBeenCalled();
+    });
+
+    it('running を finalizing に変更し、更新後のジョブを返す', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob());
+        await expect(claimJobForFinalize(JOB_ID)).resolves.toEqual({
+            id: JOB_ID,
+            ownerId: 'synthetic-owner',
+            ownerType: 'user',
+            docId: 'synthetic-document',
+            azureSelfUrl: 'https://example.invalid/transcriptions/synthetic-job',
+            status: 'finalizing',
+            audioSec: 120,
+            storagePath: 'synthetic-owner/audio.mp3',
+            promptName: '全文文字起こし',
+            createdAtMs: NOW_MS - 60_000,
+            updatedAtMs: NOW_MS,
+        });
+        expect(doubles.runTransaction).toHaveBeenCalledTimes(1);
+        expect(doubles.update).toHaveBeenCalledWith({ id: JOB_PATH }, { status: 'finalizing', updatedAt: 'SERVER_TS' });
+        expect(doubles.jobs.get(JOB_PATH)?.status).toBe('finalizing');
+    });
+
+    it.each([0, FINALIZE_LEASE_MS - 1, FINALIZE_LEASE_MS])('リースが切れていない finalizing（経過 %i ms）は取得しない', async elapsedMs => {
+        doubles.jobs.set(JOB_PATH, makeJob({ status: 'finalizing', updatedAt: { toMillis: () => NOW_MS - elapsedMs } }));
+        await expect(claimJobForFinalize(JOB_ID)).resolves.toBeNull();
+        expect(doubles.update).not.toHaveBeenCalled();
+    });
+
+    it('リースが切れた finalizing は取得し直して時刻を更新する', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob({ status: 'finalizing', updatedAt: { toMillis: () => NOW_MS - FINALIZE_LEASE_MS - 1 } }));
+        await expect(claimJobForFinalize(JOB_ID)).resolves.toMatchObject({ status: 'finalizing', updatedAtMs: NOW_MS });
+        expect(doubles.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('並行した 2 リクエストのうち 1 つだけ確定権を得る', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob());
+        const jobs = await Promise.all([claimJobForFinalize(JOB_ID), claimJobForFinalize(JOB_ID)]);
+        expect(jobs.filter(job => job !== null)).toHaveLength(1);
+        expect(jobs.filter(job => job === null)).toHaveLength(1);
+        expect(doubles.runTransaction).toHaveBeenCalledTimes(2);
+        expect(doubles.update).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/server/transcriptionJob.test.ts
+++ b/src/server/transcriptionJob.test.ts
@@ -5,16 +5,21 @@ type JobData = Record<string, unknown>;
 type Transaction = {
     get: (ref: JobRef) => Promise<{ exists: boolean; data: () => JobData | undefined }>;
     update: (ref: JobRef, patch: JobData) => void;
+    set: (ref: JobRef, patch: JobData, options: { merge: boolean }) => void;
 };
 
 const doubles = vi.hoisted(() => ({
     jobs: new Map<string, JobData>(),
     transactionTail: Promise.resolve() as Promise<unknown>,
+    commitError: undefined as Error | undefined,
+    get: vi.fn(),
     update: vi.fn(),
+    set: vi.fn(),
     runTransaction: vi.fn(),
+    warn: vi.fn(),
 }));
 
-vi.mock('@/lib/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('@/lib/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: doubles.warn, error: vi.fn() }) }));
 vi.mock('firebase-admin/firestore', () => ({
     FieldValue: { serverTimestamp: () => 'SERVER_TS' },
 }));
@@ -25,11 +30,14 @@ vi.mock('./firebaseAdmin', () => ({
     }),
 }));
 
-import { claimJobForFinalize, FINALIZE_LEASE_MS } from './transcriptionJob';
+import { claimJobForFinalize, commitTerminalOutcome, FINALIZE_LEASE_MS, type TerminalOutcome } from './transcriptionJob';
 
 const NOW_MS = 1_800_000_000_000;
 const JOB_ID = 'synthetic-job';
 const JOB_PATH = `transcriptionJobs/${JOB_ID}`;
+const DOC_ID = 'synthetic-document';
+const DOC_PATH = `transcriptions/${DOC_ID}`;
+const OWNER_ID = 'synthetic-owner';
 
 const makeJob = (patch: JobData = {}): JobData => ({
     ownerId: 'synthetic-owner',
@@ -45,17 +53,38 @@ const makeJob = (patch: JobData = {}): JobData => ({
     ...patch,
 });
 
+const makeDocument = (patch: JobData = {}): JobData => ({
+    ownerId: OWNER_ID,
+    status: 'processing',
+    transcription: '合成の処理中本文',
+    title: '合成の文書',
+    ...patch,
+});
+
+const successOutcome: TerminalOutcome = {
+    kind: 'succeeded',
+    transcription: '合成の文字起こし結果',
+    generatedByModel: 'Azure synthetic model',
+    speakers: 2,
+};
+const failureOutcome: TerminalOutcome = { kind: 'failed', reason: '合成の失敗理由' };
+const terminalParams = (outcome: TerminalOutcome) => ({ jobId: JOB_ID, docId: DOC_ID, expectedOwnerId: OWNER_ID, outcome });
+
 beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(Date, 'now').mockReturnValue(NOW_MS);
     doubles.jobs.clear();
     doubles.transactionTail = Promise.resolve();
+    doubles.commitError = undefined;
+    doubles.set.mockReset();
     // Firestore の同じ文書に対するトランザクションを直列化し、確定した更新を次の読取へ渡す。
     doubles.runTransaction.mockImplementation((fn: (tx: Transaction) => Promise<unknown>) => {
         const result = doubles.transactionTail.then(async () => {
             const pendingUpdates: Array<{ ref: JobRef; patch: JobData }> = [];
             const value = await fn({
                 get: async ref => {
+                    if (pendingUpdates.length > 0) throw new Error('Firestore reads must precede writes');
+                    doubles.get(ref);
                     const data = doubles.jobs.get(ref.id);
                     return { exists: data !== undefined, data: () => data };
                 },
@@ -63,7 +92,12 @@ beforeEach(() => {
                     doubles.update(ref, patch);
                     pendingUpdates.push({ ref, patch });
                 },
+                set: (ref, patch, options) => {
+                    doubles.set(ref, patch, options);
+                    pendingUpdates.push({ ref, patch });
+                },
             });
+            if (doubles.commitError) throw doubles.commitError;
             for (const { ref, patch } of pendingUpdates) {
                 doubles.jobs.set(ref.id, {
                     ...doubles.jobs.get(ref.id),
@@ -134,5 +168,125 @@ describe('claimJobForFinalize', () => {
         expect(jobs.filter(job => job === null)).toHaveLength(1);
         expect(doubles.runTransaction).toHaveBeenCalledTimes(2);
         expect(doubles.update).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('commitTerminalOutcome', () => {
+    beforeEach(() => {
+        doubles.jobs.set(JOB_PATH, makeJob({ status: 'finalizing', updatedAt: { toMillis: () => NOW_MS } }));
+        doubles.jobs.set(DOC_PATH, makeDocument());
+    });
+
+    it('文書とジョブを同じトランザクションで読み、成功本文と終端状態を同時に保存する', async () => {
+        await expect(commitTerminalOutcome(terminalParams(successOutcome))).resolves.toBe('committed');
+        expect(doubles.runTransaction).toHaveBeenCalledTimes(1);
+        expect(doubles.get.mock.calls).toEqual([[{ id: JOB_PATH }], [{ id: DOC_PATH }]]);
+        expect(doubles.set).toHaveBeenCalledTimes(2);
+        expect(doubles.set).toHaveBeenNthCalledWith(1, { id: DOC_PATH }, {
+            transcription: successOutcome.transcription,
+            generatedByModel: successOutcome.generatedByModel,
+            status: 'completed',
+            updatedAt: 'SERVER_TS',
+        }, { merge: true });
+        expect(doubles.set).toHaveBeenNthCalledWith(2, { id: JOB_PATH }, {
+            status: 'succeeded', speakers: 2, updatedAt: 'SERVER_TS',
+        }, { merge: true });
+        expect(doubles.jobs.get(DOC_PATH)).toMatchObject({
+            title: '合成の文書', status: 'completed', transcription: successOutcome.transcription,
+            generatedByModel: successOutcome.generatedByModel,
+        });
+        expect(doubles.jobs.get(JOB_PATH)).toMatchObject({ status: 'succeeded', speakers: 2, docId: DOC_ID });
+        expect(doubles.update).not.toHaveBeenCalled();
+    });
+
+    it('失敗でも文書を消さず理由本文を残し、ジョブも同じトランザクションで失敗にする', async () => {
+        await expect(commitTerminalOutcome(terminalParams(failureOutcome))).resolves.toBe('committed');
+        expect(doubles.runTransaction).toHaveBeenCalledTimes(1);
+        expect(doubles.get.mock.calls).toEqual([[{ id: JOB_PATH }], [{ id: DOC_PATH }]]);
+        expect(doubles.set).toHaveBeenCalledTimes(2);
+        expect(doubles.set).toHaveBeenNthCalledWith(1, { id: DOC_PATH }, {
+            transcription: `文字起こしに失敗しました。\n\n理由: ${failureOutcome.reason}\n\nお手数ですが、もう一度お試しください。`,
+            status: 'failed', updatedAt: 'SERVER_TS',
+        }, { merge: true });
+        expect(doubles.set).toHaveBeenNthCalledWith(2, { id: JOB_PATH }, {
+            status: 'failed', error: failureOutcome.reason, updatedAt: 'SERVER_TS',
+        }, { merge: true });
+        expect(doubles.jobs.get(DOC_PATH)).toMatchObject({
+            title: '合成の文書', status: 'failed', transcription: expect.stringContaining(failureOutcome.reason),
+        });
+        expect(doubles.jobs.get(JOB_PATH)).toMatchObject({ status: 'failed', error: failureOutcome.reason });
+        expect(doubles.jobs.size).toBe(2);
+    });
+
+    it.each([undefined, 'running', 'succeeded', 'failed'])('ジョブが %s なら not_owner を返し、どちらにも書かない', async status => {
+        if (status === undefined) doubles.jobs.delete(JOB_PATH);
+        else doubles.jobs.set(JOB_PATH, makeJob({ status }));
+        const previous = new Map(doubles.jobs);
+        await expect(commitTerminalOutcome(terminalParams(successOutcome))).resolves.toBe('not_owner');
+        expect(doubles.get.mock.calls).toEqual([[{ id: JOB_PATH }]]);
+        expect(doubles.set).not.toHaveBeenCalled();
+        expect(doubles.update).not.toHaveBeenCalled();
+        expect(doubles.jobs).toEqual(previous);
+    });
+
+    describe.each([successOutcome, failureOutcome])('$kind の文書保護と原子性', outcome => {
+        it.each([
+            { name: '削除済み', document: undefined },
+            { name: '所有者が異なる', document: makeDocument({ ownerId: 'synthetic-other-owner' }) },
+            { name: 'completed', document: makeDocument({ status: 'completed', transcription: '利用者の合成編集' }) },
+            { name: 'failed', document: makeDocument({ status: 'failed', transcription: '既存の合成失敗理由' }) },
+            { name: 'status 未設定', document: makeDocument({ status: undefined }) },
+        ])('$name の文書は復活・上書きせず、ジョブだけを終端化する', async ({ document }) => {
+            if (document === undefined) doubles.jobs.delete(DOC_PATH);
+            else doubles.jobs.set(DOC_PATH, document);
+            await expect(commitTerminalOutcome(terminalParams(outcome))).resolves.toBe('committed');
+            expect(doubles.jobs.get(DOC_PATH)).toEqual(document);
+            expect(doubles.jobs.get(JOB_PATH)?.status).toBe(outcome.kind);
+            expect(doubles.set).toHaveBeenCalledTimes(1);
+            expect(doubles.set).toHaveBeenCalledWith({ id: JOB_PATH }, expect.objectContaining({ status: outcome.kind }), { merge: true });
+            expect(doubles.warn).toHaveBeenCalledTimes(1);
+        });
+
+        it.each(['文書の書き込み', 'ジョブの書き込み', 'コミット'])('%s が失敗したら両方を維持し、リース切れ後に本文保存を再試行できる', async stage => {
+            const error = new Error('synthetic transaction failure');
+            if (stage === 'コミット') {
+                doubles.commitError = error;
+            } else {
+                if (stage === 'ジョブの書き込み') doubles.set.mockImplementationOnce(() => undefined);
+                doubles.set.mockImplementationOnce(() => { throw error; });
+            }
+            const previous = new Map(doubles.jobs);
+            await expect(commitTerminalOutcome(terminalParams(outcome))).rejects.toBe(error);
+            expect(doubles.jobs).toEqual(previous);
+            expect(doubles.jobs.get(DOC_PATH)?.status).toBe('processing');
+            expect(doubles.jobs.get(JOB_PATH)?.status).toBe('finalizing');
+
+            doubles.commitError = undefined;
+            vi.mocked(Date.now).mockReturnValue(NOW_MS + FINALIZE_LEASE_MS + 1);
+            await expect(claimJobForFinalize(JOB_ID)).resolves.toMatchObject({ status: 'finalizing' });
+            await expect(commitTerminalOutcome(terminalParams(successOutcome))).resolves.toBe('committed');
+            expect(doubles.jobs.get(DOC_PATH)).toMatchObject({ status: 'completed', transcription: successOutcome.transcription });
+            expect(doubles.jobs.get(JOB_PATH)).toMatchObject({ status: 'succeeded', speakers: 2 });
+        });
+
+        it('確定済みなら再実行しても本文とジョブを変更しない', async () => {
+            await expect(commitTerminalOutcome(terminalParams(outcome))).resolves.toBe('committed');
+            const committed = new Map(doubles.jobs);
+            doubles.set.mockClear();
+            await expect(commitTerminalOutcome(terminalParams(successOutcome))).resolves.toBe('not_owner');
+            expect(doubles.jobs).toEqual(committed);
+            expect(doubles.set).not.toHaveBeenCalled();
+        });
+    });
+
+    it('並行した成功・失敗の確定は片方だけコミットし、文書とジョブの終端状態が一致する', async () => {
+        const results = await Promise.all([
+            commitTerminalOutcome(terminalParams(successOutcome)),
+            commitTerminalOutcome(terminalParams(failureOutcome)),
+        ]);
+        expect(results).toEqual(['committed', 'not_owner']);
+        expect(doubles.jobs.get(DOC_PATH)).toMatchObject({ status: 'completed', transcription: successOutcome.transcription });
+        expect(doubles.jobs.get(JOB_PATH)?.status).toBe('succeeded');
+        expect(doubles.set).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/server/transcriptionJob.ts
+++ b/src/server/transcriptionJob.ts
@@ -1,0 +1,106 @@
+/**
+ * 非同期バッチ文字起こしの**ジョブ状態**を Firestore `transcriptionJobs/{jobId}` に持つ。
+ *
+ * 🔴 なぜ永続化するか（設計 §7.2・L5-#5 の指摘）: 現行はジョブ状態がブラウザのメモリにしか無く、
+ *    タブを閉じる/リロード/スリープで全損し、再開は全チャンクやり直し（再課金）だった。
+ *    バッチは Azure 側で数分〜数十分走るので、状態をサーバに持てば**タブ非依存**で完了を拾える。
+ *
+ * 🔴 このコレクションはサーバ (Admin SDK) だけが書く。クライアントは status API 経由で読む。
+ *    Firestore ルールでクライアントの直接読み書きは禁止する（別途 firestore.rules）。
+ */
+import { FieldValue, type Firestore } from 'firebase-admin/firestore';
+import { getAdminFirestore } from './firebaseAdmin';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('server/transcriptionJob');
+
+export const TRANSCRIPTION_JOBS_COLLECTION = 'transcriptionJobs';
+
+export type TranscriptionJobStatus = 'running' | 'succeeded' | 'failed';
+
+export interface TranscriptionJob {
+    id: string;
+    ownerId: string;
+    ownerType: 'guest' | 'user';
+    /** 先に作っておく文書の ID。完了時にここへ本文を書き込む */
+    docId: string;
+    /** Azure バッチジョブの参照 URL（?api-version 付き。二重付与しないこと） */
+    azureSelfUrl: string;
+    status: TranscriptionJobStatus;
+    audioSec: number;
+    storagePath: string;
+    promptName: string;
+    /** 失敗理由（利用者にも記録にも残す。件数だけの警報にしない） */
+    error?: string;
+    /** 何名の話者が出たか等、完了時の要約（本文は入れない） */
+    speakers?: number;
+    createdAtMs: number;
+    updatedAtMs: number;
+}
+
+export interface CreateTranscriptionJobInput {
+    ownerId: string;
+    ownerType: 'guest' | 'user';
+    docId: string;
+    azureSelfUrl: string;
+    audioSec: number;
+    storagePath: string;
+    promptName: string;
+}
+
+const db = (): Firestore => getAdminFirestore();
+
+const toMs = (v: unknown): number => {
+    if (v && typeof v === 'object' && typeof (v as { toMillis?: () => number }).toMillis === 'function') {
+        return (v as { toMillis: () => number }).toMillis();
+    }
+    return typeof v === 'number' ? v : 0;
+};
+
+const parseJob = (id: string, data: FirebaseFirestore.DocumentData | undefined): TranscriptionJob | null => {
+    if (!data) return null;
+    if (typeof data.azureSelfUrl !== 'string' || typeof data.docId !== 'string') return null;
+    return {
+        id,
+        ownerId: String(data.ownerId ?? ''),
+        ownerType: data.ownerType === 'user' ? 'user' : 'guest',
+        docId: data.docId,
+        azureSelfUrl: data.azureSelfUrl,
+        status: (['running', 'succeeded', 'failed'] as const).includes(data.status) ? data.status : 'running',
+        audioSec: typeof data.audioSec === 'number' ? data.audioSec : 0,
+        storagePath: String(data.storagePath ?? ''),
+        promptName: String(data.promptName ?? ''),
+        ...(typeof data.error === 'string' && { error: data.error }),
+        ...(typeof data.speakers === 'number' && { speakers: data.speakers }),
+        createdAtMs: toMs(data.createdAt),
+        updatedAtMs: toMs(data.updatedAt),
+    };
+};
+
+/** ジョブを作る。ID は Firestore の自動採番を使う。 */
+export async function createTranscriptionJob(input: CreateTranscriptionJobInput): Promise<string> {
+    const ref = db().collection(TRANSCRIPTION_JOBS_COLLECTION).doc();
+    await ref.set({
+        ...input,
+        status: 'running' satisfies TranscriptionJobStatus,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+    });
+    logger.info('文字起こしジョブを登録', { jobId: ref.id, ownerType: input.ownerType, audioSec: input.audioSec });
+    return ref.id;
+}
+
+export async function getTranscriptionJob(jobId: string): Promise<TranscriptionJob | null> {
+    const snap = await db().collection(TRANSCRIPTION_JOBS_COLLECTION).doc(jobId).get();
+    return parseJob(jobId, snap.exists ? snap.data() : undefined);
+}
+
+export async function updateTranscriptionJob(
+    jobId: string,
+    patch: Partial<Pick<TranscriptionJob, 'status' | 'error' | 'speakers'>>,
+): Promise<void> {
+    await db().collection(TRANSCRIPTION_JOBS_COLLECTION).doc(jobId).set(
+        { ...patch, updatedAt: FieldValue.serverTimestamp() },
+        { merge: true },
+    );
+}

--- a/src/server/transcriptionJob.ts
+++ b/src/server/transcriptionJob.ts
@@ -16,7 +16,15 @@ const logger = createLogger('server/transcriptionJob');
 
 export const TRANSCRIPTION_JOBS_COLLECTION = 'transcriptionJobs';
 
-export type TranscriptionJobStatus = 'running' | 'succeeded' | 'failed';
+/**
+ * `finalizing` は確定処理中の一時状態（内部用）。
+ * 🔴 並行に status が 2 回叩かれても確定を 1 回にするための CAS ロック（設計 §3.7・冪等性）。
+ *    利用者向けの公開ステータスは running / succeeded / failed の 3 値だけ（finalizing は running 相当に見せる）。
+ */
+export type TranscriptionJobStatus = 'running' | 'finalizing' | 'succeeded' | 'failed';
+
+/** finalizing のまま放置されたジョブ（確定中にプロセスが落ちた等）を再確定できるようにするリース期限 */
+export const FINALIZE_LEASE_MS = 3 * 60 * 1000;
 
 export interface TranscriptionJob {
     id: string;
@@ -66,7 +74,7 @@ const parseJob = (id: string, data: FirebaseFirestore.DocumentData | undefined):
         ownerType: data.ownerType === 'user' ? 'user' : 'guest',
         docId: data.docId,
         azureSelfUrl: data.azureSelfUrl,
-        status: (['running', 'succeeded', 'failed'] as const).includes(data.status) ? data.status : 'running',
+        status: (['running', 'finalizing', 'succeeded', 'failed'] as const).includes(data.status) ? data.status : 'running',
         audioSec: typeof data.audioSec === 'number' ? data.audioSec : 0,
         storagePath: String(data.storagePath ?? ''),
         promptName: String(data.promptName ?? ''),
@@ -93,6 +101,24 @@ export async function createTranscriptionJob(input: CreateTranscriptionJobInput)
 export async function getTranscriptionJob(jobId: string): Promise<TranscriptionJob | null> {
     const snap = await db().collection(TRANSCRIPTION_JOBS_COLLECTION).doc(jobId).get();
     return parseJob(jobId, snap.exists ? snap.data() : undefined);
+}
+
+/** 確定権を取得する。処理中のリースが切れた場合だけ、別リクエストで再取得できる。 */
+export async function claimJobForFinalize(jobId: string): Promise<TranscriptionJob | null> {
+    const firestore = db();
+    const ref = firestore.collection(TRANSCRIPTION_JOBS_COLLECTION).doc(jobId);
+    return firestore.runTransaction(async tx => {
+        const snap = await tx.get(ref);
+        const job = parseJob(jobId, snap.exists ? snap.data() : undefined);
+        if (!job || job.status === 'succeeded' || job.status === 'failed') return null;
+
+        const nowMs = Date.now();
+        if (job.status === 'finalizing' && nowMs - job.updatedAtMs <= FINALIZE_LEASE_MS) return null;
+
+        tx.update(ref, { status: 'finalizing', updatedAt: FieldValue.serverTimestamp() });
+        // serverTimestamp は commit 時に確定するため、戻り値には取得時刻を使う。
+        return { ...job, status: 'finalizing', updatedAtMs: nowMs };
+    });
 }
 
 export async function updateTranscriptionJob(

--- a/src/server/transcriptionJob.ts
+++ b/src/server/transcriptionJob.ts
@@ -10,6 +10,7 @@
  */
 import { FieldValue, type Firestore } from 'firebase-admin/firestore';
 import { getAdminFirestore } from './firebaseAdmin';
+import { TRANSCRIPTIONS_COLLECTION, type TranscriptionDocStatus } from './transcriptionDocument';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('server/transcriptionJob');
@@ -55,6 +56,10 @@ export interface CreateTranscriptionJobInput {
     storagePath: string;
     promptName: string;
 }
+
+export type TerminalOutcome =
+    | { kind: 'succeeded'; transcription: string; generatedByModel: string; speakers: number }
+    | { kind: 'failed'; reason: string };
 
 const db = (): Firestore => getAdminFirestore();
 
@@ -118,6 +123,57 @@ export async function claimJobForFinalize(jobId: string): Promise<TranscriptionJ
         tx.update(ref, { status: 'finalizing', updatedAt: FieldValue.serverTimestamp() });
         // serverTimestamp は commit 時に確定するため、戻り値には取得時刻を使う。
         return { ...job, status: 'finalizing', updatedAtMs: nowMs };
+    });
+}
+
+/** 文書とジョブを同時に終端化する。失敗時は両方の更新を取り消し、リース切れ後に再確定できる。 */
+export async function commitTerminalOutcome(params: {
+    jobId: string;
+    docId: string;
+    expectedOwnerId: string;
+    outcome: TerminalOutcome;
+}): Promise<'committed' | 'not_owner'> {
+    const { jobId, docId, expectedOwnerId, outcome } = params;
+    const firestore = db();
+    const jobRef = firestore.collection(TRANSCRIPTION_JOBS_COLLECTION).doc(jobId);
+    const docRef = firestore.collection(TRANSCRIPTIONS_COLLECTION).doc(docId);
+    return firestore.runTransaction(async tx => {
+        const jobSnap = await tx.get(jobRef);
+        if (!jobSnap.exists || jobSnap.data()?.status !== 'finalizing') return 'not_owner';
+
+        const docSnap = await tx.get(docRef);
+        const doc = docSnap.data();
+        const updatedAt = FieldValue.serverTimestamp();
+        if (!docSnap.exists) {
+            logger.warn('削除済みの文書の終端更新をスキップ', { docId });
+        } else if (doc?.ownerId !== expectedOwnerId) {
+            logger.warn('所有者が異なる文書の終端更新をスキップ', { docId });
+        } else if (doc.status !== 'processing') {
+            logger.warn('処理中でない文書の終端更新をスキップ', { docId });
+        } else {
+            tx.set(docRef, outcome.kind === 'succeeded' ? {
+                transcription: outcome.transcription,
+                generatedByModel: outcome.generatedByModel,
+                status: 'completed' satisfies TranscriptionDocStatus,
+                updatedAt,
+            } : {
+                transcription: `文字起こしに失敗しました。\n\n理由: ${outcome.reason}\n\nお手数ですが、もう一度お試しください。`,
+                status: 'failed' satisfies TranscriptionDocStatus,
+                updatedAt,
+            }, { merge: true });
+        }
+
+        // 文書が削除・変更されていてもジョブは終端化し、同じ結果の取り込みを繰り返さない。
+        tx.set(jobRef, outcome.kind === 'succeeded' ? {
+            status: 'succeeded' satisfies TranscriptionJobStatus,
+            speakers: outcome.speakers,
+            updatedAt,
+        } : {
+            status: 'failed' satisfies TranscriptionJobStatus,
+            error: outcome.reason,
+            updatedAt,
+        }, { merge: true });
+        return 'committed';
     });
 }
 


### PR DESCRIPTION
## 概要

全文文字起こしを**非同期バッチ方式**（Azure Speech batch transcription）へ全面移行します。0ベースの再監査で判明した「普通の録音で文字起こしを丸ごと失う障害が8つ以上重なっていた」状態を、土台ごと解消します。

裁定（東野）: 非同期バッチ方式へ移行・Vercel Hobby は維持。

## なぜ必要か（旧・同期チャンク方式の根本原因）

| # | 障害 | 由来 |
|---|---|---|
| 1 | 1区間でも失敗すると成功区間の本文も全部捨てる | 消費側が `success:false` で例外→本文破棄 |
| 2 | 全区間成功でも冒頭末尾の無音が合計120秒超で全文破棄 | 結合の不変条件 |
| 3 | タイムアウト予算 595秒 > Vercel 300秒 | MAI 115s＋Files API待ち240s＋推論240s の直列 |
| 4 | MAI-Transcribe-2 が10分チャンクで 0/3 | 約120秒の同期上限。かつ本番非推奨のプレビュー |
| 5 | レートがチャンク1試行=1消費（2時間で最大36消費） | 議事録と共有の50/時に接近 |
| 6 | 無音チャンク（休憩）が品質検査G2で必ず失敗しジョブ全滅 | |
| 7 | ffmpeg が元ファイルを毎試行書き直し・並走でクロストーク | ブラウザ分割 |
| 8 | 進捗ゼロ・タブを閉じると全損 | 状態がメモリのみ |

3・4・6・7 は「同期・分割・300秒」という土台そのものに由来し、バッチ方式で構造的に消えます。

## 実測で裏付け（合成23分 + 実商談2本の18分窓）

- 提出→完了 **9〜16分（実時間の0.26〜0.39倍）**。1時間会議で約16〜23分。「完了後に反映」型で実用。
- **実際の人間の声では話者分離が正しく2名に分かれた**（合成音声で1名だったのは合成音の音響的類似が原因）。
- 単語時刻は末尾まで欠落なし。標準モデルの信頼度 0.72〜0.86。

## 実音源での動作検証（本PRのコードで実施・2026-09-05）

実商談1本の18分窓を Azure バッチで起こし、**本PRの本番モジュール**（`parseBatchResult` →
`buildTranscriptMarkdownFromBatch`）にそのまま通して、生成文書の構造を検査（日本語の発話内容は一切出力せず件数・秒・ラベルのみ）:

| 検査 | 結果 |
|---|---|
| 提出→完了 | 281秒（18分音声・実時間の0.26倍） |
| 話者 | **2名（spk:1 / spk:2）** |
| 注釈（句） | 90・落とした句 0 |
| 時刻リンク | 17・範囲外時刻なし（最大1,060 ≤ 1,080秒） |
| 文書の形 | `[mm:ss](#t=秒) **spk:N** 本文`（既存UIがそのままシーク再生を描画できる形式） |

検証後、Azure 上の音声・ジョブ・生結果はすべて削除済み。実顧客データはコミットにもPRにも含めない。

## 新しい流れ

1. 音声を**分割せず丸ごと**アップロード（動画は音声抽出1回のみ）。
2. 短命な `POST /api/transcribe/submit` が Azure バッチへ1本投げ、**処理中の文書を先に作って** `{jobId, docId}` を即返す。
3. `POST /api/transcribe/status` をポーリング。Azure が完了すれば**その場で確定**（結果取得→Markdown化→文書更新→Azureジョブ削除）。

- 各関数呼び出しが数秒 → Vercel 300秒に当たらない（**Hobby維持で問題なし**）。
- 文書はサーバが作って完成させる → **タブを閉じても継続**。
- **失敗しても文書を消さず理由を残す**（最重大欠陥#1の是正）。
- 確定は `job.status` で**冪等** → webhook 無しでもポーリングだけで完結。
- レートは**1ジョブ1消費**。
- 出力整形は既存の merge/markdown を再利用 → **文書の見た目・時刻シーク再生・PDF は現行と同一**。

## トレードオフ（明示）

- エンジンは **Azure 標準モデル**（バッチは MAI/Gemini 不可）。用語集は結合後の表記統一で代替（設計 §5.1）。標準モデルの網羅・信頼度は MAI よりやや低い可能性。
- **顧客音声が Azure southeastasia を経由**します。データ所在の可否は経営判断が必要（別途）。
- Vercel Hobby は規約上「商用利用禁止」が明文化されています（本PRの範囲外・経営判断）。

## テスト

- **実ルートを通す契約テスト**（submit/status）を新設。本番で3回出た「テスト緑なのに壊れる」型（継ぎ目が全部モックで orchestration を一度も実行していなかった）の再発防止として、「submit が Azure提出・文書作成・ジョブ作成を実際に呼ぶ」「Succeeded で確定が最後まで貫通する」「Failed でも文書を消さない」「冪等」を錠にしています。
- 解析器・クライアントアダプタの単体テスト（合成データのみ・公開リポに実顧客データは置かない）。
- 全体 **1,588 passed / 1 skipped / 0 failed**。tsc・lint 緑。Preview ビルド成功。

## このPRに含めないもの（次段）

- 旧・同期チャンク経路（`/api/transcribe/chunk`・`transcribeWithFallback`・`maiTranscribe`・`useTranscriptionJob` のチャンク分割）は**休眠**（クライアントからは呼ばれない）。退役の削除は影響範囲が大きいので別PR。
- 進捗の粒度表示（「文字起こし中 k/N」相当）・区間再試行UI。
- 100MB単一上限の緩和（長時間対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
