### PR TITLE
feat(文字起こし): 全文文字起こしの進捗段階表示（PR1）

### DIFF
--- a/src/app/(dashboard)/documents/page.test.tsx
+++ b/src/app/(dashboard)/documents/page.test.tsx
@@ -5,6 +5,10 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Transcription } from '@/lib/firestore';
 import type { TranscribeStatusResponse } from '@/lib/transcribeBatchContract';
+import type {
+  DocumentStatusWatchOptions,
+  DocumentStatusWatchSnapshot,
+} from '@/hooks/batchTranscriptionClient';
 import DocumentsPage from './page';
 
 // jsdomはshowModal/closeを実装していないため、共通Dialogを使う画面のテストは
@@ -51,7 +55,33 @@ type DetailPanelProps = {
   onDirtyChange?: (dirty: boolean) => void;
   onDraftDiscarded?: () => void;
   onRequestLatestDocument?: () => void;
+  processingWatch?: DocumentStatusWatchSnapshot | null;
+  onCheckProcessingStatus?: () => void;
 };
+
+// 継続確認の偽物。page が渡した onChange/onTerminal をテストから叩けるように保持する。
+type FakeWatch = {
+  docId: string;
+  options: DocumentStatusWatchOptions;
+  stop: ReturnType<typeof vi.fn>;
+  checkNow: ReturnType<typeof vi.fn>;
+  getSnapshot: ReturnType<typeof vi.fn>;
+};
+const fakeWatches: FakeWatch[] = [];
+
+const watchSnapshot = (
+  docId: string,
+  overrides: Partial<DocumentStatusWatchSnapshot> = {},
+): DocumentStatusWatchSnapshot => ({
+  docId,
+  mode: 'checking',
+  lastResponse: null,
+  lastResponseAtMs: null,
+  lastError: null,
+  consecutiveFailures: 0,
+  startedAtMs: 0,
+  ...overrides,
+});
 
 type MountedPage = {
   container: HTMLDivElement;
@@ -96,6 +126,7 @@ const mocks = vi.hoisted(() => ({
   detailSave: vi.fn(),
   headerNavigation: vi.fn(),
   reconcileProcessingDocument: vi.fn(),
+  startDocumentStatusWatch: vi.fn(),
   restoreTranscription: vi.fn(),
   updateTranscription: vi.fn(),
 }));
@@ -123,6 +154,7 @@ vi.mock('@/hooks/useAuth', () => ({
 
 vi.mock('@/hooks/batchTranscriptionClient', () => ({
   reconcileProcessingDocument: mocks.reconcileProcessingDocument,
+  startDocumentStatusWatch: mocks.startDocumentStatusWatch,
 }));
 
 vi.mock('@/components/DocumentListSidebar', () => ({
@@ -321,7 +353,16 @@ vi.mock('@/components/DocumentDetailPanel', async () => {
           data-document-id={props.document?.id ?? ''}
           data-document-title={props.document?.title ?? ''}
           data-document-text={props.document?.text ?? ''}
+          data-watch-mode={props.processingWatch?.mode ?? ''}
+          data-watch-doc-id={props.processingWatch?.docId ?? ''}
         >
+          <button
+            type="button"
+            data-testid="check-processing-status"
+            onClick={() => props.onCheckProcessingStatus?.()}
+          >
+            状態を確認
+          </button>
           <button
             type="button"
             data-testid="mark-dirty"
@@ -517,6 +558,23 @@ describe('DocumentsPage', () => {
     mocks.reconcileProcessingDocument.mockReset().mockImplementation(async (docId: string) => ({
       status: 'running', docId,
     }));
+    fakeWatches.length = 0;
+    mocks.startDocumentStatusWatch.mockReset().mockImplementation((
+      docId: string,
+      options: DocumentStatusWatchOptions = {},
+    ) => {
+      const watch: FakeWatch = {
+        docId,
+        options,
+        stop: vi.fn(),
+        checkNow: vi.fn(async () => null),
+        getSnapshot: vi.fn(() => watchSnapshot(docId)),
+      };
+      fakeWatches.push(watch);
+      // 実装と同じく、開始時に「確認中」のスナップショットを同期で 1 回流す。
+      options.onChange?.(watchSnapshot(docId));
+      return watch;
+    });
     mocks.restoreTranscription.mockReset().mockResolvedValue(undefined);
     mocks.updateTranscription.mockReset().mockResolvedValue(undefined);
     vi.spyOn(window, 'confirm').mockImplementation(mocks.confirm);
@@ -608,12 +666,114 @@ describe('DocumentsPage', () => {
       'processing-0', 'processing-1', 'processing-2', 'processing-3', 'processing-4',
     ]);
 
-    // 一覧の自動確認上限を超えた文書も、詳細を開けば 1 回確認する。
+    // 一覧の自動確認上限を超えた文書も、詳細を開けば確認される。ただし選択中の文書は
+    // 直列キューではなく継続確認（watch）が受け持ち、同じ文書を二重に問い合わせない（仕様 §A2 手順3）。
     await act(async () => latestListSidebarProps?.onDocumentClick(documents[6]));
     await act(async () => latestListSidebarProps?.onDocumentClick(documents[6]));
     await publishLoadedDocuments([...documents]);
-    expect(mocks.reconcileProcessingDocument).toHaveBeenCalledTimes(6);
-    expect(mocks.reconcileProcessingDocument.mock.calls[5][0]).toBe('processing-6');
+    expect(mocks.reconcileProcessingDocument).toHaveBeenCalledTimes(5);
+    expect(mocks.startDocumentStatusWatch).toHaveBeenCalledTimes(1);
+    expect(mocks.startDocumentStatusWatch.mock.calls[0][0]).toBe('processing-6');
+  });
+
+  describe('選択中の processing 文書の継続確認（仕様 §A2 手順3〜5・A4）', () => {
+    const processingFirst: Transcription = {
+      ...firstDocument, status: 'processing', ownerId: 'owner-1', ownerType: 'user',
+      processingProgress: { stage: 'queued' },
+    };
+    const completedSecond: Transcription = {
+      ...secondDocument, status: 'completed', ownerId: 'owner-1', ownerType: 'user',
+    };
+
+    it('processing 文書を選ぶと継続確認を開始し、鮮度スナップショットを詳細へ渡す。選択を変えると止める', async () => {
+      const mounted = await mountPage();
+      await publishLoadedDocuments([processingFirst, completedSecond]);
+      expect(mocks.startDocumentStatusWatch).not.toHaveBeenCalled();
+
+      await act(async () => latestListSidebarProps?.onDocumentClick(processingFirst));
+      expect(mocks.startDocumentStatusWatch).toHaveBeenCalledExactlyOnceWith(
+        firstDocument.id, expect.objectContaining({ onChange: expect.any(Function), onTerminal: expect.any(Function) }),
+      );
+      expect(getByTestId(mounted.container, 'detail-panel').dataset.watchMode).toBe('checking');
+      expect(getByTestId(mounted.container, 'detail-panel').dataset.watchDocId).toBe(firstDocument.id);
+
+      // 一覧の定期取得（同じ内容）では watch を作り直さない。
+      await publishLoadedDocuments([{ ...processingFirst }, completedSecond]);
+      expect(mocks.startDocumentStatusWatch).toHaveBeenCalledTimes(1);
+      expect(fakeWatches[0].stop).not.toHaveBeenCalled();
+
+      await act(async () => fakeWatches[0].options.onChange?.(watchSnapshot(firstDocument.id!, { mode: 'waiting' })));
+      expect(getByTestId(mounted.container, 'detail-panel').dataset.watchMode).toBe('waiting');
+
+      await act(async () => latestListSidebarProps?.onDocumentClick(completedSecond));
+      expect(fakeWatches[0].stop).toHaveBeenCalledOnce();
+      // completed 文書は継続確認の対象にしない（一覧の全行を照会する構成にもしない）。
+      expect(mocks.startDocumentStatusWatch).toHaveBeenCalledTimes(1);
+      expect(getByTestId(mounted.container, 'detail-panel').dataset.watchMode).toBe('');
+    });
+
+    it('🔴 終端応答を受けたら一覧を再取得し、文書が completed になれば継続確認を止める', async () => {
+      const mounted = await mountPage();
+      await publishLoadedDocuments([processingFirst]);
+      await act(async () => latestListSidebarProps?.onDocumentClick(processingFirst));
+      expect(getByTestId(mounted.container, 'update-trigger').textContent).toBe('0');
+
+      await act(async () => {
+        fakeWatches[0].options.onTerminal?.({ status: 'succeeded', docId: firstDocument.id!, stage: 'completed' });
+      });
+      expect(getByTestId(mounted.container, 'update-trigger').textContent).toBe('1');
+      expect(mocks.updateTranscription).not.toHaveBeenCalled();
+
+      await publishLoadedDocuments([{ ...processingFirst, status: 'completed', text: '完成した本文' }]);
+      expect(fakeWatches[0].stop).toHaveBeenCalledOnce();
+      expect(getByTestId(mounted.container, 'detail-panel').dataset.documentText).toBe('完成した本文');
+      expect(getByTestId(mounted.container, 'detail-panel').dataset.watchMode).toBe('');
+    });
+
+    it('「状態を確認」は継続確認の checkNow を呼ぶ（新しい確認経路や submit を作らない）', async () => {
+      const mounted = await mountPage();
+      await publishLoadedDocuments([processingFirst]);
+      await act(async () => latestListSidebarProps?.onDocumentClick(processingFirst));
+
+      const reconcileCallsBeforeClick = mocks.reconcileProcessingDocument.mock.calls.length;
+      await click(getByTestId(mounted.container, 'check-processing-status'));
+      expect(fakeWatches[0].checkNow).toHaveBeenCalledOnce();
+      // 手動確認は継続確認の経路を使う。一度限りの再確定キューを新たに叩かない
+      expect(mocks.reconcileProcessingDocument).toHaveBeenCalledTimes(reconcileCallsBeforeClick);
+    });
+
+    it('unmount で継続確認を止める', async () => {
+      const mounted = await mountPage();
+      await publishLoadedDocuments([processingFirst]);
+      await act(async () => latestListSidebarProps?.onDocumentClick(processingFirst));
+      expect(fakeWatches).toHaveLength(1);
+
+      await unmountPage(mounted);
+      expect(fakeWatches[0].stop).toHaveBeenCalledOnce();
+    });
+
+    it('owner 切替で継続確認を止め、新 owner には古い監視を渡さない', async () => {
+      const mounted = await mountPage();
+      await publishLoadedDocuments([processingFirst]);
+      await act(async () => latestListSidebarProps?.onDocumentClick(processingFirst));
+
+      mocks.authState.user = { uid: 'owner-2' };
+      await rerenderPage(mounted);
+      expect(fakeWatches[0].stop).toHaveBeenCalledOnce();
+      expect(getByTestId(mounted.container, 'detail-panel').dataset.watchMode).toBe('');
+      expect(mocks.startDocumentStatusWatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('他 owner の processing 文書や completed 文書は継続確認しない', async () => {
+      const mounted = await mountPage();
+      const otherOwner: Transcription = { ...processingFirst, id: 'other-owner', ownerId: 'owner-2' };
+      await publishLoadedDocuments([otherOwner, completedSecond]);
+
+      await act(async () => latestListSidebarProps?.onDocumentClick(otherOwner));
+      await act(async () => latestListSidebarProps?.onDocumentClick(completedSecond));
+      expect(mocks.startDocumentStatusWatch).not.toHaveBeenCalled();
+      expect(getByTestId(mounted.container, 'detail-panel').dataset.watchMode).toBe('');
+    });
   });
 
   it('確認失敗でも後続文書を確認し、一覧は表示し続ける', async () => {

--- a/src/app/(dashboard)/documents/page.tsx
+++ b/src/app/(dashboard)/documents/page.tsx
@@ -27,7 +27,12 @@ import {
   updateTranscription,
 } from '@/lib/firestore';
 import { useAuth } from '@/hooks/useAuth';
-import { reconcileProcessingDocument } from '@/hooks/batchTranscriptionClient';
+import {
+  reconcileProcessingDocument,
+  startDocumentStatusWatch,
+  type DocumentStatusWatch,
+  type DocumentStatusWatchSnapshot,
+} from '@/hooks/batchTranscriptionClient';
 
 type DocumentListState = {
   status: 'loading' | 'success' | 'error';
@@ -129,6 +134,9 @@ export default function DocumentsPage() {
     checkedDocumentIds: Set<string>;
     pending: Promise<void>;
   } | null>(null);
+  // 選択中の processing 文書 1 件の継続確認（仕様 §A2 手順3〜5）。状態カードの鮮度情報の出所。
+  const [processingWatch, setProcessingWatch] = useState<DocumentStatusWatchSnapshot | null>(null);
+  const processingWatchRef = useRef<DocumentStatusWatch | null>(null);
 
   const isOwnerContextChanged = activeOwnerKey !== ownerKey;
 
@@ -515,10 +523,13 @@ export default function DocumentsPage() {
     const documentsToReconcile = processingDocuments.slice(
       0, Math.max(0, MAX_DOCUMENT_RECONCILES_PER_OPEN - reconciliation.checkedDocumentIds.size),
     );
-    // 自動確認の上限を超える文書も、詳細を選択したときは同じ直列キューで確認する。
+    // 選択中の processing 文書は継続確認（下の watch effect）が即時に 1 回確認し、以後 15 秒間隔で
+    // 続ける。直列キューでは扱わず、同じ文書を二重に問い合わせない（仕様 §A2 手順3）。
     const selectedProcessingDocument = processingDocuments.find(document => document.id === selectedDocumentId);
-    if (selectedProcessingDocument && !documentsToReconcile.includes(selectedProcessingDocument)) {
-      documentsToReconcile.push(selectedProcessingDocument);
+    if (selectedProcessingDocument) {
+      reconciliation.checkedDocumentIds.add(selectedProcessingDocument.id!);
+      const selectedIndex = documentsToReconcile.indexOf(selectedProcessingDocument);
+      if (selectedIndex >= 0) documentsToReconcile.splice(selectedIndex, 1);
     }
 
     for (const document of documentsToReconcile) {
@@ -537,6 +548,39 @@ export default function DocumentsPage() {
       });
     }
   }, [documents, handleRequestLatestDocument, isOwnerContextChanged, listState.status, ownerKey, selectedDocumentId, user]);
+
+  // 継続確認の対象: 自分が所有する、選択中の processing 文書 1 件だけ（一覧の全行は照会しない）。
+  // 選択変更・owner 変更・終端（一覧の再取得で status が変わる）・画面離脱で対象が外れ、watch は止まる。
+  const watchedDocumentId = !isOwnerContextChanged
+    && listState.status === 'success'
+    && selectedDocument?.id
+    && selectedDocument.status === 'processing'
+    && selectedDocument.ownerId === (user?.uid ?? 'GUEST')
+    && selectedDocument.ownerType === (user ? 'user' : 'guest')
+    ? selectedDocument.id
+    : null;
+
+  useEffect(() => {
+    if (!watchedDocumentId) {
+      setProcessingWatch(null);
+      return;
+    }
+    const watch = startDocumentStatusWatch(watchedDocumentId, {
+      onChange: setProcessingWatch,
+      // 終端応答: サーバは既に文書を確定済み。最新文書を取り直し、状態カードから本文/失敗理由へ切り替える。
+      onTerminal: () => handleRequestLatestDocument(),
+    });
+    processingWatchRef.current = watch;
+    return () => {
+      watch.stop();
+      if (processingWatchRef.current === watch) processingWatchRef.current = null;
+    };
+  }, [handleRequestLatestDocument, watchedDocumentId]);
+
+  // 状態カードの「状態を確認」。継続確認と同じ経路を使い、実行中は重複送信しない（仕様 §A2 手順4）。
+  const handleCheckProcessingStatus = useCallback(() => {
+    void processingWatchRef.current?.checkNow();
+  }, []);
 
   useEffect(() => {
     componentMountedRef.current = true;
@@ -1153,6 +1197,8 @@ export default function DocumentsPage() {
                     onDraftDiscarded={handleDetailDraftDiscarded}
                     onRequestLatestDocument={handleRequestLatestDocument}
                     onBackToList={handleBackToList}
+                    processingWatch={processingWatch}
+                    onCheckProcessingStatus={handleCheckProcessingStatus}
                   />
                 </div>
               </div>

--- a/src/app/api/transcribe/batch.contract.test.ts
+++ b/src/app/api/transcribe/batch.contract.test.ts
@@ -8,7 +8,9 @@
  *    「status が Succeeded で確定処理を最後まで配線している」ことを錠にする。
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { AzureBatchResult } from '@/lib/azureBatchContract';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
+import type { AzureBatchResult, AzureBatchStatus } from '@/lib/azureBatchContract';
+import type { TranscribeJobPublicStatus, TranscribeProgressStage } from '@/lib/transcribeBatchContract';
 
 const documentDb = vi.hoisted(() => ({
     data: undefined as Record<string, unknown> | undefined,
@@ -81,6 +83,7 @@ vi.mock('@/server/transcriptionDocument', async (importActual) => {
         ...actual,
         createProcessingDocument: vi.fn(async () => 'doc-1'),
         attachJobToDocument: vi.fn(actual.attachJobToDocument),
+        writeProcessingProgress: vi.fn(actual.writeProcessingProgress),
     };
 });
 vi.mock('@/server/transcriptionJob', async (importActual) => {
@@ -89,6 +92,7 @@ vi.mock('@/server/transcriptionJob', async (importActual) => {
         ...actual,
         claimJobForFinalize: vi.fn(),
         commitTerminalOutcome: vi.fn(actual.commitTerminalOutcome),
+        recordAzureObservation: vi.fn(actual.recordAzureObservation),
         createTranscriptionJob: vi.fn(async () => 'job-1'),
         getTranscriptionJob: vi.fn(),
         getTranscriptionJobByDocId: vi.fn(),
@@ -101,10 +105,37 @@ import { POST as statusPOST } from './status/route';
 import { resolveRequestSubject } from '@/server/auth';
 import { submitBatchJob, getAzureCredentials, getBatchJob, fetchBatchResult, deleteBatchJob } from '@/server/azureBatchTranscribe';
 import { getSignedReadUrl } from '@/server/mediaSource';
-import { attachJobToDocument, createProcessingDocument } from '@/server/transcriptionDocument';
-import { claimJobForFinalize, commitTerminalOutcome, FINALIZE_LEASE_MS, createTranscriptionJob, getTranscriptionJob, getTranscriptionJobByDocId, updateTranscriptionJob } from '@/server/transcriptionJob';
+import { attachJobToDocument, createProcessingDocument, writeProcessingProgress } from '@/server/transcriptionDocument';
+import { claimJobForFinalize, commitTerminalOutcome, recordAzureObservation, type TranscriptionJob, FINALIZE_LEASE_MS, createTranscriptionJob, getTranscriptionJob, getTranscriptionJobByDocId, updateTranscriptionJob } from '@/server/transcriptionJob';
 import { getTranscriptionDocuments, getTranscriptions, getTranscriptionsByOwnerId, restoreTranscription } from '@/lib/firestore';
 import * as finalization from '@/server/finalizeTranscription';
+
+const syntheticNowMs = 1_788_000_000_000;
+const syntheticCreatedAtMs = syntheticNowMs - 600_000;
+
+const expectedStatus = (status: TranscribeJobPublicStatus, options: {
+    stage?: TranscribeProgressStage; observed?: boolean; error?: string;
+} = {}) => ({
+    status, docId: 'doc-1',
+    stage: options.stage ?? (status === 'succeeded' ? 'completed' : status === 'failed' ? 'failed' : 'checking'),
+    createdAtMs: syntheticCreatedAtMs, audioSec: 600, serverNowMs: syntheticNowMs,
+    ...(options.observed && { azureStatusCheckedAtMs: syntheticNowMs }),
+    ...(options.error !== undefined && { error: options.error }),
+});
+
+// Firestore の merge/set と delete/serverTimestamp を合成データ上で適用する。
+const mergeFirestorePatch = (data: Record<string, unknown> | undefined, patch: Record<string, unknown>) => {
+    const result = { ...data };
+    for (const [key, value] of Object.entries(patch)) {
+        if (value instanceof FieldValue && value.isEqual(FieldValue.delete())) delete result[key];
+        else if (value instanceof FieldValue && value.isEqual(FieldValue.serverTimestamp())) {
+            result[key] = Timestamp.fromMillis(Date.now());
+        } else if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+            result[key] = mergeFirestorePatch(undefined, value as Record<string, unknown>);
+        } else result[key] = value;
+    }
+    return result;
+};
 
 const guest = { kind: 'guest' as const };
 const req = (body: unknown) => new Request('http://t/api', { method: 'POST', body: JSON.stringify(body) });
@@ -120,16 +151,22 @@ const sampleAzureResult = (): AzureBatchResult => ({
 
 beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(Date, 'now').mockReturnValue(syntheticNowMs);
     vi.mocked(resolveRequestSubject).mockResolvedValue(guest);
     documentDb.data = { ownerId: 'GUEST', status: 'processing', title: '合成の文書', transcription: '処理中' };
-    documentDb.jobData = { status: 'finalizing' };
+    documentDb.jobData = {
+        ownerId: 'GUEST', ownerType: 'guest', docId: 'doc-1', status: 'finalizing',
+        azureSelfUrl: 'https://ep/speechtotext/transcriptions/JID?api-version=2024-11-15',
+        audioSec: 600, storagePath: 'audio/GUEST/x.mp3', promptName: 'p',
+        createdAt: Timestamp.fromMillis(syntheticCreatedAtMs), updatedAt: Timestamp.fromMillis(syntheticNowMs),
+    };
     documentDb.commitError = undefined;
     documentDb.ref.get.mockImplementation(async () => ({
         exists: documentDb.data !== undefined,
         data: () => documentDb.data,
     }));
     documentDb.ref.set.mockImplementation(async (patch) => {
-        documentDb.data = { ...documentDb.data, ...patch };
+        documentDb.data = mergeFirestorePatch(documentDb.data, patch);
     });
     documentDb.tx.get.mockImplementation(async (ref) => {
         const data = ref.path === documentDb.jobRef.path ? documentDb.jobData : documentDb.data;
@@ -139,14 +176,15 @@ beforeEach(() => {
         const writes: Array<{ ref: { path: string }; patch: Record<string, unknown> }> = [];
         documentDb.tx.set.mockImplementation((ref, patch) => { writes.push({ ref, patch }); });
         const result = await fn(documentDb.tx);
-        if (documentDb.commitError) {
+        if (documentDb.commitError && writes.some(({ ref, patch }) =>
+            ref.path === documentDb.jobRef.path && (patch.status === 'succeeded' || patch.status === 'failed'))) {
             const error = documentDb.commitError;
             documentDb.commitError = undefined;
             throw error;
         }
         for (const { ref, patch } of writes) {
-            if (ref.path === documentDb.jobRef.path) documentDb.jobData = { ...documentDb.jobData, ...patch };
-            else documentDb.data = { ...documentDb.data, ...patch };
+            if (ref.path === documentDb.jobRef.path) documentDb.jobData = mergeFirestorePatch(documentDb.jobData, patch);
+            else documentDb.data = mergeFirestorePatch(documentDb.data, patch);
         }
         return result;
     });
@@ -222,7 +260,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         id: 'job-1', ownerId: 'GUEST', ownerType: 'guest' as const, docId: 'doc-1',
         azureSelfUrl: 'https://ep/speechtotext/transcriptions/JID?api-version=2024-11-15',
         status: 'running' as const, audioSec: 600, storagePath: 'audio/GUEST/x.mp3',
-        promptName: 'p', createdAtMs: 0, updatedAtMs: 0,
+        promptName: 'p', createdAtMs: syntheticCreatedAtMs, updatedAtMs: syntheticNowMs,
     };
 
     beforeEach(() => {
@@ -237,7 +275,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
         const res = await statusPOST(req({ docId: 'doc-1' }));
         expect(res.status).toBe(200);
-        expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
         expect(documentDb.ref.get).toHaveBeenCalledTimes(1);
         expect(getTranscriptionJob).toHaveBeenCalledExactlyOnceWith('job-1');
         expect(getTranscriptionJobByDocId).not.toHaveBeenCalled();
@@ -253,7 +291,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
         vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
         const res = await statusPOST(req({ docId: 'doc-1' }));
-        expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
         expect(getTranscriptionJobByDocId).toHaveBeenCalledExactlyOnceWith('doc-1');
         expect(getTranscriptionJob).not.toHaveBeenCalled();
         expect(documentDb.data).toMatchObject({ status: 'completed' });
@@ -263,7 +301,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
     it('docId から Azure の失敗も文書とジョブへ確定する', async () => {
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Failed', error: '合成の失敗理由' });
         const res = await statusPOST(req({ docId: 'doc-1' }));
-        expect(await res.json()).toEqual({ status: 'failed', docId: 'doc-1', error: '合成の失敗理由' });
+        expect(await res.json()).toEqual(expectedStatus('failed', { error: '合成の失敗理由', observed: true }));
         expect(documentDb.data).toMatchObject({ status: 'failed', transcription: expect.stringContaining('合成の失敗理由') });
         expect(documentDb.jobData).toMatchObject({ status: 'failed' });
     });
@@ -299,7 +337,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         });
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Running' });
         const res = await statusPOST(req({ docId: 'doc-1' }));
-        expect(await res.json()).toEqual({ status: 'running', docId: 'doc-1' });
+        expect(await res.json()).toEqual(expectedStatus('running', { stage: 'transcribing', observed: true }));
         expect(getTranscriptionJob).toHaveBeenCalledWith('synthetic-stale-job');
         expect(getTranscriptionJobByDocId).toHaveBeenCalledExactlyOnceWith('doc-1');
         expect(claimJobForFinalize).toHaveBeenCalledExactlyOnceWith('job-1');
@@ -335,10 +373,122 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         vi.mocked(getTranscriptionJob).mockResolvedValue(runningJob);
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Running' });
         const res = await statusPOST(req({ jobId: 'job-1' }));
-        expect(await res.json()).toEqual({ status: 'running', docId: 'doc-1' });
+        expect(await res.json()).toEqual(expectedStatus('running', { stage: 'transcribing', observed: true }));
         expect(commitTerminalOutcome).not.toHaveBeenCalled();
         expect(claimJobForFinalize).toHaveBeenCalledWith('job-1');
         expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'running' });
+    });
+
+    it.each([
+        ['NotStarted', 'queued'],
+        ['Running', 'transcribing'],
+    ] as const)('Azure %s は %s を返し、文書へ段階を投影する', async (azureStatus, stage) => {
+        vi.mocked(getBatchJob).mockResolvedValue({ status: azureStatus });
+        const beforeUpdatedAt = documentDb.jobData?.updatedAt;
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual(expectedStatus('running', { stage, observed: true }));
+        expect(recordAzureObservation).toHaveBeenCalledExactlyOnceWith('job-1', azureStatus);
+        expect(documentDb.jobData).toMatchObject({
+            azureStatus, azureStatusCheckedAt: Timestamp.fromMillis(syntheticNowMs), updatedAt: beforeUpdatedAt,
+        });
+        expect(writeProcessingProgress).toHaveBeenCalledExactlyOnceWith('doc-1', 'GUEST', {
+            jobId: 'job-1', stage, jobCreatedAtMs: syntheticCreatedAtMs, audioSec: 600,
+        });
+        expect(documentDb.data).toMatchObject({
+            status: 'processing', jobId: 'job-1', transcription: '処理中',
+            processingProgress: {
+                stage, stageObservedAt: Timestamp.fromMillis(syntheticNowMs),
+                jobCreatedAtMs: syntheticCreatedAtMs, audioSec: 600,
+            },
+        });
+        expect(fetchBatchResult).not.toHaveBeenCalled();
+        expect(commitTerminalOutcome).not.toHaveBeenCalled();
+    });
+
+    it('同じ段階の再 poll は観測時刻だけを進め、文書の段階時刻を書き直さない', async () => {
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Running' });
+        await statusPOST(req({ jobId: 'job-1' }));
+        const savedProgress = documentDb.data?.processingProgress;
+        documentDb.tx.set.mockClear();
+        vi.mocked(Date.now).mockReturnValue(syntheticNowMs + 30_000);
+
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+
+        expect(await res.json()).toMatchObject({
+            stage: 'transcribing', azureStatusCheckedAtMs: syntheticNowMs + 30_000,
+            serverNowMs: syntheticNowMs + 30_000,
+        });
+        expect(documentDb.data?.processingProgress).toEqual(savedProgress);
+        expect(documentDb.tx.set).toHaveBeenCalledExactlyOnceWith(documentDb.jobRef, {
+            azureStatus: 'Running', azureStatusCheckedAt: FieldValue.serverTimestamp(),
+        }, { merge: true });
+    });
+
+    it('Succeeded を観測したら本文取得の前に importing を投影し、保存後に completed にする', async () => {
+        let signalImporting!: () => void;
+        const importing = new Promise<void>(resolve => { signalImporting = resolve; });
+        let finishImport!: () => void;
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+        vi.mocked(fetchBatchResult).mockImplementationOnce(() => {
+            signalImporting();
+            return new Promise(resolve => { finishImport = () => resolve(sampleAzureResult()); });
+        });
+
+        const request = statusPOST(req({ jobId: 'job-1' }));
+        await importing;
+        expect(documentDb.data).toMatchObject({ status: 'processing', processingProgress: { stage: 'importing' } });
+        expect(documentDb.jobData).toMatchObject({ status: 'finalizing', azureStatus: 'Succeeded' });
+        expect(commitTerminalOutcome).not.toHaveBeenCalled();
+        expect(deleteBatchJob).not.toHaveBeenCalled();
+
+        vi.mocked(getTranscriptionJob).mockResolvedValueOnce({
+            ...runningJob, status: 'finalizing', azureStatus: 'Succeeded', azureStatusCheckedAtMs: syntheticNowMs,
+        });
+        const concurrent = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await concurrent.json()).toEqual(expectedStatus('running', { stage: 'importing', observed: true }));
+        finishImport();
+        expect(await (await request).json()).toEqual(expectedStatus('succeeded', { observed: true }));
+        expect(documentDb.data).toMatchObject({ status: 'completed', transcription: expect.stringContaining('よろしくお願いします') });
+        expect(documentDb.data).not.toHaveProperty('processingProgress');
+    });
+
+    it.each([
+        [undefined, 'checking'], ['NotStarted', 'queued'], ['Running', 'transcribing'],
+        ['Succeeded', 'importing'], ['Failed', 'checking'], ['Unknown', 'checking'],
+    ] as const)('finalizing は Azure 観測 %s の段階 %s を返す', async (azureStatus, stage) => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue({
+            ...runningJob, status: 'finalizing', azureStatus: azureStatus as AzureBatchStatus | undefined,
+        });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual(expectedStatus('running', { stage }));
+        expect(getBatchJob).not.toHaveBeenCalled();
+        expect(recordAzureObservation).not.toHaveBeenCalled();
+        expect(writeProcessingProgress).not.toHaveBeenCalled();
+    });
+
+    it.each(['succeeded', 'failed'] as const)('終端 %s は保存済みの Azure Running より優先する', async status => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue({
+            ...runningJob, status, azureStatus: 'Running', azureStatusCheckedAtMs: syntheticNowMs - 60_000,
+        });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual({
+            ...expectedStatus(status), azureStatusCheckedAtMs: syntheticNowMs - 60_000,
+        });
+        expect(getBatchJob).not.toHaveBeenCalled();
+        expect(writeProcessingProgress).not.toHaveBeenCalled();
+    });
+
+    it.each([undefined, 0, -1, NaN, Infinity, 'invalid'])('旧欠損・不正値 %s の任意情報は省略する', async value => {
+        vi.mocked(getTranscriptionJob).mockResolvedValue({
+            ...runningJob, status: 'finalizing', createdAtMs: value, audioSec: value, azureStatusCheckedAtMs: value,
+        } as unknown as TranscriptionJob);
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual({
+            status: 'running', docId: 'doc-1', stage: 'checking', serverNowMs: syntheticNowMs,
+        });
+        expect(getBatchJob).not.toHaveBeenCalled();
     });
 
     it('🔴 Succeeded で結果取得→Markdown化→文書とジョブの原子的確定→Azure削除まで貫通する', async () => {
@@ -346,7 +496,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
         vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
         const res = await statusPOST(req({ jobId: 'job-1' }));
-        expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
         expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
         // 実の buildTranscriptMarkdownFromBatch を通した本文が入る（話者ラベル＋時刻）
         expect(commitTerminalOutcome).toHaveBeenCalledWith({
@@ -360,7 +510,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
             status: 'completed', transcription: expect.stringContaining('よろしくお願いします'), title: '合成の文書',
         });
         expect(documentDb.jobData).toMatchObject({ status: 'succeeded', speakers: 2 });
-        expect(documentDb.runTransaction).toHaveBeenCalledTimes(1);
+        expect(documentDb.runTransaction).toHaveBeenCalledTimes(3);
         expect(updateTranscriptionJob).not.toHaveBeenCalled();
         expect(deleteBatchJob).toHaveBeenCalledTimes(1);
         expect(documentDb.tx.set.mock.invocationCallOrder.at(-1)).toBeLessThan(vi.mocked(deleteBatchJob).mock.invocationCallOrder[0]);
@@ -371,7 +521,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Failed', error: 'AudioLengthLimitExceeded' });
         const res = await statusPOST(req({ jobId: 'job-1' }));
         const body = await res.json();
-        expect(body.status).toBe('failed');
+        expect(body).toMatchObject(expectedStatus('failed', { observed: true }));
         expect(body.error).toContain('AudioLength');
         expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
         expect(commitTerminalOutcome).toHaveBeenCalledWith({
@@ -388,7 +538,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
     it('🔴 既に succeeded のジョブは Azure を叩かず即返す（冪等・二重確定しない）', async () => {
         vi.mocked(getTranscriptionJob).mockResolvedValue({ ...runningJob, status: 'succeeded' });
         const res = await statusPOST(req({ jobId: 'job-1' }));
-        expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(await res.json()).toEqual(expectedStatus('succeeded'));
         expect(getBatchJob).not.toHaveBeenCalled();
         expect(commitTerminalOutcome).not.toHaveBeenCalled();
         expect(claimJobForFinalize).not.toHaveBeenCalled();
@@ -397,7 +547,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
     it('既に failed のジョブは理由を返し、再確定も文書削除もしない', async () => {
         vi.mocked(getTranscriptionJob).mockResolvedValue({ ...runningJob, status: 'failed', error: '合成の失敗理由' });
         const res = await statusPOST(req({ jobId: 'job-1' }));
-        expect(await res.json()).toEqual({ status: 'failed', docId: 'doc-1', error: '合成の失敗理由' });
+        expect(await res.json()).toEqual(expectedStatus('failed', { error: '合成の失敗理由' }));
         expect(claimJobForFinalize).not.toHaveBeenCalled();
         expect(getBatchJob).not.toHaveBeenCalled();
         expect(documentDb.tx.set).not.toHaveBeenCalled();
@@ -406,7 +556,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
     it('有効な finalizing リースは公開 running として返す', async () => {
         vi.mocked(getTranscriptionJob).mockResolvedValue({ ...runningJob, status: 'finalizing', updatedAtMs: Date.now() });
         const res = await statusPOST(req({ jobId: 'job-1' }));
-        expect(await res.json()).toEqual({ status: 'running', docId: 'doc-1' });
+        expect(await res.json()).toEqual(expectedStatus('running'));
         expect(claimJobForFinalize).not.toHaveBeenCalled();
         expect(getBatchJob).not.toHaveBeenCalled();
     });
@@ -418,7 +568,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
         vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
         const res = await statusPOST(req({ jobId: 'job-1' }));
-        expect(await res.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
         expect(claimJobForFinalize).toHaveBeenCalledWith('job-1');
         expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
     });
@@ -431,7 +581,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
                 .mockResolvedValueOnce(runningJob)
                 .mockResolvedValueOnce({ ...runningJob, status, ...error });
             const res = await statusPOST(req({ jobId: 'job-1' }));
-            expect(await res.json()).toEqual({ status: status === 'finalizing' ? 'running' : status, docId: 'doc-1', ...error });
+            expect(await res.json()).toEqual(expectedStatus(status === 'finalizing' ? 'running' : status, error));
             expect(getTranscriptionJob).toHaveBeenCalledTimes(2);
             expect(getBatchJob).not.toHaveBeenCalled();
             expect(documentDb.tx.set).not.toHaveBeenCalled();
@@ -453,9 +603,9 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const first = statusPOST(req({ jobId: 'job-1' }));
         await started;
         const second = await statusPOST(req({ jobId: 'job-1' }));
-        expect(await second.json()).toEqual({ status: 'running', docId: 'doc-1' });
+        expect(await second.json()).toEqual(expectedStatus('running'));
         releaseAzure();
-        expect(await (await first).json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
+        expect(await (await first).json()).toEqual(expectedStatus('succeeded', { observed: true }));
         expect(getBatchJob).toHaveBeenCalledTimes(1);
         expect(fetchBatchResult).toHaveBeenCalledTimes(1);
         expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
@@ -465,7 +615,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
     it('Azure 設定がなくなっても running に戻して再試行できる', async () => {
         vi.mocked(getAzureCredentials).mockReturnValueOnce(null);
         const res = await statusPOST(req({ jobId: 'job-1' }));
-        expect(await res.json()).toEqual({ status: 'running', docId: 'doc-1' });
+        expect(await res.json()).toEqual(expectedStatus('running'));
         expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'running' });
         expect(getBatchJob).not.toHaveBeenCalled();
     });
@@ -475,6 +625,58 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect(res.status).toBe(502);
         expect(updateTranscriptionJob).toHaveBeenCalledWith('job-1', { status: 'running' });
+        expect(commitTerminalOutcome).not.toHaveBeenCalled();
+    });
+
+    it.each(['通信失敗', '未知の状態'] as const)('%s は HTTP エラーのまま checking と以前の観測時刻を返す', async failure => {
+        const checkedAtMs = syntheticNowMs - 300_000;
+        const observedJob = {
+            ...runningJob, azureStatus: 'Running' as const, azureStatusCheckedAtMs: checkedAtMs,
+        };
+        vi.mocked(getTranscriptionJob).mockResolvedValue(observedJob);
+        vi.mocked(claimJobForFinalize).mockResolvedValue({ ...observedJob, status: 'finalizing' });
+        documentDb.jobData = {
+            ...documentDb.jobData, azureStatus: 'Running', azureStatusCheckedAt: Timestamp.fromMillis(checkedAtMs),
+        };
+        documentDb.data = {
+            ...documentDb.data, processingProgress: { stage: 'transcribing', stageObservedAt: Timestamp.fromMillis(checkedAtMs) },
+        };
+        const before = { ...documentDb.data };
+        if (failure === '通信失敗') vi.mocked(getBatchJob).mockRejectedValueOnce(new Error('合成の通信障害'));
+        else vi.mocked(getBatchJob).mockResolvedValueOnce({ status: 'Unknown' as AzureBatchStatus });
+
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(res.status).toBe(502);
+        const body = await res.json();
+        expect(body).toEqual({
+            error: 'upstream_error', message: expect.any(String), docId: 'doc-1', stage: 'checking',
+            azureStatusCheckedAtMs: checkedAtMs, createdAtMs: syntheticCreatedAtMs,
+            audioSec: 600, serverNowMs: syntheticNowMs,
+        });
+        expect(body).not.toHaveProperty('status');
+        expect(recordAzureObservation).not.toHaveBeenCalled();
+        expect(writeProcessingProgress).not.toHaveBeenCalled();
+        expect(documentDb.data).toEqual(before);
+        expect(documentDb.jobData?.azureStatusCheckedAt).toEqual(Timestamp.fromMillis(checkedAtMs));
+        expect(updateTranscriptionJob).toHaveBeenCalledExactlyOnceWith('job-1', { status: 'running' });
+        expect(commitTerminalOutcome).not.toHaveBeenCalled();
+        expect(deleteBatchJob).not.toHaveBeenCalled();
+    });
+
+    it('保存済み Azure 終端から逆戻りする観測は採用せず checking と旧鮮度を返す', async () => {
+        const checkedAtMs = syntheticNowMs - 60_000;
+        documentDb.jobData = {
+            ...documentDb.jobData, azureStatus: 'Succeeded', azureStatusCheckedAt: Timestamp.fromMillis(checkedAtMs),
+        };
+        vi.mocked(getBatchJob).mockResolvedValueOnce({ status: 'Running' });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+
+        expect(res.status).toBe(502);
+        expect(await res.json()).toMatchObject({
+            stage: 'checking', azureStatusCheckedAtMs: checkedAtMs, serverNowMs: syntheticNowMs,
+        });
+        expect(documentDb.tx.set).not.toHaveBeenCalled();
+        expect(writeProcessingProgress).not.toHaveBeenCalled();
         expect(commitTerminalOutcome).not.toHaveBeenCalled();
     });
 
@@ -505,7 +707,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
             const res = await statusPOST(req({ jobId: 'job-1' }));
             const reason = '文字起こし結果の取り込みに失敗しました。もう一度お試しください。';
             expect(res.status).toBe(200);
-            expect(await res.json()).toEqual({ status: 'failed', docId: 'doc-1', error: reason });
+            expect(await res.json()).toEqual(expectedStatus('failed', { error: reason, observed: true }));
             expect(commitTerminalOutcome).toHaveBeenCalledWith({
                 jobId: 'job-1', docId: 'doc-1', expectedOwnerId: 'GUEST', outcome: { kind: 'failed', reason },
             });
@@ -528,9 +730,12 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
             documentDb.commitError = new Error('合成の commit エラー');
             const res = await statusPOST(req({ jobId: 'job-1' }));
             expect(res.status).toBe(502);
-            expect(documentDb.tx.set).toHaveBeenCalledTimes(2);
-            expect(documentDb.data).toEqual(original);
-            expect(documentDb.jobData).toEqual({ status: 'finalizing' });
+            expect(documentDb.tx.set).toHaveBeenCalledTimes(4);
+            expect(documentDb.data).toMatchObject(original);
+            expect(documentDb.data).toMatchObject({
+                status: 'processing', processingProgress: { stage: stage === 'Failed' ? 'checking' : 'importing' },
+            });
+            expect(documentDb.jobData).toMatchObject({ status: 'finalizing' });
             expect(commitTerminalOutcome).toHaveBeenCalledTimes(1);
             expect(updateTranscriptionJob).not.toHaveBeenCalled();
             expect(deleteBatchJob).not.toHaveBeenCalled();
@@ -538,11 +743,18 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
             vi.mocked(getTranscriptionJob).mockResolvedValueOnce({
                 ...runningJob, status: 'finalizing', updatedAtMs: Date.now() - FINALIZE_LEASE_MS - 1,
             });
-            vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+            vi.mocked(getBatchJob).mockResolvedValue({ status: stage === 'Failed' ? 'Failed' : 'Succeeded' });
             const retried = await statusPOST(req({ jobId: 'job-1' }));
-            expect(await retried.json()).toEqual({ status: 'succeeded', docId: 'doc-1' });
-            expect(documentDb.data).toMatchObject({ status: 'completed', transcription: expect.stringContaining('よろしくお願いします') });
-            expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
+            const failed = stage === 'Failed';
+            expect(await retried.json()).toEqual(expectedStatus(failed ? 'failed' : 'succeeded', {
+                observed: true, ...(failed && { error: 'Azure 側で処理に失敗しました。' }),
+            }));
+            expect(documentDb.data).toMatchObject({
+                status: failed ? 'failed' : 'completed',
+                transcription: expect.stringContaining(failed ? 'Azure 側で処理に失敗しました。' : 'よろしくお願いします'),
+            });
+            expect(documentDb.data).not.toHaveProperty('processingProgress');
+            expect(documentDb.jobData).toMatchObject({ status: failed ? 'failed' : 'succeeded' });
             expect(deleteBatchJob).toHaveBeenCalledTimes(1);
         },
     );
@@ -554,7 +766,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect((await res.json()).status).toBe(status === 'Succeeded' ? 'succeeded' : 'failed');
         expect(documentDb.data).toBeUndefined();
-        expect(documentDb.tx.set).toHaveBeenCalledTimes(1);
+        expect(documentDb.tx.set).toHaveBeenCalledTimes(2);
         expect(documentDb.tx.set).toHaveBeenCalledWith(documentDb.jobRef, expect.objectContaining({
             status: status === 'Succeeded' ? 'succeeded' : 'failed',
         }), { merge: true });
@@ -563,9 +775,14 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
     });
 
     it.each(['Succeeded', 'Failed', '取り込み失敗'] as const)(
-        '%s の commit が not_owner なら最新の失敗理由を返し、文書更新も Azure 削除もしない', async (stage) => {
+        '%s の commit が not_owner なら最新の失敗理由を返し、本文更新も Azure 削除もしない', async (stage) => {
             const reason = '別リクエストが確定した合成の失敗理由';
-            documentDb.jobData = { status: 'failed', error: reason };
+            vi.mocked(commitTerminalOutcome).mockImplementationOnce(async params => {
+                // Azure 観測と進捗投影を終えた後、保存直前に別リクエストが確定する。
+                documentDb.jobData = { ...documentDb.jobData, status: 'failed', error: reason };
+                const actual = await vi.importActual<typeof import('@/server/transcriptionJob')>('@/server/transcriptionJob');
+                return actual.commitTerminalOutcome(params);
+            });
             vi.mocked(getTranscriptionJob)
                 .mockResolvedValueOnce(runningJob)
                 .mockResolvedValueOnce({ ...runningJob, status: 'failed', error: reason });
@@ -575,10 +792,11 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
                 vi.mocked(fetchBatchResult).mockRejectedValueOnce(new Error('合成の取得エラー'));
             }
             const res = await statusPOST(req({ jobId: 'job-1' }));
-            expect(await res.json()).toEqual({ status: 'failed', docId: 'doc-1', error: reason });
+            expect(await res.json()).toEqual(expectedStatus('failed', { error: reason }));
             expect(commitTerminalOutcome).toHaveResolvedWith('not_owner');
             expect(getTranscriptionJob).toHaveBeenCalledTimes(2);
-            expect(documentDb.tx.set).not.toHaveBeenCalled();
+            expect(documentDb.tx.set).toHaveBeenCalledTimes(2);
+            expect(documentDb.data).toMatchObject({ status: 'processing', transcription: '処理中' });
             expect(updateTranscriptionJob).not.toHaveBeenCalled();
             expect(deleteBatchJob).not.toHaveBeenCalled();
         },
@@ -586,8 +804,12 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
 
     it.each(['running', 'finalizing', 'succeeded', 'deleted'] as const)(
         'commit 権を失った後の現在状態 %s を返す', async (status) => {
-            // commit の時点では running に戻っていて、再読込時に次の処理が進んでいる場合も含む。
-            documentDb.jobData = status === 'deleted' ? undefined : { status: 'running' };
+            // 観測後の commit 時点で権限を失い、再読込時に次の処理が進んでいる場合も含む。
+            vi.mocked(commitTerminalOutcome).mockImplementationOnce(async params => {
+                documentDb.jobData = status === 'deleted' ? undefined : { ...documentDb.jobData, status: 'running' };
+                const actual = await vi.importActual<typeof import('@/server/transcriptionJob')>('@/server/transcriptionJob');
+                return actual.commitTerminalOutcome(params);
+            });
             vi.mocked(getTranscriptionJob)
                 .mockResolvedValueOnce(runningJob)
                 .mockResolvedValueOnce(status === 'deleted' ? null : { ...runningJob, status });
@@ -595,8 +817,10 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
             vi.mocked(fetchBatchResult).mockResolvedValue(sampleAzureResult());
             const res = await statusPOST(req({ jobId: 'job-1' }));
             if (status === 'deleted') expect(res.status).toBe(404);
-            else expect(await res.json()).toEqual({ status: status === 'finalizing' ? 'running' : status, docId: 'doc-1' });
-            expect(documentDb.tx.set).not.toHaveBeenCalled();
+            else expect(await res.json()).toEqual(expectedStatus(status === 'finalizing' ? 'running' : status));
+            expect(commitTerminalOutcome).toHaveResolvedWith('not_owner');
+            expect(documentDb.tx.set).toHaveBeenCalledTimes(2);
+            expect(documentDb.data).toMatchObject({ status: 'processing', transcription: '処理中' });
             expect(deleteBatchJob).not.toHaveBeenCalled();
         },
     );
@@ -623,6 +847,7 @@ describe.each(['completed', 'failed'] as const)('文書を %s にする際のト
     });
 
     it('所有者が一致する processing のみ更新し、再確定で本文を上書きしない', async () => {
+        documentDb.data = { ...documentDb.data, processingProgress: { stage: 'importing' } };
         await expect(finalizeDocument()).resolves.toBe('committed');
         expect(documentDb.runTransaction).toHaveBeenCalledTimes(1);
         expect(documentDb.tx.get).toHaveBeenCalledWith(documentDb.jobRef);
@@ -631,6 +856,10 @@ describe.each(['completed', 'failed'] as const)('文書を %s にする際のト
             status: terminalStatus,
         }), { merge: true });
         expect(documentDb.data).toMatchObject({ status: terminalStatus, ownerId: 'GUEST', title: '合成の文書' });
+        expect(documentDb.data).not.toHaveProperty('processingProgress');
+        expect(documentDb.tx.set).toHaveBeenCalledWith(documentDb.ref, expect.objectContaining({
+            processingProgress: FieldValue.delete(),
+        }), { merge: true });
         const saved = { ...documentDb.data };
         expect(documentDb.jobData).toMatchObject({ status: terminalStatus === 'completed' ? 'succeeded' : 'failed' });
         await expect(finalizeDocument()).resolves.toBe('not_owner');

--- a/src/app/api/transcribe/status/route.ts
+++ b/src/app/api/transcribe/status/route.ts
@@ -10,13 +10,14 @@ import type {
     TranscribeStatusRequest,
     TranscribeStatusResponse,
     TranscribeBatchErrorBody,
+    TranscribeProgressStage,
 } from '@/lib/transcribeBatchContract';
-import { isTerminalBatchStatus } from '@/lib/azureBatchContract';
+import { isTerminalBatchStatus, type AzureBatchStatus } from '@/lib/azureBatchContract';
 import { resolveRequestSubject } from '@/server/auth';
 import { GenerateApiError } from '@/server/errors';
 import { isOwnedBySubject } from '@/server/mediaSource';
 import { getAdminFirestore } from '@/server/firebaseAdmin';
-import { TRANSCRIPTIONS_COLLECTION } from '@/server/transcriptionDocument';
+import { TRANSCRIPTIONS_COLLECTION, writeProcessingProgress } from '@/server/transcriptionDocument';
 import {
     getAzureCredentials,
     getBatchJob,
@@ -31,6 +32,7 @@ import {
     FINALIZE_LEASE_MS,
     getTranscriptionJob,
     getTranscriptionJobByDocId,
+    recordAzureObservation,
     updateTranscriptionJob,
     type TranscriptionJob,
 } from '@/server/transcriptionJob';
@@ -47,8 +49,53 @@ const jsonResponse = (body: unknown, status: number): Response =>
         headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
     });
 
-const errorResponse = (error: GenerateApiError): Response =>
-    jsonResponse({ error: error.code, message: error.message } satisfies TranscribeBatchErrorBody, error.status);
+const isPositiveFinite = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0;
+
+const isAzureStatus = (value: unknown): value is AzureBatchStatus =>
+    value === 'NotStarted' || value === 'Running' || value === 'Succeeded' || value === 'Failed';
+
+/** finalizing は確定権であり、表示段階は最後の有効な Azure 観測からのみ導出する。 */
+const observedStage = (job: TranscriptionJob): Exclude<TranscribeProgressStage, 'completed' | 'failed'> => {
+    switch (job.azureStatus) {
+        case 'NotStarted': return 'queued';
+        case 'Running': return 'transcribing';
+        case 'Succeeded': return 'importing';
+        default: return 'checking';
+    }
+};
+
+const progressMetadata = (job: TranscriptionJob) => ({
+    ...(isPositiveFinite(job.azureStatusCheckedAtMs) && { azureStatusCheckedAtMs: job.azureStatusCheckedAtMs }),
+    ...(isPositiveFinite(job.createdAtMs) && { createdAtMs: job.createdAtMs }),
+    ...(isPositiveFinite(job.audioSec) && { audioSec: job.audioSec }),
+});
+
+const statusResponse = (job: TranscriptionJob, stage = observedStage(job)): Response => {
+    const response: TranscribeStatusResponse = {
+        status: job.status === 'finalizing' ? 'running' : job.status,
+        docId: job.docId,
+        ...(job.error ? { error: job.error } : {}),
+        stage: job.status === 'succeeded' ? 'completed' : job.status === 'failed' ? 'failed' : stage,
+        ...progressMetadata(job),
+        serverNowMs: Date.now(),
+    };
+    return jsonResponse(response, 200);
+};
+
+/** 確認失敗でも HTTP エラーを維持し、最後の有効観測の時刻を進めず返す。 */
+const errorResponse = (error: GenerateApiError, job?: TranscriptionJob): Response =>
+    jsonResponse({
+        error: error.code,
+        message: error.message,
+        ...(job && { docId: job.docId, stage: 'checking', ...progressMetadata(job) }),
+        serverNowMs: Date.now(),
+    } satisfies TranscribeBatchErrorBody & Partial<TranscribeStatusResponse>, error.status);
+
+const statusCheckError = (error: unknown): GenerateApiError => error instanceof GenerateApiError
+    ? error
+    : new GenerateApiError('upstream_error',
+        '文字起こしの状態確認でエラーが発生しました。しばらくしてから再試行してください。');
 
 const invalid = (message: string): GenerateApiError => new GenerateApiError('invalid_request', message);
 
@@ -73,23 +120,45 @@ export function validateStatusBody(raw: unknown): TranscribeStatusRequest {
  * 失敗: 文書に理由を残してジョブと原子的に確定。取り込み失敗では Azure の結果を残す。
  * 未完: ジョブを running に戻し、次の poll で再確認する。
  */
-async function finalizeIfTerminal(job: TranscriptionJob): Promise<TranscribeJobPublicStatusInternal> {
+async function finalizeIfTerminal(job: TranscriptionJob): Promise<Response> {
     const credentials = getAzureCredentials();
     if (!credentials) {
         // 設定が消えた等。設定を直せば次の poll で進むよう、確定権を解放する。
         await updateTranscriptionJob(job.id, { status: 'running' });
-        return { status: 'running', docId: job.docId };
+        return statusResponse({ ...job, status: 'running' }, 'checking');
     }
     let state: Awaited<ReturnType<typeof getBatchJob>>;
     try {
         state = await getBatchJob(job.azureSelfUrl, credentials);
+        if (!isAzureStatus(state.status)) {
+            throw new GenerateApiError('upstream_error', '文字起こしの状態を確認できませんでした。しばらくしてから再試行してください。');
+        }
     } catch (error) {
         await updateTranscriptionJob(job.id, { status: 'running' });
-        throw error;
+        const failure = statusCheckError(error);
+        logger.warn('Azure の状態確認に失敗', { jobId: job.id, code: failure.code });
+        return errorResponse(failure, job);
     }
+    const observedJob = await recordAzureObservation(job.id, state.status);
+    if (!observedJob) throw new GenerateApiError('media_not_found', '文字起こしジョブが見つかりません。');
+    job = observedJob;
+    // 遅れた照会中に別リクエストが終端化した場合は、現在の終端を優先する。
+    if (job.status === 'succeeded' || job.status === 'failed') return statusResponse(job);
+    if (job.azureStatus !== state.status) {
+        // 保存済み Azure 終端から逆戻りする観測は採用せず、鮮度も更新しない。
+        await updateTranscriptionJob(job.id, { status: 'running' });
+        return errorResponse(new GenerateApiError('upstream_error',
+            '文字起こしの状態を確認できませんでした。しばらくしてから再試行してください。'), job);
+    }
+    await writeProcessingProgress(job.docId, job.ownerId, {
+        jobId: job.id,
+        stage: observedStage(job),
+        ...(isPositiveFinite(job.createdAtMs) && { jobCreatedAtMs: job.createdAtMs }),
+        ...(isPositiveFinite(job.audioSec) && { audioSec: job.audioSec }),
+    });
     if (!isTerminalBatchStatus(state.status)) {
         await updateTranscriptionJob(job.id, { status: 'running' });
-        return { status: 'running', docId: job.docId };
+        return statusResponse({ ...job, status: 'running' });
     }
     if (state.status === 'Failed') {
         const reason = state.error ?? 'Azure 側で処理に失敗しました。';
@@ -101,7 +170,7 @@ async function finalizeIfTerminal(job: TranscriptionJob): Promise<TranscribeJobP
         });
         if (committed === 'not_owner') return getCurrentPublicStatus(job.id);
         await deleteBatchJob(job.azureSelfUrl, credentials);
-        return { status: 'failed', docId: job.docId, error: reason };
+        return statusResponse({ ...job, status: 'failed', error: reason });
     }
     // Succeeded
     let parsed: ReturnType<typeof parseBatchResult>;
@@ -123,7 +192,7 @@ async function finalizeIfTerminal(job: TranscriptionJob): Promise<TranscribeJobP
         });
         if (committed === 'not_owner') return getCurrentPublicStatus(job.id);
         // 未取り込みの結果は削除せず、Azure 側の TTL に任せる。
-        return { status: 'failed', docId: job.docId, error: reason };
+        return statusResponse({ ...job, status: 'failed', error: reason });
     }
     // 保存失敗は取り込み失敗として確定せず、finalizing のリース切れ後に再試行する。
     const committed = await commitTerminalOutcome({
@@ -135,23 +204,13 @@ async function finalizeIfTerminal(job: TranscriptionJob): Promise<TranscribeJobP
     if (committed === 'not_owner') return getCurrentPublicStatus(job.id);
     await deleteBatchJob(job.azureSelfUrl, credentials);
     logger.info('文字起こしを確定', { jobId: job.id, speakers: parsed.speakers, chars: markdown.length });
-    return { status: 'succeeded', docId: job.docId };
+    return statusResponse({ ...job, status: 'succeeded' });
 }
 
-interface TranscribeJobPublicStatusInternal {
-    status: 'running' | 'succeeded' | 'failed';
-    docId: string;
-    error?: string;
-}
-
-async function getCurrentPublicStatus(jobId: string): Promise<TranscribeJobPublicStatusInternal> {
+async function getCurrentPublicStatus(jobId: string): Promise<Response> {
     const current = await getTranscriptionJob(jobId);
     if (!current) throw new GenerateApiError('media_not_found', '文字起こしジョブが見つかりません。');
-    return {
-        status: current.status === 'finalizing' ? 'running' : current.status,
-        docId: current.docId,
-        ...(current.error ? { error: current.error } : {}),
-    };
+    return statusResponse(current);
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -186,33 +245,15 @@ export async function POST(request: Request): Promise<Response> {
         const expiredFinalize = job.status === 'finalizing'
             && Date.now() - job.updatedAtMs > FINALIZE_LEASE_MS;
         if (job.status !== 'running' && !expiredFinalize) {
-            const response: TranscribeStatusResponse = {
-                status: job.status === 'finalizing' ? 'running' : job.status,
-                docId: job.docId,
-                ...(job.error ? { error: job.error } : {}),
-            };
-            return jsonResponse(response, 200);
+            return statusResponse(job);
         }
 
         const claimedJob = await claimJobForFinalize(job.id);
         if (!claimedJob) {
-            const current = await getTranscriptionJob(job.id);
-            if (!current) throw new GenerateApiError('media_not_found', '文字起こしジョブが見つかりません。');
-            const response: TranscribeStatusResponse = {
-                status: current.status === 'finalizing' ? 'running' : current.status,
-                docId: current.docId,
-                ...(current.error ? { error: current.error } : {}),
-            };
-            return jsonResponse(response, 200);
+            return await getCurrentPublicStatus(job.id);
         }
 
-        const outcome = await finalizeIfTerminal(claimedJob);
-        const response: TranscribeStatusResponse = {
-            status: outcome.status,
-            docId: outcome.docId,
-            ...(outcome.error ? { error: outcome.error } : {}),
-        };
-        return jsonResponse(response, 200);
+        return await finalizeIfTerminal(claimedJob);
     } catch (error) {
         if (error instanceof GenerateApiError) {
             logger.warn('status を拒否/失敗', { code: error.code, status: error.status });

--- a/src/components/DocumentDetailPanel.test.tsx
+++ b/src/components/DocumentDetailPanel.test.tsx
@@ -11,9 +11,12 @@ import {
     type Transcription,
 } from '@/lib/firestore';
 import {
+    describeProcessingFreshness,
     DocumentDetailPanelView as DocumentDetailPanel,
+    ProcessingStateCard,
     type DocumentDetailPanelHandle,
 } from './DocumentDetailPanel';
+import type { DocumentStatusWatchSnapshot } from '@/hooks/batchTranscriptionClient';
 import { PdfDocumentHeader } from './PdfDocumentHeader';
 
 const { createPortal, documentPrintPortal, printPdf } = vi.hoisted(() => ({
@@ -1608,6 +1611,168 @@ describe('DocumentDetailPanel', () => {
         findButtonByText(tree, 'キャンセル')?.props.onClick();
 
         expect(setShowDiscardConfirmation).toHaveBeenCalledWith(true);
+    });
+
+    describe('処理中文書の状態カード（仕様 §A1・A4）', () => {
+        const observedAtMs = Date.UTC(2026, 8, 5, 3, 10, 0);
+        const jobCreatedAtMs = Date.UTC(2026, 8, 5, 3, 0, 0);
+        const processingDocument: Transcription = {
+            ...document,
+            id: 'processing-1',
+            status: 'processing',
+            text: '（文字起こしを実行しています。完了すると自動で反映されます。）',
+            processingProgress: { stage: 'queued', stageObservedAtMs: observedAtMs - 60_000, jobCreatedAtMs },
+        };
+        const snapshot = (overrides: Partial<DocumentStatusWatchSnapshot> = {}): DocumentStatusWatchSnapshot => ({
+            docId: 'processing-1',
+            mode: 'waiting',
+            lastResponse: {
+                status: 'running',
+                docId: 'processing-1',
+                stage: 'transcribing',
+                azureStatusCheckedAtMs: observedAtMs,
+                createdAtMs: jobCreatedAtMs,
+                serverNowMs: observedAtMs + 5_000,
+            },
+            lastResponseAtMs: observedAtMs + 5_000,
+            lastError: null,
+            consecutiveFailures: 0,
+            startedAtMs: observedAtMs,
+            ...overrides,
+        });
+
+        type AnyElement = React.ReactElement<Record<string, unknown> & { children?: React.ReactNode }>;
+        const findElement = (
+            node: React.ReactNode,
+            predicate: (element: AnyElement) => boolean,
+        ): AnyElement | null => {
+            if (Array.isArray(node)) {
+                for (const child of node) {
+                    const found = findElement(child, predicate);
+                    if (found) return found;
+                }
+                return null;
+            }
+            if (!React.isValidElement<Record<string, unknown> & { children?: React.ReactNode }>(node)) return null;
+            if (predicate(node)) return node;
+            return findElement(node.props.children, predicate);
+        };
+        const renderCard = (props: React.ComponentProps<typeof ProcessingStateCard>): React.ReactNode => {
+            // カードは実描画でしかフックを走らせない設計。ここでは素の関数として呼び、
+            // useState は初期値をそのまま返す・useEffect は走らせない
+            vi.mocked(useState).mockReset();
+            vi.mocked(useState).mockImplementation(((initialValue?: unknown) =>
+                [resolveInitialValue(initialValue), vi.fn()]) as never);
+            return ProcessingStateCard(props);
+        };
+
+        it('🔴 processing 文書では本文プレビューの代わりに状態カードを置き、本文編集・PDF 出力を無効にする', () => {
+            mockPanelState();
+            const onCheckProcessingStatus = vi.fn();
+            const tree = DocumentDetailPanel({
+                document: processingDocument,
+                onDocumentUpdate: async () => undefined,
+                processingWatch: snapshot(),
+                onCheckProcessingStatus,
+            });
+
+            expect(findPdfPreview(tree)).toBeNull();
+            const card = findElement(tree, element => element.type === ProcessingStateCard);
+            expect(card).not.toBeNull();
+            expect(card?.props.document).toBe(processingDocument);
+            expect(card?.props.watch).toEqual(snapshot());
+            expect(card?.props.onCheck).toBe(onCheckProcessingStatus);
+
+            expect(findButtonByText(tree, '編集')?.props.disabled).toBe(true);
+            expect(findPdfButton(tree)?.props.disabled).toBe(true);
+            expect(findPdfButton(tree)?.props.title).toBe('文字起こしが完了すると印刷できます');
+            // タイトルは表示（見出し）のまま。変更は一覧側の既存操作で行う
+            expect(getText(tree)).toContain(processingDocument.title);
+        });
+
+        it('completed（status なしの既存文書を含む）では従来どおり本文プレビューを出し、編集も有効', () => {
+            mockPanelState();
+            const tree = DocumentDetailPanel({ document, onDocumentUpdate: async () => undefined });
+
+            expect(findPdfPreview(tree)).not.toBeNull();
+            expect(findElement(tree, element => element.type === ProcessingStateCard)).toBeNull();
+            expect(findButtonByText(tree, '編集')?.props.disabled).toBe(false);
+            expect(findPdfButton(tree)?.props.disabled).toBe(false);
+        });
+
+        it('状態カードは段階を 1 つの live 領域に出し、経過・観測時刻・最終確認・「状態を確認」を持つ', () => {
+            const onCheck = vi.fn();
+            const tree = renderCard({ document: processingDocument, watch: snapshot(), onCheck });
+            const text = getText(tree);
+
+            const live = findElement(tree, element => element.props.role === 'status');
+            expect(live?.props['aria-live']).toBe('polite');
+            // status 応答の観測（transcribing）は投影（queued・古い）より新しいので採用される
+            expect(getText(live)).toBe('文字起こし中');
+            expect(text).toContain('受付からの経過');
+            expect(text).toContain('状態の観測時刻');
+            expect(text).toContain('最終確認');
+            expect(text).toContain('この画面を離れても文字起こしは継続します');
+            expect(text).not.toContain('%');
+
+            const current = findElement(tree, element => element.props['aria-current'] === 'step');
+            expect(getText(current)).toContain('文字起こし');
+
+            const button = findButtonByText(tree, '状態を確認');
+            expect(button?.props.disabled).toBe(false);
+            button?.props.onClick();
+            expect(onCheck).toHaveBeenCalledOnce();
+        });
+
+        it('確認中は「状態を確認」を無効にし、文言で伝える（色・スピナーだけに依存しない）', () => {
+            const tree = renderCard({ document: processingDocument, watch: snapshot({ mode: 'checking' }), onCheck: vi.fn() });
+            const button = findButtonByText(tree, '確認しています…');
+            expect(button?.props.disabled).toBe(true);
+            expect(getText(tree)).toContain('状態を確認しています…');
+        });
+
+        it('継続確認が無い（保存された投影だけ）でも段階を出し、「最終確認時」の記録だと分かる', () => {
+            const tree = renderCard({ document: processingDocument, watch: null });
+            const live = findElement(tree, element => element.props.role === 'status');
+            expect(getText(live)).toBe('文字起こしの開始を待っています');
+            expect(getText(tree)).toContain('保存された記録です');
+            expect(getText(tree)).toContain('この画面ではまだ確認していません');
+        });
+
+        it('failed 段階は理由（本文）を出し、手順の一覧を出さない', () => {
+            const failedDocument: Transcription = {
+                ...processingDocument, text: '文字起こしに失敗しました。\n\n理由: 音声が長すぎます',
+            };
+            const tree = renderCard({
+                document: failedDocument,
+                watch: snapshot({ lastResponse: { status: 'failed', docId: 'processing-1', error: '音声が長すぎます' }, mode: 'terminal' }),
+            });
+            expect(getText(findElement(tree, element => element.props.role === 'status'))).toBe('文字起こしに失敗しました');
+            expect(getText(tree)).toContain('理由: 音声が長すぎます');
+            expect(findElement(tree, element => element.type === 'ol')).toBeNull();
+        });
+
+        it('鮮度の文言: 通信失敗・停止は処理段階でもジョブ失敗でもなく、最後の観測を残す', () => {
+            const observation = { stage: 'transcribing' as const, source: 'status' as const };
+            expect(describeProcessingFreshness(snapshot({ lastError: { message: '通信に失敗しました。', httpStatus: 502 } }), observation))
+                .toBe('現在の状態を確認できません（通信に失敗しました。）。最終確認時は「文字起こし中」でした。自動で再試行します。');
+            expect(describeProcessingFreshness(snapshot({ lastError: { message: '通信に失敗しました。' } }), null))
+                .toBe('現在の状態を確認できません（通信に失敗しました。）。自動で再試行します。');
+            expect(describeProcessingFreshness(snapshot({ mode: 'stopped_limit' }), observation))
+                .toBe('自動確認を停止しました。文字起こしはサーバーで継続します。最終確認時は「文字起こし中」でした。「状態を確認」で確認を再開できます。');
+            expect(describeProcessingFreshness(snapshot({ mode: 'stopped_not_found' }), observation))
+                .toContain('文書またはジョブを確認できません');
+            expect(describeProcessingFreshness(snapshot({ mode: 'stopped_not_found' }), observation))
+                .toContain('再提出は行いません');
+            expect(describeProcessingFreshness(snapshot({ mode: 'stopped_auth' }), observation))
+                .toContain('権限または認証を確認してください');
+            expect(describeProcessingFreshness(snapshot({ mode: 'paused_offline' }), observation))
+                .toContain('オフラインのため自動確認を止めています');
+            expect(describeProcessingFreshness(snapshot({ mode: 'paused_hidden' }), null))
+                .toBe('画面が非表示のため自動確認を止めています。表示に戻ると確認を再開します。');
+            expect(describeProcessingFreshness(null, null))
+                .toBe('状態を確認できません。「状態を確認」をお試しください。');
+        });
     });
 });
 

--- a/src/components/DocumentDetailPanel.tsx
+++ b/src/components/DocumentDetailPanel.tsx
@@ -7,12 +7,16 @@ import React, {
     useState,
 } from 'react';
 import {
+    AlertCircle,
     ArrowLeft,
     Check,
+    CheckCircle2,
     Eye,
     FileText,
     FileTextIcon,
+    Loader2,
     Printer,
+    RefreshCw,
 } from 'lucide-react';
 import type { Timestamp } from 'firebase/firestore';
 import {
@@ -21,6 +25,16 @@ import {
     Transcription,
     TranscriptionConflictError,
 } from '@/lib/firestore';
+import type { TranscribeProgressStage } from '@/lib/transcribeBatchContract';
+import {
+    describeElapsed,
+    describeProgressStage,
+    estimateServerNowMs,
+    formatClockTime,
+    resolveProgressObservation,
+    type DocumentStatusWatchSnapshot,
+    type ProgressObservation,
+} from '@/hooks/batchTranscriptionClient';
 import { createLogger } from '@/lib/logger';
 import { MarkdownDocument } from '@/components/MarkdownDocument';
 import { TranscriptAudioBar, TranscriptAwareMarkdown } from '@/components/TranscriptDocumentView';
@@ -94,6 +108,13 @@ export interface DocumentDetailPanelProps {
     /** 保存競合時の「最新の内容を読み込む」導線。親が一覧の再取得を引き受ける。 */
     onRequestLatestDocument?: () => void;
     onBackToList?: () => void;
+    /**
+     * 選択中の processing 文書の継続確認スナップショット（親が保持・仕様 §A2 手順3）。
+     * processing 以外の文書では無視する。無ければ保存された投影だけで状態カードを描く。
+     */
+    processingWatch?: DocumentStatusWatchSnapshot | null;
+    /** 状態カードの「状態を確認」。実行中の重複送信は継続確認側が抑える。 */
+    onCheckProcessingStatus?: () => void;
 }
 
 type SaveErrorState = {
@@ -111,6 +132,8 @@ export function DocumentDetailPanelView({
     onDraftDiscarded,
     onRequestLatestDocument,
     onBackToList,
+    processingWatch = null,
+    onCheckProcessingStatus,
 }: DocumentDetailPanelProps, ref?: React.ForwardedRef<DocumentDetailPanelHandle>) {
     const [isViewMode, setIsViewMode] = useState(true);
     const [editedTitle, setEditedTitle] = useState(document?.title ?? '');
@@ -537,12 +560,17 @@ export function DocumentDetailPanelView({
     const autoFontLabel =
         PDF_FONTS.find(font => font.id === resolvePdfFontId('auto', pdfTheme))
             ?.label.split('（')[0] ?? '';
-    const canPrintPdf = isViewMode && !saving && !isPreparing;
-    const pdfButtonTitle = saving
-        ? '保存完了後に印刷できます'
-        : !isViewMode
-            ? '保存後に印刷できます'
-            : undefined;
+    // 処理中の文書は本文がまだ無い（静的な仮本文だけ）。完成本文に対する操作は無効にする（仕様 §A4）。
+    // タイトルの変更は一覧側の既存操作で引き続きできる。
+    const isProcessingDocument = document.status === 'processing';
+    const canPrintPdf = isViewMode && !saving && !isPreparing && !isProcessingDocument;
+    const pdfButtonTitle = isProcessingDocument
+        ? '文字起こしが完了すると印刷できます'
+        : saving
+            ? '保存完了後に印刷できます'
+            : !isViewMode
+                ? '保存後に印刷できます'
+                : undefined;
 
     const handlePrintPdf = (): void => {
         if (!canPrintPdf) {
@@ -649,11 +677,14 @@ export function DocumentDetailPanelView({
                                             setSaveError(null);
                                             setIsViewMode(false);
                                         }}
-                                        className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors flex items-center space-x-2 ${!isViewMode
+                                        className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors flex items-center space-x-2 disabled:cursor-not-allowed disabled:opacity-50 ${!isViewMode
                                             ? 'bg-purple-100 text-purple-700'
                                             : 'text-gray-600 hover:text-gray-900'
                                             }`}
-                                        disabled={saving}
+                                        disabled={saving || isProcessingDocument}
+                                        title={isProcessingDocument
+                                            ? '文字起こしが完了すると本文を編集できます（タイトルは一覧から変更できます）'
+                                            : undefined}
                                     >
                                         <FileText className="w-4 h-4" />
                                         <span>編集</span>
@@ -730,7 +761,14 @@ export function DocumentDetailPanelView({
             </div>
 
             <div className="flex-1 overflow-y-auto p-3 sm:p-6 bg-gray-50">
-                {isViewMode ? (
+                {isViewMode && isProcessingDocument ? (
+                    // 🔴 processing の仮本文は文字起こし結果ではない。静的プレースホルダの代わりに状態カードを出す（仕様 §A4）
+                    <ProcessingStateCard
+                        document={document}
+                        watch={processingWatch}
+                        onCheck={onCheckProcessingStatus}
+                    />
+                ) : isViewMode ? (
                     <div
                         className={`pdf-preview pdf-preview--reading pdf-theme-${pdfTheme} pdf-font-${resolvedPdfFont} shadow`}
                     >
@@ -760,8 +798,9 @@ export function DocumentDetailPanelView({
                 )}
             </div>
 
-            {/* 文書に従属する細い帯。時刻リンクを持たない文書では、この要素ごと null になる */}
-            <TranscriptAudioBar document={document} />
+            {/* 文書に従属する細い帯。時刻リンクを持たない文書では、この要素ごと null になる。
+                処理中の仮本文は文字起こし結果として解釈しないので、帯も出さない */}
+            {!isProcessingDocument && <TranscriptAudioBar document={document} />}
 
             {isEditable && !isViewMode && (
                 <div className="flex items-center justify-end space-x-3 p-4 border-t bg-white">
@@ -865,3 +904,183 @@ export function DocumentDetailPanelView({
 export const DocumentDetailPanel = React.forwardRef(DocumentDetailPanelView);
 
 DocumentDetailPanel.displayName = 'DocumentDetailPanel';
+
+// ---------------------------------------------------------------------------------------------
+// 処理中文書の状態カード（仕様 §A1・A4）。
+// 🔴 パネル本体と別コンポーネントに切り出しているのは意図的（TranscriptDocumentView と同じ理由）。
+//    パネルのテストはコンポーネントを素の関数として呼び、useState/useEffect/useRef/useImperativeHandle
+//    だけをモックする。ここに切り出せば、パネル側は「要素を 1 つ置く」だけになり、
+//    カードのフック（経過時間の 30 秒更新）は実描画のときにしか走らない。
+// ---------------------------------------------------------------------------------------------
+
+/** 経過時間の再計算間隔。時刻表示のために API を叩かず、30 秒より細かく更新しない（仕様 §A1） */
+export const PROCESSING_ELAPSED_REFRESH_MS = 30_000;
+
+/** 「開始待ち → 文字起こし → 取り込み → 完了」。等間隔は所要時間の比率を意味しない（仕様 §A4） */
+const PROGRESS_STEPS: readonly { stage: TranscribeProgressStage; label: string }[] = [
+    { stage: 'queued', label: '開始待ち' },
+    { stage: 'transcribing', label: '文字起こし' },
+    { stage: 'importing', label: '取り込み' },
+    { stage: 'completed', label: '完了' },
+];
+
+const timestampToMillis = (timestamp: Timestamp | Date | undefined): number | undefined => {
+    if (!timestamp) return undefined;
+    if (timestamp instanceof Date) return timestamp.getTime();
+    return typeof timestamp.toMillis === 'function' ? timestamp.toMillis() : undefined;
+};
+
+/**
+ * 「状態の鮮度」の文言（仕様 §A1）。通信失敗・オフライン・確認停止は処理段階でもジョブ失敗でもない。
+ * 最後の有効観測を残して「最終確認時は〜」を併記し、過去の観測が無いときだけ「状態を確認できません」。
+ */
+export function describeProcessingFreshness(
+    watch: DocumentStatusWatchSnapshot | null,
+    observation: ProgressObservation | null,
+): string {
+    const lastSeen = observation
+        ? `最終確認時は「${describeProgressStage(observation.stage, 'detail')}」でした。`
+        : '';
+    if (!watch) {
+        return observation
+            ? `保存された記録です。${lastSeen}「状態を確認」で最新の状態を取得できます。`
+            : '状態を確認できません。「状態を確認」をお試しください。';
+    }
+    switch (watch.mode) {
+        case 'checking':
+            return '状態を確認しています…';
+        case 'waiting':
+            return watch.lastError
+                ? `現在の状態を確認できません（${watch.lastError.message}）。${lastSeen}自動で再試行します。`
+                : '表示中は自動で状態を確認しています。';
+        case 'paused_hidden':
+            return `画面が非表示のため自動確認を止めています。${lastSeen}表示に戻ると確認を再開します。`;
+        case 'paused_offline':
+            return `オフラインのため自動確認を止めています。${lastSeen}回線が戻ると確認を再開します。`;
+        case 'stopped_limit':
+            return `自動確認を停止しました。文字起こしはサーバーで継続します。${lastSeen}「状態を確認」で確認を再開できます。`;
+        case 'stopped_auth':
+            return `権限または認証を確認してください。状態を確認できませんでした。${lastSeen}`;
+        case 'stopped_not_found':
+            return '文書またはジョブを確認できません。自動確認を停止しました（再提出は行いません）。';
+        case 'terminal':
+            return '結果を受け取りました。最新の文書を読み込んでいます…';
+        case 'disposed':
+            return lastSeen || '状態を確認できません。';
+        default:
+            return lastSeen || '状態を確認できません。';
+    }
+}
+
+export interface ProcessingStateCardProps {
+    document: Transcription;
+    watch: DocumentStatusWatchSnapshot | null;
+    onCheck?: () => void;
+}
+
+export function ProcessingStateCard({ document, watch, onCheck }: ProcessingStateCardProps): React.ReactElement {
+    // 経過時間はローカルで足す。30 秒ごとの刻みと、応答の受信時刻のうち新しい方を「今」とし、
+    // それ以外の理由で描き直さない（時刻表示のために API を叩かない・仕様 §A1）
+    const [tickMs, setTickMs] = useState(() => Date.now());
+    useEffect(() => {
+        const timer = window.setInterval(() => setTickMs(Date.now()), PROCESSING_ELAPSED_REFRESH_MS);
+        return () => window.clearInterval(timer);
+    }, []);
+    const lastResponseAtMs = watch?.lastResponseAtMs ?? null;
+    const nowMs = Math.max(tickMs, lastResponseAtMs ?? 0);
+
+    const observation = resolveProgressObservation(document.processingProgress, watch?.lastResponse);
+    const stage = observation?.stage;
+    const stageLabel = stage ? describeProgressStage(stage, 'detail') : '処理中・状態を確認しています';
+    const jobCreatedAtMs = observation?.jobCreatedAtMs
+        ?? document.processingProgress?.jobCreatedAtMs
+        ?? timestampToMillis(document.createdAt);
+    const serverNowMs = estimateServerNowMs(watch?.lastResponse, lastResponseAtMs, nowMs);
+    const elapsedLabel = jobCreatedAtMs !== undefined ? describeElapsed(serverNowMs - jobCreatedAtMs) : null;
+    const observedAtLabel = observation?.observedAtMs !== undefined ? formatClockTime(observation.observedAtMs) : null;
+    const lastCheckedLabel = lastResponseAtMs !== null ? formatClockTime(lastResponseAtMs) : null;
+    const isChecking = watch?.mode === 'checking';
+    const isFailed = stage === 'failed';
+    const isCompleted = stage === 'completed';
+    const currentStepIndex = stage ? PROGRESS_STEPS.findIndex(step => step.stage === stage) : -1;
+    const StageIcon = isFailed ? AlertCircle : isCompleted ? CheckCircle2 : Loader2;
+
+    return (
+        <section
+            aria-label="文字起こしの状態"
+            data-testid="processing-state-card"
+            className="rounded-xl border border-purple-100 bg-white p-5 shadow-sm"
+        >
+            <h3 className="text-sm font-semibold text-gray-700">文字起こしの状態</h3>
+            <p className={`mt-2 flex items-center gap-2 text-lg font-semibold ${isFailed ? 'text-red-800' : 'text-purple-900'}`}>
+                {/* スピナーは装飾。段階はテキストで伝え、動きを減らす設定では静止アイコンにする */}
+                <StageIcon
+                    className={`h-5 w-5 shrink-0 ${isFailed
+                        ? 'text-red-600'
+                        : isCompleted
+                            ? 'text-green-600'
+                            : 'text-purple-600 motion-safe:animate-spin'}`}
+                    aria-hidden="true"
+                />
+                {/* 段階変化だけを 1 つの live 領域で通知する。経過・時刻の更新は読み上げない */}
+                <span role="status" aria-live="polite">{stageLabel}</span>
+            </p>
+            {!isFailed && (
+                <ol
+                    aria-label="文字起こしの段階（順序のみ。所要時間の比率ではありません）"
+                    className="mt-3 flex flex-wrap gap-2 text-xs"
+                >
+                    {PROGRESS_STEPS.map((step, index) => {
+                        const state = index < currentStepIndex ? 'done' : index === currentStepIndex ? 'current' : 'todo';
+                        return (
+                            <li
+                                key={step.stage}
+                                aria-current={state === 'current' ? 'step' : undefined}
+                                className={`rounded-full border px-2 py-0.5 ${state === 'current'
+                                    ? 'border-purple-400 bg-purple-50 font-semibold text-purple-900'
+                                    : state === 'done'
+                                        ? 'border-green-200 bg-green-50 text-green-800'
+                                        : 'border-gray-200 bg-white text-gray-500'}`}
+                            >
+                                {state === 'done' ? '済 ' : state === 'current' ? '現在: ' : ''}{step.label}
+                            </li>
+                        );
+                    })}
+                </ol>
+            )}
+            {isFailed && document.text && (
+                <p className="mt-3 whitespace-pre-line text-sm text-red-800">{document.text}</p>
+            )}
+            <dl className="mt-3 grid gap-2 text-xs text-gray-600 sm:grid-cols-3">
+                <div>
+                    <dt className="font-medium text-gray-500">受付からの経過</dt>
+                    <dd className="text-gray-800">{elapsedLabel ?? '不明'}</dd>
+                </div>
+                <div>
+                    <dt className="font-medium text-gray-500">状態の観測時刻</dt>
+                    <dd className="text-gray-800">{observedAtLabel ?? '未観測'}</dd>
+                </div>
+                <div>
+                    <dt className="font-medium text-gray-500">最終確認</dt>
+                    <dd className="text-gray-800">{lastCheckedLabel ?? 'この画面ではまだ確認していません'}</dd>
+                </div>
+            </dl>
+            <p className="mt-3 text-sm text-gray-700">{describeProcessingFreshness(watch, observation)}</p>
+            {onCheck && !isCompleted && (
+                <button
+                    type="button"
+                    onClick={onCheck}
+                    disabled={isChecking}
+                    aria-busy={isChecking || undefined}
+                    className="mt-3 inline-flex min-h-11 items-center gap-2 rounded-lg bg-purple-600 px-4 text-sm font-medium text-white transition-colors hover:bg-purple-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                    <RefreshCw className={`h-4 w-4 ${isChecking ? 'motion-safe:animate-spin' : ''}`} aria-hidden="true" />
+                    {isChecking ? '確認しています…' : '状態を確認'}
+                </button>
+            )}
+            <p className="mt-3 text-xs text-gray-500">
+                この画面を離れても文字起こしは継続します。文書を開くと最新の状態を確認できます。
+            </p>
+        </section>
+    );
+}

--- a/src/components/DocumentListSidebar.test.tsx
+++ b/src/components/DocumentListSidebar.test.tsx
@@ -47,8 +47,10 @@ vi.mock('@/lib/logger', () => ({
 
 import {
     DOCUMENT_LIST_POLL_INTERVAL_MS,
+    describeProcessingBadge,
     DocumentListSidebar,
     DocumentListStatus,
+    hasSameDocumentVersion,
 } from './DocumentListSidebar';
 import type { Transcription } from '@/lib/firestore';
 
@@ -272,6 +274,57 @@ function renderSidebar(props: Partial<React.ComponentProps<typeof DocumentListSi
     );
 }
 
+describe('DocumentListSidebar 進捗投影と同一版判定（仕様 §A3）', () => {
+    const processingDocument: Transcription = {
+        ...documentFixture,
+        status: 'processing',
+        processingProgress: { stage: 'queued', stageObservedAtMs: 1_000, jobCreatedAtMs: 500 },
+    };
+
+    it('🔴 updatedAt が同じでも processingProgress が進めば別版として扱い、参照を再利用しない', () => {
+        const advanced: Transcription = {
+            ...processingDocument,
+            processingProgress: { stage: 'importing', stageObservedAtMs: 2_000, jobCreatedAtMs: 500 },
+        };
+        expect(hasSameDocumentVersion(processingDocument, advanced)).toBe(false);
+        // 投影も版印も同じなら再利用する（定期取得で再描画を増やさない）
+        expect(hasSameDocumentVersion(processingDocument, { ...processingDocument })).toBe(true);
+    });
+
+    it('投影が消えて status が completed になれば、版印の有無に関わらず置き換える', () => {
+        const completed: Transcription = {
+            ...documentFixture,
+            status: 'completed',
+            updatedAt: processingDocument.updatedAt,
+        };
+        expect(hasSameDocumentVersion(processingDocument, completed)).toBe(false);
+    });
+
+    it('updatedAt の無い legacy 文書でも投影の変化で置き換える', () => {
+        const legacy: Transcription = { ...processingDocument, updatedAt: undefined };
+        const legacyAdvanced: Transcription = {
+            ...legacy,
+            processingProgress: { stage: 'transcribing', stageObservedAtMs: 3_000 },
+        };
+        expect(hasSameDocumentVersion(legacy, { ...legacy })).toBe(true);
+        expect(hasSameDocumentVersion(legacy, legacyAdvanced)).toBe(false);
+    });
+
+    it('describeProcessingBadge: 投影あり→最終確認時＋段階＋時刻、投影なし→処理中・詳細を確認、failed→失敗、他→null', () => {
+        const at = (ms: number) => `T${ms}`;
+        expect(describeProcessingBadge(
+            { status: 'processing', processingProgress: { stage: 'transcribing', stageObservedAtMs: 123 } }, at,
+        )).toBe('最終確認時: 文字起こし中（T123）');
+        expect(describeProcessingBadge(
+            { status: 'processing', processingProgress: { stage: 'importing' } }, at,
+        )).toBe('最終確認時: 結果を文書に取り込んでいます');
+        expect(describeProcessingBadge({ status: 'processing' }, at)).toBe('処理中・詳細を確認');
+        expect(describeProcessingBadge({ status: 'failed' }, at)).toBe('文字起こしに失敗しました');
+        expect(describeProcessingBadge({ status: 'completed' }, at)).toBeNull();
+        expect(describeProcessingBadge({}, at)).toBeNull();
+    });
+});
+
 describe('DocumentListSidebar', () => {
     let layoutEffects: LayoutEffect[];
 
@@ -326,6 +379,45 @@ describe('DocumentListSidebar', () => {
         expect(markup).toContain('文書一覧を取得できませんでした');
         expect(markup).not.toContain('文書がまだありません');
         expect(markup).not.toContain('全0件');
+    });
+
+    it('processing 行には「最終確認時」と分かる段階バッジを描き、選択ボタンの aria-label にも含める', () => {
+        configureHookState({
+            subjectKey: userSubjectKey,
+            status: 'success',
+            documents: [{
+                ...documentFixture,
+                status: 'processing',
+                processingProgress: { stage: 'queued', stageObservedAtMs: Date.UTC(2026, 8, 5, 3, 4, 0) },
+            }],
+        });
+
+        const markup = renderSidebar();
+
+        expect(markup).toContain('data-processing-badge="processing"');
+        expect(markup).toContain('最終確認時: 開始待ち（');
+        expect(markup).toMatch(/aria-label="「文書A」を選択（最終確認時: 開始待ち（[^）]*））"/);
+        // 一覧は静的な「最終確認時」。スピナーは回さない
+        expect(markup).not.toContain('animate-spin');
+    });
+
+    it('投影の無い旧 processing 文書は「処理中・詳細を確認」、failed は失敗バッジ、完成文書はバッジ無し', () => {
+        configureHookState({
+            subjectKey: userSubjectKey,
+            status: 'success',
+            documents: [
+                { ...documentFixture, id: 'legacy-processing', title: '旧処理中', status: 'processing' },
+                { ...documentFixture, id: 'failed-doc', title: '失敗文書', status: 'failed' },
+                { ...documentFixture, id: 'done-doc', title: '完成文書', status: 'completed' },
+            ],
+        });
+
+        const markup = renderSidebar();
+
+        expect(markup).toContain('aria-label="「旧処理中」を選択（処理中・詳細を確認）"');
+        expect(markup).toContain('data-processing-badge="failed"');
+        expect(markup).toContain('aria-label="「失敗文書」を選択（文字起こしに失敗しました）"');
+        expect(markup).toContain('aria-label="「完成文書」を選択"');
     });
 
     it('成功後だけ件数を表示し、主操作と副操作の入力方式別UI契約を保つ', () => {

--- a/src/components/DocumentListSidebar.tsx
+++ b/src/components/DocumentListSidebar.tsx
@@ -9,11 +9,13 @@ import React, {
     useState,
 } from 'react';
 import {
+    AlertCircle,
     Check,
     Clock,
     Download,
     Edit2,
     FileText,
+    Hourglass,
     RefreshCw,
     Search,
     Trash2,
@@ -27,6 +29,7 @@ import {
     updateTranscription,
 } from '@/lib/firestore';
 import { useAuth } from '@/hooks/useAuth';
+import { describeProgressStage } from '@/hooks/batchTranscriptionClient';
 import { createLogger } from '@/lib/logger';
 
 const documentListLogger = createLogger('DocumentListSidebar');
@@ -119,10 +122,22 @@ const getLegacyContentKey = (transcription: Transcription): string => JSON.strin
     getTimestampKey(transcription.createdAt as ComparableTimestamp | undefined),
 ]);
 
-const hasSameDocumentVersion = (
+// 進捗投影（processingProgress）と status は、本文・updatedAt・並び順を変えずに更新される（仕様 §A3）。
+// 版印（updatedAt）だけで同一視すると「開始待ち→取り込み中」の前進が画面に出ないので、同一版判定に加える。
+const getProcessingStateKey = (transcription: Transcription): string => JSON.stringify([
+    transcription.status ?? null,
+    transcription.processingProgress?.stage ?? null,
+    transcription.processingProgress?.stageObservedAtMs ?? null,
+    transcription.processingProgress?.jobCreatedAtMs ?? null,
+    transcription.processingProgress?.audioSec ?? null,
+]);
+
+export const hasSameDocumentVersion = (
     currentDocument: Transcription,
     nextDocument: Transcription,
 ): boolean => {
+    if (getProcessingStateKey(currentDocument) !== getProcessingStateKey(nextDocument)) return false;
+
     const currentUpdatedAtKey = getTimestampKey(
         currentDocument.updatedAt as ComparableTimestamp | undefined,
     );
@@ -137,6 +152,25 @@ const hasSameDocumentVersion = (
     return getLegacyContentKey(currentDocument) === getLegacyContentKey(nextDocument)
         // ハッシュ衝突で変更を見逃さないよう、指紋一致時は本文も厳密比較する。
         && currentDocument.text === nextDocument.text;
+};
+
+/**
+ * 一覧行の段階バッジ文言（仕様 §A1・A4）。一覧は保存された投影しか持たないので、
+ * 「最終確認時」の情報だと分かる表現にし、投影の無い旧 processing 文書は「処理中・詳細を確認」。
+ * 一覧の全行を継続 status 照会する構成にはしない（詳細を開いた文書だけが継続確認される）。
+ */
+export const describeProcessingBadge = (
+    transcription: Pick<Transcription, 'status' | 'processingProgress'>,
+    formatObservedAt: (ms: number) => string,
+): string | null => {
+    if (transcription.status === 'failed') return '文字起こしに失敗しました';
+    if (transcription.status !== 'processing') return null;
+    const progress = transcription.processingProgress;
+    if (!progress) return '処理中・詳細を確認';
+    const label = describeProgressStage(progress.stage);
+    return progress.stageObservedAtMs !== undefined
+        ? `最終確認時: ${label}（${formatObservedAt(progress.stageObservedAtMs)}）`
+        : `最終確認時: ${label}`;
 };
 
 const preserveUnchangedDocumentReferences = (
@@ -874,6 +908,11 @@ export const DocumentListSidebar: React.FC<DocumentListSidebarProps> = ({
                             const isDeleting = deletingDocumentId === documentId;
                             const isSaving = savingDocumentId === documentId;
                             const hasActiveOperation = savingDocumentId !== null || deletingDocumentId !== null;
+                            const processingBadge = describeProcessingBadge(
+                                transcription,
+                                (ms) => formatDate(new Date(ms)),
+                            );
+                            const isFailedDocument = transcription.status === 'failed';
 
                             return (
                                 <article
@@ -940,7 +979,9 @@ export const DocumentListSidebar: React.FC<DocumentListSidebarProps> = ({
                                                 onClick={() => onDocumentClick(transcription)}
                                                 className="w-full min-h-32 rounded-xl p-4 pr-40 text-left cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2"
                                                 aria-current={isSelected ? 'true' : undefined}
-                                                aria-label={`「${transcription.title}」を選択`}
+                                                aria-label={processingBadge
+                                                    ? `「${transcription.title}」を選択（${processingBadge}）`
+                                                    : `「${transcription.title}」を選択`}
                                             >
                                                 <h3 className="text-sm font-semibold text-gray-900 truncate group-hover:text-purple-700 transition-colors">
                                                     {transcription.title}
@@ -951,6 +992,21 @@ export const DocumentListSidebar: React.FC<DocumentListSidebarProps> = ({
                                                 <p className="text-xs text-purple-600 mt-1 font-medium truncate">
                                                     {transcription.promptName}
                                                 </p>
+                                                {processingBadge && (
+                                                    // 段階はテキストとアイコンで伝える。色だけに依存せず、スピナーも回さない（一覧は静的な「最終確認時」）
+                                                    <span
+                                                        data-processing-badge={isFailedDocument ? 'failed' : 'processing'}
+                                                        className={`mt-2 inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium ${isFailedDocument
+                                                            ? 'border-red-200 bg-red-50 text-red-800'
+                                                            : 'border-amber-200 bg-amber-50 text-amber-900'
+                                                            }`}
+                                                    >
+                                                        {isFailedDocument
+                                                            ? <AlertCircle className="h-3 w-3 shrink-0" aria-hidden="true" />
+                                                            : <Hourglass className="h-3 w-3 shrink-0" aria-hidden="true" />}
+                                                        <span className="truncate">{processingBadge}</span>
+                                                    </span>
+                                                )}
                                                 <span className="flex items-center space-x-2 mt-2 text-xs text-gray-500">
                                                     <Clock className="w-3 h-3" />
                                                     <span>{formatDate(transcription.createdAt)}</span>

--- a/src/components/ProcessingStatusList.test.tsx
+++ b/src/components/ProcessingStatusList.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
-import type { FileProcessingStatus } from '@/types/processing';
-import { ProcessingStatusList } from './ProcessingStatusList';
+import type { BatchTranscriptionProgress, FileProcessingStatus } from '@/types/processing';
+import {
+    CANCEL_LOCAL_LABEL,
+    ProcessingStatusList,
+    RESUME_CONFIRMATION_LABEL,
+    STOP_CONFIRMATION_LABEL,
+} from './ProcessingStatusList';
 
 const createStatus = (overrides: Partial<FileProcessingStatus> = {}): FileProcessingStatus => ({
     fileId: 'f1',
@@ -74,5 +79,147 @@ describe('ProcessingStatusList terminal rendering (H9)', () => {
 
         expect(markup).toContain('再開する');
         expect(markup).toContain('生成済みで保存待ち: 1 件');
+    });
+});
+
+describe('全文文字起こし（バッチ）の段階表示（仕様 §A1・A4）', () => {
+    const createBatch = (overrides: Partial<BatchTranscriptionProgress> = {}): BatchTranscriptionProgress => ({
+        jobId: 'job-1',
+        docId: 'doc-1',
+        promptId: '__builtin_transcript__',
+        stage: 'transcribing',
+        confirmation: 'polling',
+        ...overrides,
+    });
+
+    it('🔴 提出後はバッチ段階を出し、「生成 0/1」「区間」「チャンク」を処理率として出さない', () => {
+        const markup = render([createStatus({ phase: 'text_generation', batch: createBatch() })], ['f1']);
+
+        expect(markup).toContain('全文文字起こし: 文字起こし中');
+        expect(markup).not.toContain('文書を生成しています: 0/1');
+        expect(markup).not.toContain('0/1');
+        expect(markup).not.toContain('区間');
+        expect(markup).not.toContain('チャンク');
+        expect(markup).not.toContain('role="progressbar"');
+        expect(markup).not.toContain('aria-valuenow');
+    });
+
+    it('段階だけを role=status/aria-live=polite の領域に置き、鮮度（時刻）は別要素に出す', () => {
+        const markup = render([createStatus({
+            phase: 'text_generation',
+            batch: createBatch({ stage: 'queued', lastCheckedAtMs: Date.UTC(2026, 8, 5, 3, 4, 5) }),
+        })]);
+
+        expect(markup).toMatch(/<span role="status" aria-live="polite">全文文字起こし: 開始待ち<\/span>/);
+        expect(markup).toContain('最終確認');
+        // 鮮度の要素は live 領域の外
+        expect(markup).not.toMatch(/aria-live="polite">[^<]*最終確認/);
+    });
+
+    it.each([
+        ['checking', '受付済み・状態を確認しています'],
+        ['queued', '開始待ち'],
+        ['transcribing', '文字起こし中'],
+        ['importing', '結果を文書に取り込んでいます'],
+    ] as const)('段階 %s は「%s」と表示する', (stage, label) => {
+        const markup = render([createStatus({ phase: 'text_generation', batch: createBatch({ stage }) })]);
+        expect(markup).toContain(`全文文字起こし: ${label}`);
+    });
+
+    it('段階が届かない旧サーバ応答では「処理中・詳細を確認」', () => {
+        const markup = render([createStatus({ phase: 'text_generation', batch: createBatch({ stage: undefined }) })]);
+        expect(markup).toContain('全文文字起こし: 処理中・詳細を確認');
+    });
+
+    it('スピナーは装飾で、動きを減らす設定では静止する（motion-safe）', () => {
+        const markup = render([createStatus({ phase: 'text_generation', batch: createBatch() })]);
+        expect(markup).toContain('motion-safe:animate-spin');
+        expect(markup).not.toMatch(/class="[^"]*(?<![-:])animate-spin/);
+        expect(markup).toContain('aria-hidden="true"');
+    });
+
+    it('提出後の中止ボタンは「この画面での確認を停止」で、ローカル処理の中止とは分ける', () => {
+        const markup = render([createStatus({ phase: 'text_generation', batch: createBatch() })], ['f1']);
+        expect(markup).toContain(STOP_CONFIRMATION_LABEL);
+        expect(markup).not.toContain(CANCEL_LOCAL_LABEL);
+        expect(markup).toContain('この画面を離れても文字起こしは継続します');
+    });
+
+    it('🔴 確認待ち（pending_confirmation）は失敗として描かず、同じジョブの確認再開の導線を出す', () => {
+        const markup = render([createStatus({
+            status: 'pending_confirmation',
+            phase: 'awaiting_confirmation',
+            batch: createBatch({ confirmation: 'pending', stage: 'transcribing' }),
+        })], ['f1']);
+
+        expect(markup).toContain('確認待ち');
+        expect(markup).toContain('文字起こしはサーバーで継続します');
+        expect(markup).toContain('最終確認時は「文字起こし中」でした');
+        expect(markup).toContain(RESUME_CONFIRMATION_LABEL);
+        expect(markup).toContain('再提出はしません');
+        expect(markup).not.toContain('エラーが発生しました');
+        expect(markup).not.toContain('role="alert"');
+        expect(markup).not.toContain('animate-spin');
+        // ジョブは手放しているので中止ボタンは出さない
+        expect(markup).not.toContain(STOP_CONFIRMATION_LABEL);
+        expect(markup).not.toContain(CANCEL_LOCAL_LABEL);
+    });
+
+    it('確認待ちの「確認を再開する」は onResumeFile を呼ぶ（新規 submit の導線を別に作らない）', () => {
+        const onResumeFile = vi.fn();
+        const status = createStatus({
+            status: 'pending_confirmation',
+            phase: 'awaiting_confirmation',
+            batch: createBatch({ confirmation: 'pending' }),
+        });
+        // 静的描画では onClick を辿れないので、描画木から該当ボタンを探して押す
+        const tree = ProcessingStatusList({ statuses: [status], onResumeFile }) as React.ReactElement;
+        const findButton = (node: React.ReactNode, label: string): React.ReactElement<{ onClick: () => void }> | null => {
+            if (!React.isValidElement<{ children?: React.ReactNode; onClick?: () => void }>(node)) return null;
+            const text = React.Children.toArray(node.props.children)
+                .map(child => (typeof child === 'string' ? child : ''))
+                .join('');
+            if (node.type === 'button' && text.includes(label)) return node as React.ReactElement<{ onClick: () => void }>;
+            for (const child of React.Children.toArray(node.props.children)) {
+                const found = findButton(child, label);
+                if (found) return found;
+            }
+            return null;
+        };
+        const button = findButton(tree, RESUME_CONFIRMATION_LABEL);
+        expect(button).not.toBeNull();
+        button!.props.onClick();
+        expect(onResumeFile).toHaveBeenCalledExactlyOnceWith('f1');
+    });
+
+    it('提出後の中止は「この画面での確認を停止」として描き、サーバ継続と再開の意味を添える', () => {
+        const markup = render([createStatus({
+            status: 'canceled',
+            phase: 'canceled',
+            error: 'ユーザー操作により中止されました。',
+            batch: createBatch({ confirmation: 'stopped' }),
+        })]);
+
+        expect(markup).toContain('この画面での確認を停止しました');
+        expect(markup).toContain('文字起こしはサーバーで継続します');
+        expect(markup).toContain('再開する');
+        expect(markup).not.toContain('処理を中止しました');
+    });
+
+    it('複数プロンプトのファイルでは、他の文書の進捗を段階とは別行で出す', () => {
+        const markup = render([createStatus({
+            phase: 'text_generation',
+            totalTranscriptions: 2,
+            batch: createBatch(),
+        })]);
+        expect(markup).toContain('全文文字起こし: 文字起こし中');
+        expect(markup).toContain('他の文書: 文書を生成しています');
+    });
+
+    it('提出前（batch なし）の表示は従来どおり', () => {
+        const markup = render([createStatus({ phase: 'uploading' })], ['f1']);
+        expect(markup).toContain('音声データをアップロードしています');
+        expect(markup).toContain(CANCEL_LOCAL_LABEL);
+        expect(markup).not.toContain('全文文字起こし:');
     });
 });

--- a/src/components/ProcessingStatusList.tsx
+++ b/src/components/ProcessingStatusList.tsx
@@ -1,12 +1,22 @@
 'use client';
 
 import React from 'react';
-import { AlertCircle, CheckCircle2, Loader2, RotateCcw, XCircle } from 'lucide-react';
 import {
+    AlertCircle,
+    CheckCircle2,
+    Clock,
+    Loader2,
+    RefreshCw,
+    RotateCcw,
+    XCircle,
+} from 'lucide-react';
+import {
+    BatchTranscriptionProgress,
     FileProcessingStatus,
     ProcessingFailedPhase,
     ProcessingPhase,
 } from '@/types/processing';
+import { describeProgressStage, formatClockTime } from '@/hooks/batchTranscriptionClient';
 
 interface ProcessingStatusListProps {
     statuses: FileProcessingStatus[];
@@ -25,6 +35,7 @@ const PHASE_LABELS: Record<ProcessingPhase, string> = {
     uploading: '音声データをアップロードしています',
     text_generation: '文書を生成しています',
     saving: '文書を保存しています',
+    awaiting_confirmation: '文字起こしの完了確認を待っています',
     completed: '完了しました',
     canceled: '中止しました',
 };
@@ -35,6 +46,23 @@ const FAILED_PHASE_LABELS: Record<ProcessingFailedPhase, string> = {
     upload: 'アップロード',
     text_generation: '文書生成',
     saving: '文書の保存',
+};
+
+/** 提出後の中止はローカル処理の中止ではなく、この画面での状態確認の停止（仕様 §A4） */
+export const CANCEL_LOCAL_LABEL = 'このファイルの処理を中止する';
+export const STOP_CONFIRMATION_LABEL = 'この画面での確認を停止する';
+export const RESUME_CONFIRMATION_LABEL = '確認を再開する';
+
+/** 全文文字起こしの段階文言。旧サーバ応答で段階が届かない間は「処理中・詳細を確認」 */
+export const describeBatchStage = (batch: BatchTranscriptionProgress): string =>
+    batch.stage ? describeProgressStage(batch.stage) : '処理中・詳細を確認';
+
+/** 鮮度の併記。段階の live 領域とは別要素に出し、時刻更新を読み上げさせない */
+const describeBatchFreshness = (batch: BatchTranscriptionProgress): string | null => {
+    const parts: string[] = [];
+    if (batch.lastCheckedAtMs !== undefined) parts.push(`最終確認 ${formatClockTime(batch.lastCheckedAtMs)}`);
+    if (batch.observedAtMs !== undefined) parts.push(`状態の観測 ${formatClockTime(batch.observedAtMs)}`);
+    return parts.length > 0 ? parts.join('・') : null;
 };
 
 export const ProcessingStatusList: React.FC<ProcessingStatusListProps> = ({
@@ -56,11 +84,16 @@ export const ProcessingStatusList: React.FC<ProcessingStatusListProps> = ({
             </h2>
             <ul className="space-y-3">
                 {statuses.map(status => {
-                    // H9: 終了状態を最優先で描画し、失敗後にスピナーが回り続けないようにする
+                    // H9: 終了状態を最優先で描画し、失敗後にスピナーが回り続けないようにする。
+                    // 確認待ち（pending_confirmation）もジョブは手放しているので終了扱い（ただし失敗ではない）
                     const isTerminal = status.status === 'completed'
                         || status.status === 'error'
-                        || status.status === 'canceled';
+                        || status.status === 'canceled'
+                        || status.status === 'pending_confirmation';
                     const savePendingCount = status.savePendingPromptIds?.length ?? 0;
+                    // 提出後のバッチ段階。音声変換の区間や生成件数とは別物なので、混ぜて出さない（仕様 §A4）
+                    const activeBatch = status.batch?.confirmation === 'polling' ? status.batch : null;
+                    const batchFreshness = status.batch ? describeBatchFreshness(status.batch) : null;
 
                     return (
                         <li key={status.fileId} className="rounded-lg border bg-white p-4 shadow-sm">
@@ -75,15 +108,49 @@ export const ProcessingStatusList: React.FC<ProcessingStatusListProps> = ({
                                 </p>
                             )}
 
+                            {status.status === 'pending_confirmation' && (
+                                <div className="flex flex-wrap items-start justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                                    <div className="min-w-0 flex-1" role="status">
+                                        <p className="flex items-center gap-2 text-sm font-medium text-amber-900">
+                                            <Clock className="h-5 w-5 shrink-0 text-amber-600" aria-hidden="true" />
+                                            確認待ち: 自動確認を停止しました。文字起こしはサーバーで継続します
+                                        </p>
+                                        {status.batch?.stage && (
+                                            <p className="mt-1 text-[13px] text-amber-900">
+                                                最終確認時は「{describeProgressStage(status.batch.stage)}」でした
+                                                {batchFreshness && `（${batchFreshness}）`}
+                                            </p>
+                                        )}
+                                        <p className="mt-1 text-[13px] text-gray-700">
+                                            文書一覧で最新の状態を確認できます。「{RESUME_CONFIRMATION_LABEL}」は同じ文字起こしの確認を再開します（再提出はしません）。
+                                        </p>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={() => onResumeFile(status.fileId)}
+                                        disabled={status.isResuming}
+                                        className="flex min-h-11 shrink-0 items-center gap-2 rounded-lg bg-purple-600 px-4 text-sm font-medium text-white transition-colors hover:bg-purple-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                    >
+                                        <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                                        {status.isResuming ? '確認を再開しています...' : RESUME_CONFIRMATION_LABEL}
+                                    </button>
+                                </div>
+                            )}
+
                             {status.status === 'canceled' && (
                                 <div className="flex flex-wrap items-start justify-between gap-3">
                                     <div className="min-w-0 flex-1" role="status">
                                         <p className="flex items-center gap-2 text-sm font-medium text-gray-700">
                                             <XCircle className="h-5 w-5 shrink-0 text-gray-500" aria-hidden="true" />
-                                            処理を中止しました
+                                            {status.batch ? 'この画面での確認を停止しました' : '処理を中止しました'}
                                         </p>
                                         {status.error && (
                                             <p className="mt-1 text-[13px] text-gray-600">{status.error}</p>
+                                        )}
+                                        {status.batch && (
+                                            <p className="mt-1 text-[13px] text-gray-600">
+                                                文字起こしはサーバーで継続します。文書一覧で最新の状態を確認できます。「再開する」は同じ文字起こしの確認を再開します（再提出はしません）。
+                                            </p>
                                         )}
                                         {status.completedPromptIds.length > 0 && (
                                             <p className="mt-1 text-[13px] text-green-700">
@@ -181,13 +248,38 @@ export const ProcessingStatusList: React.FC<ProcessingStatusListProps> = ({
                                                 />
                                             </div>
                                         </div>
+                                    ) : activeBatch ? (
+                                        // 全文文字起こし（バッチ）の段階（仕様 §A1・A4）。%・区間数・「生成 0/1」は出さない。
+                                        // 段階だけを live 領域に置き、時刻の更新は読み上げさせない。スピナーは装飾（動きを減らす設定では静止）
+                                        <div className="space-y-1">
+                                            <p className="flex items-center gap-3 text-sm font-medium text-purple-800">
+                                                <Loader2 className="h-5 w-5 shrink-0 text-purple-600 motion-safe:animate-spin" aria-hidden="true" />
+                                                <span role="status" aria-live="polite">
+                                                    全文文字起こし: {describeBatchStage(activeBatch)}
+                                                </span>
+                                            </p>
+                                            {batchFreshness && (
+                                                <p className="text-[13px] text-gray-600">{batchFreshness}</p>
+                                            )}
+                                            {status.totalTranscriptions > 1 && (
+                                                <p className="text-[13px] text-gray-600">
+                                                    他の文書: {PHASE_LABELS[status.phase]}
+                                                    {(status.phase === 'text_generation' || status.phase === 'saving') && (
+                                                        `（保存済み ${status.transcriptionCount}/${status.totalTranscriptions}）`
+                                                    )}
+                                                </p>
+                                            )}
+                                            <p className="text-[13px] text-gray-500">
+                                                この画面を離れても文字起こしは継続します。文書を開くと最新の状態を確認できます。
+                                            </p>
+                                        </div>
                                     ) : (
                                         <p
                                             role="status"
                                             aria-live="polite"
                                             className="flex items-center gap-3 text-sm font-medium text-purple-800"
                                         >
-                                            <Loader2 className="h-5 w-5 shrink-0 animate-spin text-purple-600" aria-hidden="true" />
+                                            <Loader2 className="h-5 w-5 shrink-0 text-purple-600 motion-safe:animate-spin" aria-hidden="true" />
                                             <span>
                                                 {status.phase === 'waiting' && status.isResuming
                                                     ? '音声変換の順番を待っています（他のファイルの変換が終わり次第開始します）'
@@ -199,14 +291,14 @@ export const ProcessingStatusList: React.FC<ProcessingStatusListProps> = ({
                                         </p>
                                     )}
 
-                                    {/* U7: 反応しない中止ボタンを置かない */}
+                                    {/* U7: 反応しない中止ボタンを置かない。提出後は「確認の停止」であって処理の中止ではない */}
                                     {onCancelFile && activeFileIds.includes(status.fileId) && (
                                         <button
                                             type="button"
                                             onClick={() => onCancelFile(status.fileId)}
                                             className="min-h-11 rounded-md px-3 text-sm font-medium text-red-700 transition-colors hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
                                         >
-                                            このファイルの処理を中止する
+                                            {activeBatch ? STOP_CONFIRMATION_LABEL : CANCEL_LOCAL_LABEL}
                                         </button>
                                     )}
                                 </div>

--- a/src/hooks/batchTranscriptionClient.test.ts
+++ b/src/hooks/batchTranscriptionClient.test.ts
@@ -213,6 +213,25 @@ describe('pollBatchStatus', () => {
         expect(res.status).toBe('running');
     });
 
+    it('🔴 バックオフ待ちの最中に中止されたら、満了を待たず直ちに中止理由で拒否する', async () => {
+        // 実 defaultWait（abort 対応）を使う。502 → バックオフ待ちに入り、その間に abort。
+        // タイマー満了（30秒）を待たずに reject すること（呼出側の停止待ち上限 30 秒を超えさせない）。
+        vi.useFakeTimers();
+        try {
+            const controller = new AbortController();
+            vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+                jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502));
+            // wait は注入せず実 defaultWait を使う
+            const pending = pollBatchStatus('j1', { signal: controller.signal });
+            const rejected = expect(pending).rejects.toThrow('画面を離れた');
+            await vi.advanceTimersByTimeAsync(0); // 1 回目の fetch を解決させ、バックオフ待ちへ
+            controller.abort(new Error('画面を離れた'));
+            await rejected; // タイマーを進めずに reject される
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it('タイムアウト時は最後に受け取った有効な応答（段階つき）を返す（上限直後の周回が失敗でも）', async () => {
         // 1 周目: 有効な running（段階つき）→ 待ちで時計が上限を超える → 2 周目: 一時エラー → 上限で返す
         vi.spyOn(globalThis, 'fetch')
@@ -328,7 +347,8 @@ describe('pollBatchStatus', () => {
         const wait = vi.fn(async () => { controller.abort(reason); });
 
         await expect(pollBatchStatus('j1', { signal: controller.signal, wait })).rejects.toBe(reason);
-        expect(wait).toHaveBeenCalledExactlyOnceWith(30_000);
+        // signal のある本番経路では wait に signal も渡す（defaultWait が abort に即応するため）。
+        expect(wait).toHaveBeenCalledExactlyOnceWith(30_000, controller.signal);
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 

--- a/src/hooks/batchTranscriptionClient.test.ts
+++ b/src/hooks/batchTranscriptionClient.test.ts
@@ -1,20 +1,41 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
-    submitBatchTranscription,
-    reconcileProcessingDocument,
+    countInflightStatusRequests,
+    describeElapsed,
+    estimateServerNowMs,
+    fetchBatchStatus,
     pollBatchStatus,
+    reconcileProcessingDocument,
+    resolveProgressObservation,
+    resumeBatchTranscription,
     runBatchTranscription,
+    stageFromStatusResponse,
+    startDocumentStatusWatch,
+    submitBatchTranscription,
+    TranscribeStatusError,
+    type DocumentStatusWatchEnvironment,
+    type DocumentStatusWatchSnapshot,
 } from './batchTranscriptionClient';
-import { TRANSCRIBE_SUBMIT_PATH, TRANSCRIBE_STATUS_PATH } from '@/lib/transcribeBatchContract';
+import {
+    TRANSCRIBE_SUBMIT_PATH,
+    TRANSCRIBE_STATUS_PATH,
+    type TranscribeStatusResponse,
+} from '@/lib/transcribeBatchContract';
 
 // firebase の遅延 import を無害化（Auth 初期化を避ける・ゲスト扱い）
 vi.mock('@/lib/firebase', () => ({ auth: { currentUser: null } }));
 
-const jsonResponse = (body: unknown, ok = true, status = 200) => ({
+const jsonResponse = (body: unknown, ok = true, status = 200, headers?: Record<string, string>) => ({
     ok, status, json: async () => body,
+    ...(headers ? { headers: new Headers(headers) } : {}),
 }) as unknown as Response;
 
 const noWait = async () => {};
+
+const statusRequestBodies = (fetchMock: { mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> } }): unknown[] =>
+    fetchMock.mock.calls
+        .filter(([url]) => url === TRANSCRIBE_STATUS_PATH)
+        .map(([, init]) => JSON.parse(String((init as RequestInit).body)));
 
 beforeEach(() => {
     vi.restoreAllMocks();
@@ -42,17 +63,17 @@ describe('submitBatchTranscription', () => {
 });
 
 describe('reconcileProcessingDocument', () => {
-    it('docId と signal を渡して 1 回だけ確認し、running のまま返す', async () => {
+    it('docId を渡して 1 回だけ確認し、running のまま返す', async () => {
         const status = { status: 'running', docId: 'd1' };
         const controller = new AbortController();
         const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(status));
 
         expect(await reconcileProcessingDocument('d1', controller.signal)).toBe(status);
+        // 🔴 fetch 自体には呼出元のシグナルを渡さない（同じ文書の他の確認と共有するため）。
         expect(fetchMock).toHaveBeenCalledExactlyOnceWith(TRANSCRIBE_STATUS_PATH, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
             body: JSON.stringify({ docId: 'd1' }),
-            signal: controller.signal,
         });
     });
 
@@ -64,11 +85,102 @@ describe('reconcileProcessingDocument', () => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it('確認エラーは再試行せず呼出元へ返す', async () => {
+    it('確認エラーは再試行せず、HTTP ステータス付きの TranscribeStatusError で呼出元へ返す', async () => {
         const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
             jsonResponse({ error: 'upstream_error', message: '確認できません' }, false, 502));
 
-        await expect(reconcileProcessingDocument('d1')).rejects.toThrow('確認できません');
+        const failure = await reconcileProcessingDocument('d1').catch((error: unknown) => error);
+        expect(failure).toBeInstanceOf(TranscribeStatusError);
+        expect((failure as TranscribeStatusError).message).toBe('確認できません');
+        expect((failure as TranscribeStatusError).httpStatus).toBe(502);
+        expect((failure as TranscribeStatusError).code).toBe('upstream_error');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('既に中止されたシグナルでは fetch せずに中止理由で拒否する', async () => {
+        const controller = new AbortController();
+        controller.abort(new Error('stopped'));
+        const fetchMock = vi.spyOn(globalThis, 'fetch');
+        await expect(reconcileProcessingDocument('d1', controller.signal)).rejects.toThrow('stopped');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('TranscribeStatusError の Retry-After', () => {
+    it('本文の retryAfterSec を ms にして持つ', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'rate_limited', message: '混雑', retryAfterSec: 20 }, false, 429));
+        const failure = await reconcileProcessingDocument('d1').catch((error: unknown) => error) as TranscribeStatusError;
+        expect(failure.httpStatus).toBe(429);
+        expect(failure.retryAfterMs).toBe(20_000);
+    });
+
+    it('本文に無ければ Retry-After ヘッダ（秒）を読む', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'rate_limited', message: '混雑' }, false, 429, { 'retry-after': '7' }));
+        const failure = await reconcileProcessingDocument('d1').catch((error: unknown) => error) as TranscribeStatusError;
+        expect(failure.retryAfterMs).toBe(7_000);
+    });
+
+    it('どちらも無ければ undefined', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'rate_limited', message: '混雑' }, false, 429));
+        const failure = await reconcileProcessingDocument('d1').catch((error: unknown) => error) as TranscribeStatusError;
+        expect(failure.retryAfterMs).toBeUndefined();
+    });
+});
+
+describe('🔴 状態確認の共有（仕様 §A2 手順3: 同一 docId の実行中リクエストを共有し、二重 poll を作らない）', () => {
+    it('同じ docId の同時確認は fetch 1 回を共有する（docId 指定も jobId+docId 指定も同じ鍵）', async () => {
+        let resolveFetch!: (response: Response) => void;
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+            () => new Promise<Response>(resolve => { resolveFetch = resolve; }));
+
+        const first = reconcileProcessingDocument('d1');
+        const second = reconcileProcessingDocument('d1');
+        const byJob = fetchBatchStatus('j1', undefined, 'd1');
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        expect(countInflightStatusRequests()).toBe(1);
+
+        resolveFetch(jsonResponse({ status: 'running', docId: 'd1' }));
+        const results = await Promise.all([first, second, byJob]);
+        expect(results.map(result => result.status)).toEqual(['running', 'running', 'running']);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(countInflightStatusRequests()).toBe(0);
+    });
+
+    it('別の docId は共有しない', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+            const body = JSON.parse(String((init as RequestInit).body)) as { docId: string };
+            return jsonResponse({ status: 'running', docId: body.docId });
+        });
+        const [a, b] = await Promise.all([reconcileProcessingDocument('d1'), reconcileProcessingDocument('d2')]);
+        expect(a.docId).toBe('d1');
+        expect(b.docId).toBe('d2');
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('完了した後の次の確認は新しいリクエストになる', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ status: 'running', docId: 'd1' }));
+        await reconcileProcessingDocument('d1');
+        await reconcileProcessingDocument('d1');
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('片方の中止は共有相手を巻き添えにしない（中止側だけが中止理由で拒否される）', async () => {
+        let resolveFetch!: (response: Response) => void;
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+            () => new Promise<Response>(resolve => { resolveFetch = resolve; }));
+        const controller = new AbortController();
+
+        const aborting = reconcileProcessingDocument('d1', controller.signal);
+        const surviving = reconcileProcessingDocument('d1');
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        controller.abort(new Error('画面を離れた'));
+        await expect(aborting).rejects.toThrow('画面を離れた');
+
+        resolveFetch(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        expect((await surviving).status).toBe('succeeded');
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 });
@@ -101,6 +213,21 @@ describe('pollBatchStatus', () => {
         expect(res.status).toBe('running');
     });
 
+    it('タイムアウト時は最後に受け取った有効な応答（段階つき）を返す（上限直後の周回が失敗でも）', async () => {
+        // 1 周目: 有効な running（段階つき）→ 待ちで時計が上限を超える → 2 周目: 一時エラー → 上限で返す
+        vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ status: 'running', docId: 'd1', stage: 'transcribing' }))
+            .mockResolvedValueOnce(jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502));
+        let nowOffset = 0;
+        const realNow = Date.now;
+        vi.spyOn(Date, 'now').mockImplementation(() => realNow() + nowOffset);
+        const result = await pollBatchStatus('j1', {
+            wait: async () => { nowOffset += 10 * 60_000; },
+            timeoutMs: 60_000,
+        });
+        expect(result).toEqual({ status: 'running', docId: 'd1', stage: 'transcribing' });
+    });
+
     it('🔴 一時的な状態確認エラー（502）で止まらず、次の周回で確定を拾う', async () => {
         // 1回目 502（サーバの確定 commit が transient で落ちた等）→ 飲み込んで再試行 → 2回目 succeeded。
         // これで止まると、サーバのリース切れ再確定に永遠に到達せず文書が processing で固まる（再レビュー major）。
@@ -130,18 +257,42 @@ describe('pollBatchStatus', () => {
     });
 });
 
+describe('resumeBatchTranscription（提出済みジョブの確認再開）', () => {
+    it('🔴 submit を呼ばず、jobId の確認だけを再開して成功を返す', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ status: 'running', docId: 'd1', stage: 'importing' }))
+            .mockResolvedValueOnce(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        const ticks: (string | undefined)[] = [];
+        const res = await resumeBatchTranscription({
+            jobId: 'j1', docId: 'd1', pollIntervalMs: 1, onTick: (status) => ticks.push(status.stage),
+        });
+        expect(res).toEqual({ outcome: 'succeeded', success: true, jobId: 'j1', docId: 'd1' });
+        expect(fetchMock.mock.calls.every(([url]) => url === TRANSCRIBE_STATUS_PATH)).toBe(true);
+        expect(statusRequestBodies(fetchMock)).toEqual([{ jobId: 'j1' }, { jobId: 'j1' }]);
+        expect(ticks).toEqual(['importing', undefined]);
+    });
+
+    it('失敗はサーバの理由を返す', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ status: 'failed', docId: 'd1', error: '音声が長すぎます' }));
+        expect(await resumeBatchTranscription({ jobId: 'j1', docId: 'd1' })).toEqual({
+            outcome: 'failed', success: false, jobId: 'j1', docId: 'd1', error: '音声が長すぎます',
+        });
+    });
+});
+
 describe('runBatchTranscription', () => {
     const input = {
         storagePath: 'audio/GUEST/x.mp3', fileName: 'x.mp3', mimeType: 'audio/mpeg',
         audioSec: 600, promptName: 'p', originalFileType: 'audio', pollIntervalMs: 0,
     };
 
-    it('提出→ポーリング→成功で {success:true, docId}', async () => {
+    it('提出→ポーリング→成功で {outcome:succeeded, jobId, docId}', async () => {
         vi.spyOn(globalThis, 'fetch')
             .mockResolvedValueOnce(jsonResponse({ jobId: 'j1', docId: 'd1' }))   // submit
             .mockResolvedValueOnce(jsonResponse({ status: 'succeeded', docId: 'd1' })); // status
         const res = await runBatchTranscription(input);
-        expect(res).toEqual({ success: true, docId: 'd1' });
+        expect(res).toEqual({ outcome: 'succeeded', success: true, jobId: 'j1', docId: 'd1' });
     });
 
     it('失敗はサーバの理由を返す（文書は消えない前提）', async () => {
@@ -149,6 +300,338 @@ describe('runBatchTranscription', () => {
             .mockResolvedValueOnce(jsonResponse({ jobId: 'j1', docId: 'd1' }))
             .mockResolvedValueOnce(jsonResponse({ status: 'failed', docId: 'd1', error: '音声が長すぎます' }));
         const res = await runBatchTranscription(input);
-        expect(res).toEqual({ success: false, docId: 'd1', error: '音声が長すぎます' });
+        expect(res).toEqual({ outcome: 'failed', success: false, jobId: 'j1', docId: 'd1', error: '音声が長すぎます' });
+    });
+
+    it('提出直後に onSubmitted へ {jobId, docId} を渡す（確認再開用に呼出元が保持する）', async () => {
+        vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ jobId: 'j1', docId: 'd1' }))
+            .mockResolvedValueOnce(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        const onSubmitted = vi.fn();
+        await runBatchTranscription({ ...input, onSubmitted });
+        expect(onSubmitted).toHaveBeenCalledExactlyOnceWith({ jobId: 'j1', docId: 'd1' });
+    });
+
+    it('🔴 確認上限の pending は失敗ではなく outcome:pending（最後の有効応答つき）で返す', async () => {
+        vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ jobId: 'j1', docId: 'd1' }))
+            .mockResolvedValue(jsonResponse({ status: 'running', docId: 'd1', stage: 'queued' }));
+        let nowOffset = 0;
+        const realNow = Date.now;
+        vi.spyOn(Date, 'now').mockImplementation(() => realNow() + nowOffset);
+        // 1 周目の応答後に時計を進めて上限を超えさせる
+        const onTick = vi.fn(() => { nowOffset += STATUS_POLL_TIMEOUT_MS_FOR_TEST; });
+        const res = await runBatchTranscription({ ...input, onTick });
+        expect(res).toEqual({
+            outcome: 'pending', success: false, pending: true, jobId: 'j1', docId: 'd1',
+            lastStatus: { status: 'running', docId: 'd1', stage: 'queued' },
+        });
+    });
+});
+
+const STATUS_POLL_TIMEOUT_MS_FOR_TEST = 91 * 60_000;
+
+describe('表示段階のヘルパ（仕様 §A1・A3）', () => {
+    it('stageFromStatusResponse: 応答の stage を使い、無ければ終端だけ公開 3 値から導く', () => {
+        expect(stageFromStatusResponse({ status: 'running', docId: 'd', stage: 'queued' })).toBe('queued');
+        expect(stageFromStatusResponse({ status: 'succeeded', docId: 'd' })).toBe('completed');
+        expect(stageFromStatusResponse({ status: 'failed', docId: 'd' })).toBe('failed');
+        // 旧サーバ: running で stage 無し → 不明（勝手に段階を作らない）
+        expect(stageFromStatusResponse({ status: 'running', docId: 'd' })).toBeUndefined();
+    });
+
+    it('resolveProgressObservation: 終端を最優先し、非終端では観測時刻が新しい方を採用する', () => {
+        const projection = { stage: 'importing' as const, stageObservedAtMs: 2_000, jobCreatedAtMs: 100 };
+        const older: TranscribeStatusResponse = { status: 'running', docId: 'd', stage: 'transcribing', azureStatusCheckedAtMs: 1_000 };
+        const newer: TranscribeStatusResponse = { status: 'running', docId: 'd', stage: 'transcribing', azureStatusCheckedAtMs: 3_000 };
+        const terminal: TranscribeStatusResponse = { status: 'succeeded', docId: 'd' };
+
+        expect(resolveProgressObservation(projection, older)).toMatchObject({ stage: 'importing', source: 'projection' });
+        expect(resolveProgressObservation(projection, newer)).toMatchObject({ stage: 'transcribing', source: 'status' });
+        expect(resolveProgressObservation(projection, terminal)).toMatchObject({ stage: 'completed', source: 'status' });
+        expect(resolveProgressObservation(projection, null)).toMatchObject({ stage: 'importing', jobCreatedAtMs: 100 });
+        expect(resolveProgressObservation(undefined, null)).toBeNull();
+        // 観測時刻が無い側があれば、生きている応答を優先する
+        expect(resolveProgressObservation({ stage: 'queued' }, older)).toMatchObject({ stage: 'transcribing' });
+    });
+
+    it('describeElapsed: 分単位で丸め、秒やパーセントを出さない', () => {
+        expect(describeElapsed(0)).toBe('1分未満');
+        expect(describeElapsed(59_000)).toBe('1分未満');
+        expect(describeElapsed(5 * 60_000 + 30_000)).toBe('5分');
+        expect(describeElapsed(65 * 60_000)).toBe('1時間5分');
+        expect(describeElapsed(120 * 60_000)).toBe('2時間');
+        expect(describeElapsed(Number.NaN)).toBe('1分未満');
+    });
+
+    it('estimateServerNowMs: serverNowMs にローカル経過を足し、無ければローカル時刻', () => {
+        const response: TranscribeStatusResponse = { status: 'running', docId: 'd', serverNowMs: 10_000 };
+        expect(estimateServerNowMs(response, 500_000, 530_000)).toBe(40_000);
+        expect(estimateServerNowMs({ status: 'running', docId: 'd' }, 500_000, 530_000)).toBe(530_000);
+        expect(estimateServerNowMs(null, null, 530_000)).toBe(530_000);
+    });
+});
+
+describe('startDocumentStatusWatch（選択中文書の継続確認・仕様 §A2 手順3〜5）', () => {
+    interface FakeTimer { id: number; callback: () => void; ms: number }
+
+    const createEnvironment = (initial: { visible?: boolean; online?: boolean } = {}) => {
+        const timers: FakeTimer[] = [];
+        const listeners = new Set<() => void>();
+        let nextId = 1;
+        const state = { visible: initial.visible ?? true, online: initial.online ?? true, now: 1_000_000 };
+        const environment: DocumentStatusWatchEnvironment = {
+            isVisible: () => state.visible,
+            isOnline: () => state.online,
+            subscribe: (onChange) => {
+                listeners.add(onChange);
+                return () => listeners.delete(onChange);
+            },
+            now: () => state.now,
+            setTimer: (callback, ms) => {
+                const id = nextId++;
+                timers.push({ id, callback, ms });
+                return id;
+            },
+            clearTimer: (handle) => {
+                const index = timers.findIndex(timer => timer.id === handle);
+                if (index >= 0) timers.splice(index, 1);
+            },
+        };
+        return {
+            environment,
+            state,
+            timers,
+            listenerCount: () => listeners.size,
+            /** 次のタイマーを 1 本だけ発火させる */
+            fireNext: () => {
+                const timer = timers.shift();
+                if (!timer) throw new Error('発火できるタイマーがありません');
+                timer.callback();
+            },
+            notify: () => listeners.forEach(listener => listener()),
+        };
+    };
+
+    const running = (stage: TranscribeStatusResponse['stage'] = 'transcribing'): TranscribeStatusResponse =>
+        ({ status: 'running', docId: 'd1', stage, azureStatusCheckedAtMs: 999_000, serverNowMs: 1_000_100 });
+
+    const waitForMode = (watch: { getSnapshot: () => DocumentStatusWatchSnapshot }, mode: DocumentStatusWatchSnapshot['mode']) =>
+        vi.waitFor(() => expect(watch.getSnapshot().mode).toBe(mode));
+
+    it('開始時に即時 1 回確認し、完了後に基本間隔のタイマーを 1 本だけ積む（積み重ねない）', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(running()));
+        const env = createEnvironment();
+        const onChange = vi.fn();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment, onChange });
+
+        expect(watch.getSnapshot().mode).toBe('checking');
+        await waitForMode(watch, 'waiting');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(statusRequestBodies(fetchMock)).toEqual([{ docId: 'd1' }]);
+        expect(env.timers.map(timer => timer.ms)).toEqual([15_000]);
+        expect(watch.getSnapshot()).toMatchObject({
+            lastResponse: running(), lastResponseAtMs: 1_000_000, lastError: null, consecutiveFailures: 0,
+        });
+
+        env.fireNext();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+        await waitForMode(watch, 'waiting');
+        expect(env.timers).toHaveLength(1);
+        expect(onChange).toHaveBeenLastCalledWith(watch.getSnapshot());
+        watch.stop();
+    });
+
+    it('手動確認（checkNow）は実行中のリクエストを共有し、重複送信しない', async () => {
+        let resolveFetch!: (response: Response) => void;
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+            () => new Promise<Response>(resolve => { resolveFetch = resolve; }));
+        const env = createEnvironment();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment });
+
+        const first = watch.checkNow();
+        const second = watch.checkNow();
+        expect(second).toBe(first);
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+        resolveFetch(jsonResponse(running()));
+        expect((await first)?.status).toBe('running');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        watch.stop();
+    });
+
+    it('🔴 HTTP 一時失敗は 30→60 秒へ延ばし、成功で 15 秒へ戻す。失敗では lastResponse を進めない', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502))
+            .mockResolvedValueOnce(jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502))
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(jsonResponse(running()));
+        const env = createEnvironment();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment });
+
+        await waitForMode(watch, 'waiting');
+        expect(env.timers.map(timer => timer.ms)).toEqual([30_000]);
+        expect(watch.getSnapshot()).toMatchObject({
+            lastResponse: null, lastError: { message: '一時エラー', httpStatus: 502 }, consecutiveFailures: 1,
+        });
+
+        env.fireNext();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+        await vi.waitFor(() => expect(env.timers.map(timer => timer.ms)).toEqual([60_000]));
+
+        env.fireNext();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+        await vi.waitFor(() => expect(env.timers.map(timer => timer.ms)).toEqual([60_000]));
+        expect(watch.getSnapshot()).toMatchObject({
+            lastError: { message: '通信に失敗しました。' }, consecutiveFailures: 3,
+        });
+
+        env.fireNext();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+        await vi.waitFor(() => expect(env.timers.map(timer => timer.ms)).toEqual([15_000]));
+        expect(watch.getSnapshot()).toMatchObject({ lastError: null, consecutiveFailures: 0, lastResponse: running() });
+        watch.stop();
+    });
+
+    it('429 は Retry-After を尊重する', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'rate_limited', message: '混雑', retryAfterSec: 20 }, false, 429));
+        const env = createEnvironment();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment });
+        await waitForMode(watch, 'waiting');
+        expect(env.timers.map(timer => timer.ms)).toEqual([20_000]);
+        watch.stop();
+    });
+
+    it.each([401, 403])('%s は自動確認を止め（stopped_auth）、タイマーを積まない', async (httpStatus) => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'forbidden', message: '権限がありません' }, false, httpStatus));
+        const env = createEnvironment();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment });
+        await waitForMode(watch, 'stopped_auth');
+        expect(env.timers).toHaveLength(0);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        watch.stop();
+    });
+
+    it('🔴 404 は「確認できません」として自動確認を止め、再提出しない。手動確認で再開できる', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ error: 'media_not_found', message: '文書が見つかりません。' }, false, 404))
+            .mockResolvedValueOnce(jsonResponse(running()));
+        const env = createEnvironment();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment });
+        await waitForMode(watch, 'stopped_not_found');
+        expect(env.timers).toHaveLength(0);
+        expect(fetchMock.mock.calls.every(([url]) => url === TRANSCRIBE_STATUS_PATH)).toBe(true);
+
+        await watch.checkNow();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls.every(([url]) => url === TRANSCRIBE_STATUS_PATH)).toBe(true);
+        await waitForMode(watch, 'waiting');
+        expect(env.timers.map(timer => timer.ms)).toEqual([15_000]);
+        watch.stop();
+    });
+
+    it('終端応答で onTerminal を 1 回呼び、以後はタイマーも fetch も無い', async () => {
+        const terminal: TranscribeStatusResponse = { status: 'succeeded', docId: 'd1', stage: 'completed' };
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(terminal));
+        const env = createEnvironment();
+        const onTerminal = vi.fn();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment, onTerminal });
+        await waitForMode(watch, 'terminal');
+        expect(onTerminal).toHaveBeenCalledExactlyOnceWith(terminal);
+        expect(env.timers).toHaveLength(0);
+
+        expect(await watch.checkNow()).toEqual(terminal);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        watch.stop();
+    });
+
+    it('🔴 非表示なら確認せず、表示に戻ったら即時 1 回確認する。待機中に非表示になればタイマーを外す', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(running()));
+        const env = createEnvironment({ visible: false });
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment });
+        expect(watch.getSnapshot().mode).toBe('paused_hidden');
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        env.state.visible = true;
+        env.notify();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        await waitForMode(watch, 'waiting');
+        expect(env.timers).toHaveLength(1);
+
+        env.state.visible = false;
+        env.notify();
+        expect(watch.getSnapshot().mode).toBe('paused_hidden');
+        expect(env.timers).toHaveLength(0);
+
+        env.state.visible = true;
+        env.notify();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+        watch.stop();
+    });
+
+    it('オフラインなら確認を止め、回線復帰で即時 1 回確認する', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(running()));
+        const env = createEnvironment({ online: false });
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment });
+        expect(watch.getSnapshot().mode).toBe('paused_offline');
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        env.state.online = true;
+        env.notify();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        await waitForMode(watch, 'waiting');
+        watch.stop();
+    });
+
+    it('🔴 確認上限に達したら自動確認を止め（stopped_limit）、手動確認で時計を仕切り直して再開する', async () => {
+        let resolveFetch!: (response: Response) => void;
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+            () => new Promise<Response>(resolve => { resolveFetch = resolve; }));
+        const env = createEnvironment();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment, maxDurationMs: 1_000 });
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+        env.state.now += 5_000;
+        resolveFetch(jsonResponse(running()));
+        await waitForMode(watch, 'stopped_limit');
+        expect(env.timers).toHaveLength(0);
+        // 上限で止まっても最後の有効観測は残る（「最終確認時は文字起こし中」に使う）
+        expect(watch.getSnapshot().lastResponse).toEqual(running());
+
+        const manual = watch.checkNow();
+        expect(watch.getSnapshot().startedAtMs).toBe(env.state.now);
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+        resolveFetch(jsonResponse(running()));
+        await manual;
+        await waitForMode(watch, 'waiting');
+        expect(env.timers.map(timer => timer.ms)).toEqual([15_000]);
+        watch.stop();
+    });
+
+    it('stop() はタイマーと購読を解き、遅れて届いた応答で onChange/onTerminal を呼ばない', async () => {
+        let resolveFetch!: (response: Response) => void;
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+            () => new Promise<Response>(resolve => { resolveFetch = resolve; }));
+        const env = createEnvironment();
+        const onChange = vi.fn();
+        const onTerminal = vi.fn();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment, onChange, onTerminal });
+        expect(env.listenerCount()).toBe(1);
+        // 認証ヘッダの準備（遅延 import）を挟むので、fetch が実際に飛ぶまで待ってから止める
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+        watch.stop();
+        expect(watch.getSnapshot().mode).toBe('disposed');
+        expect(env.listenerCount()).toBe(0);
+        const changesAtStop = onChange.mock.calls.length;
+
+        resolveFetch(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        await vi.waitFor(() => expect(countInflightStatusRequests()).toBe(0));
+        expect(onChange).toHaveBeenCalledTimes(changesAtStop);
+        expect(onTerminal).not.toHaveBeenCalled();
+        expect(env.timers).toHaveLength(0);
+        expect(await watch.checkNow()).toBeNull();
     });
 });

--- a/src/hooks/batchTranscriptionClient.test.ts
+++ b/src/hooks/batchTranscriptionClient.test.ts
@@ -239,6 +239,99 @@ describe('pollBatchStatus', () => {
         expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
+    it.each([
+        { retryAfterSec: 20, expectedWaitMs: 20_000 },
+        { retryAfterSec: 0, expectedWaitMs: 0 },
+        { retryAfterSec: undefined, expectedWaitMs: 30_000 },
+    ])('429 の Retry-After $retryAfterSec 秒を待ち、指定が無ければバックオフする', async ({ retryAfterSec, expectedWaitMs }) => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ error: 'rate_limited', message: '混雑', retryAfterSec }, false, 429))
+            .mockResolvedValueOnce(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        const wait = vi.fn(noWait);
+
+        expect(await pollBatchStatus('j1', { docId: 'd1', wait })).toEqual({ status: 'succeeded', docId: 'd1' });
+        expect(wait).toHaveBeenCalledExactlyOnceWith(expectedWaitMs);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('502・503・回線断の連続失敗は 30→60→60 秒で再試行し、running の成功で失敗数を戻す', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502))
+            .mockResolvedValueOnce(jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 503))
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(jsonResponse({ status: 'running', docId: 'd1', stage: 'transcribing' }))
+            .mockResolvedValueOnce(jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502))
+            .mockResolvedValueOnce(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        const waits: number[] = [];
+        const onTick = vi.fn();
+
+        const result = await pollBatchStatus('j1', { docId: 'd1', wait: async ms => { waits.push(ms); }, onTick });
+
+        expect(result.status).toBe('succeeded');
+        expect(waits).toEqual([30_000, 60_000, 60_000, 15_000, 30_000]);
+        expect(fetchMock).toHaveBeenCalledTimes(6);
+        expect(onTick.mock.calls.map(([status]) => status.status)).toEqual(['running', 'succeeded']);
+    });
+
+    describe.each([401, 403, 404])('HTTP %s で確認を停止する', (httpStatus) => {
+        it('有効な応答が無ければ docId 付きの running を返し、再試行しない', async () => {
+            const fetchMock = vi.spyOn(globalThis, 'fetch')
+                .mockResolvedValueOnce(jsonResponse({ error: 'unavailable', message: '確認できません' }, false, httpStatus))
+                .mockResolvedValue(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+            const wait = vi.fn(noWait);
+            const onTick = vi.fn();
+
+            expect(await pollBatchStatus('j1', { docId: 'd1', wait, onTick })).toEqual({ status: 'running', docId: 'd1' });
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(wait).not.toHaveBeenCalled();
+            expect(onTick).not.toHaveBeenCalled();
+        });
+
+        it('最後の有効応答と onTick の観測を保持し、エラー後は再試行しない', async () => {
+            const lastStatus: TranscribeStatusResponse = { status: 'running', docId: 'd1', stage: 'transcribing' };
+            const fetchMock = vi.spyOn(globalThis, 'fetch')
+                .mockResolvedValueOnce(jsonResponse(lastStatus))
+                .mockResolvedValueOnce(jsonResponse({ error: 'unavailable', message: '確認できません' }, false, httpStatus))
+                .mockResolvedValue(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+            const wait = vi.fn(noWait);
+            const onTick = vi.fn();
+
+            expect(await pollBatchStatus('j1', { docId: 'd1', wait, onTick })).toBe(lastStatus);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(wait).toHaveBeenCalledExactlyOnceWith(15_000);
+            expect(onTick).toHaveBeenCalledExactlyOnceWith(lastStatus);
+        });
+    });
+
+    it('有効な応答が無いままバックオフ中に上限へ達したら、docId 付きの running を返す', async () => {
+        let now = 1_000_000;
+        vi.spyOn(Date, 'now').mockImplementation(() => now);
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502));
+        const waits: number[] = [];
+
+        const result = await pollBatchStatus('j1', {
+            docId: 'd1', timeoutMs: 20_000,
+            wait: async ms => { waits.push(ms); now += ms; },
+        });
+
+        expect(result).toEqual({ status: 'running', docId: 'd1' });
+        expect(waits).toEqual([30_000]);
+        expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(2);
+    });
+
+    it('バックオフ待機中の中止理由を投げ、次の問い合わせを送らない', async () => {
+        const controller = new AbortController();
+        const reason = new Error('aborted-during-backoff');
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502));
+        const wait = vi.fn(async () => { controller.abort(reason); });
+
+        await expect(pollBatchStatus('j1', { signal: controller.signal, wait })).rejects.toBe(reason);
+        expect(wait).toHaveBeenCalledExactlyOnceWith(30_000);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('🔴 一時エラーが続いてもタイムアウトまで諦めない', async () => {
         vi.spyOn(globalThis, 'fetch').mockResolvedValue(
             jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502));
@@ -279,6 +372,22 @@ describe('resumeBatchTranscription（提出済みジョブの確認再開）', (
             outcome: 'failed', success: false, jobId: 'j1', docId: 'd1', error: '音声が長すぎます',
         });
     });
+
+    it('403 で確認を止め、最後の観測を outcome:pending に渡す', async () => {
+        const lastStatus: TranscribeStatusResponse = { status: 'running', docId: 'd1', stage: 'importing' };
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse(lastStatus))
+            .mockResolvedValueOnce(jsonResponse({ error: 'forbidden', message: '確認できません' }, false, 403))
+            .mockResolvedValue(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        const onTick = vi.fn();
+
+        expect(await resumeBatchTranscription({ jobId: 'j1', docId: 'd1', pollIntervalMs: 1, onTick })).toEqual({
+            outcome: 'pending', success: false, pending: true, jobId: 'j1', docId: 'd1', lastStatus,
+        });
+        expect(onTick).toHaveBeenCalledExactlyOnceWith(lastStatus);
+        expect(statusRequestBodies(fetchMock)).toEqual([{ jobId: 'j1' }, { jobId: 'j1' }]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
 });
 
 describe('runBatchTranscription', () => {
@@ -310,6 +419,20 @@ describe('runBatchTranscription', () => {
         const onSubmitted = vi.fn();
         await runBatchTranscription({ ...input, onSubmitted });
         expect(onSubmitted).toHaveBeenCalledExactlyOnceWith({ jobId: 'j1', docId: 'd1' });
+    });
+
+    it('提出直後の 404 で outcome:pending を返し、再提出も再確認もしない', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(jsonResponse({ jobId: 'j1', docId: 'd1' }))
+            .mockResolvedValueOnce(jsonResponse({ error: 'media_not_found', message: '確認できません' }, false, 404))
+            .mockResolvedValue(jsonResponse({ status: 'succeeded', docId: 'd1' }));
+        const onSubmitted = vi.fn();
+
+        expect(await runBatchTranscription({ ...input, onSubmitted })).toEqual({
+            outcome: 'pending', success: false, pending: true, jobId: 'j1', docId: 'd1', lastStatus: null,
+        });
+        expect(onSubmitted).toHaveBeenCalledExactlyOnceWith({ jobId: 'j1', docId: 'd1' });
+        expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([TRANSCRIBE_SUBMIT_PATH, TRANSCRIBE_STATUS_PATH]);
     });
 
     it('🔴 確認上限の pending は失敗ではなく outcome:pending（最後の有効応答つき）で返す', async () => {
@@ -503,6 +626,49 @@ describe('startDocumentStatusWatch（選択中文書の継続確認・仕様 §A
         watch.stop();
     });
 
+    it.each(['manual', 'visible', 'online', 'timer'] as const)(
+        '429 の待機中は %s から確認しても再送せず、期限後に送信する', async (entrance) => {
+            const fetchMock = vi.spyOn(globalThis, 'fetch')
+                .mockResolvedValueOnce(jsonResponse({ error: 'rate_limited', message: '混雑', retryAfterSec: 20 }, false, 429))
+                .mockResolvedValue(jsonResponse(running()));
+            const env = createEnvironment();
+            const watch = startDocumentStatusWatch('d1', { environment: env.environment });
+            await waitForMode(watch, 'waiting');
+            expect(watch.getSnapshot().notBeforeMs).toBe(1_020_000);
+            expect(env.timers.map(timer => timer.ms)).toEqual([20_000]);
+
+            env.state.now += 5_000;
+            if (entrance === 'manual') {
+                await watch.checkNow();
+                await watch.checkNow();
+            } else if (entrance === 'timer') {
+                // タイマーの早期発火も同じ待機期限で防ぐ。
+                env.fireNext();
+            } else {
+                env.state[entrance] = false;
+                env.notify();
+                expect(watch.getSnapshot().mode).toBe(entrance === 'visible' ? 'paused_hidden' : 'paused_offline');
+                expect(env.timers).toHaveLength(0);
+                env.state[entrance] = true;
+                env.notify();
+            }
+
+            await waitForMode(watch, 'waiting');
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(env.timers.map(timer => timer.ms)).toEqual([15_000]);
+            expect(watch.getSnapshot()).toMatchObject({ notBeforeMs: 1_020_000, consecutiveFailures: 1 });
+
+            env.state.now += 15_000;
+            env.fireNext();
+            expect(watch.getSnapshot().notBeforeMs).toBeUndefined();
+            await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+            await waitForMode(watch, 'waiting');
+            expect(watch.getSnapshot()).toMatchObject({ lastError: null, consecutiveFailures: 0 });
+            expect(env.timers.map(timer => timer.ms)).toEqual([15_000]);
+            watch.stop();
+        },
+    );
+
     it.each([401, 403])('%s は自動確認を止め（stopped_auth）、タイマーを積まない', async (httpStatus) => {
         const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
             jsonResponse({ error: 'forbidden', message: '権限がありません' }, false, httpStatus));
@@ -606,6 +772,81 @@ describe('startDocumentStatusWatch（選択中文書の継続確認・仕様 §A
         resolveFetch(jsonResponse(running()));
         await manual;
         await waitForMode(watch, 'waiting');
+        expect(env.timers.map(timer => timer.ms)).toEqual([15_000]);
+        watch.stop();
+    });
+
+    it.each([
+        new TranscribeStatusError('一時エラー', { httpStatus: 502 }),
+        new TypeError('Failed to fetch'),
+    ])('失敗が続き上限を超えて戻った $name は stopped_limit にしてタイマーを残さない', async (failure) => {
+        let rejectFetch!: (reason: unknown) => void;
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockRejectedValueOnce(failure)
+            .mockImplementationOnce(() => new Promise<Response>((_resolve, reject) => { rejectFetch = reject; }));
+        const env = createEnvironment();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment, maxDurationMs: 40_000 });
+        await waitForMode(watch, 'waiting');
+        expect(env.timers.map(timer => timer.ms)).toEqual([30_000]);
+
+        env.state.now += 30_000;
+        env.fireNext();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+        env.state.now += 10_001;
+        rejectFetch(failure);
+
+        await waitForMode(watch, 'stopped_limit');
+        expect(watch.getSnapshot()).toMatchObject({ lastResponse: null, consecutiveFailures: 2 });
+        expect(env.timers).toHaveLength(0);
+        watch.stop();
+    });
+
+    it('失敗後のタイマーが上限を超えて発火しても再送せず stopped_limit にする', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            jsonResponse({ error: 'upstream_error', message: '一時エラー' }, false, 502));
+        const env = createEnvironment();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment, maxDurationMs: 40_000 });
+        await waitForMode(watch, 'waiting');
+        expect(env.timers.map(timer => timer.ms)).toEqual([30_000]);
+
+        env.state.now += 40_001;
+        env.fireNext();
+
+        await waitForMode(watch, 'stopped_limit');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(env.timers).toHaveLength(0);
+        watch.stop();
+    });
+
+    it('上限超過後の 429 は待機期限を保持し、手動再開で起点を戻しても Retry-After を守る', async () => {
+        let resolveFetch!: (response: Response) => void;
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockImplementationOnce(() => new Promise<Response>(resolve => { resolveFetch = resolve; }))
+            .mockResolvedValue(jsonResponse(running()));
+        const env = createEnvironment();
+        const watch = startDocumentStatusWatch('d1', { environment: env.environment, maxDurationMs: 30_000 });
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+        env.state.now += 40_000;
+        resolveFetch(jsonResponse({ error: 'rate_limited', message: '混雑', retryAfterSec: 20 }, false, 429));
+        await waitForMode(watch, 'stopped_limit');
+        expect(watch.getSnapshot()).toMatchObject({ startedAtMs: 1_000_000, notBeforeMs: 1_060_000 });
+        expect(env.timers).toHaveLength(0);
+
+        env.state.now += 5_000;
+        await watch.checkNow();
+        expect(watch.getSnapshot()).toMatchObject({
+            mode: 'waiting', startedAtMs: 1_045_000, notBeforeMs: 1_060_000,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(env.timers.map(timer => timer.ms)).toEqual([15_000]);
+
+        env.state.now += 15_000;
+        env.fireNext();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+        await waitForMode(watch, 'waiting');
+        expect(watch.getSnapshot().notBeforeMs).toBeUndefined();
+        expect(watch.getSnapshot().startedAtMs).toBe(1_045_000);
         expect(env.timers.map(timer => timer.ms)).toEqual([15_000]);
         watch.stop();
     });

--- a/src/hooks/batchTranscriptionClient.ts
+++ b/src/hooks/batchTranscriptionClient.ts
@@ -210,7 +210,8 @@ const defaultWait = (ms: number) => new Promise<void>((resolve) => setTimeout(re
  *    サーバ側は確定処理が途中で落ちても finalizing のリース切れ後に**次の poll で再確定**できる設計
  *    （commitTerminalOutcome）。ここで一度の失敗で抜けると、その回復経路に永遠に到達せず、
  *    文書が「処理中」のまま固まり、利用者が別ジョブを再提出して二重課金になる（再レビュー major）。
- *    だから状態確認の失敗は飲み込んで待ち、次の周回で再試行する。中止（abort）は即座に投げる。
+ *    一時障害は間隔を延ばして再試行し、429 は Retry-After を尊重する。
+ *    401/403/404 は確認待ちとして返す。中止（abort）はそのまま投げる。
  */
 export async function pollBatchStatus(jobId: string, options: PollOptions = {}): Promise<TranscribeStatusResponse> {
     const {
@@ -218,17 +219,29 @@ export async function pollBatchStatus(jobId: string, options: PollOptions = {}):
     } = options;
     const startedAt = Date.now();
     let lastStatus: TranscribeStatusResponse | null = null;
+    let consecutiveFailures = 0;
     for (;;) {
         if (signal?.aborted) throw abortReason(signal);
         let status: TranscribeStatusResponse | null = null;
+        let waitMs = intervalMs;
         try {
             status = await fetchBatchStatus(jobId, signal, docId);
         } catch (error) {
-            // 中止はそのまま伝える。それ以外（502・回線断）は一時障害として次の周回で再試行。
-            if (signal?.aborted) throw signal.reason ?? error;
-            status = null;
+            if (signal?.aborted) throw abortReason(signal);
+            const httpStatus = error instanceof TranscribeStatusError ? error.httpStatus : undefined;
+            if (httpStatus === 401 || httpStatus === 403 || httpStatus === 404) {
+                return lastStatus ?? { status: 'running', docId: docId ?? '' };
+            }
+            consecutiveFailures += 1;
+            const retryAfterMs = error instanceof TranscribeStatusError && httpStatus === 429
+                ? error.retryAfterMs
+                : undefined;
+            const backoffMs = STATUS_RETRY_INTERVALS_MS[Math.min(consecutiveFailures, STATUS_RETRY_INTERVALS_MS.length) - 1]
+                ?? intervalMs;
+            waitMs = retryAfterMs ?? backoffMs;
         }
         if (status) {
+            consecutiveFailures = 0;
             lastStatus = status;
             onTick?.(status);
             if (status.status !== 'running') return status;
@@ -237,7 +250,7 @@ export async function pollBatchStatus(jobId: string, options: PollOptions = {}):
             // ジョブは Azure 側で継続中。文書は「処理中」のまま残り、後で開けば確定できる。
             return lastStatus ?? { status: 'running', docId: docId ?? '' };
         }
-        await wait(intervalMs);
+        await wait(waitMs);
     }
 }
 
@@ -261,7 +274,7 @@ export interface RunBatchTranscriptionInput {
 
 /**
  * 提出→確認の結果。
- * 🔴 `pending` は失敗ではない（仕様 §A4）。確認の上限に達しただけで、ジョブはサーバ側で継続し、
+ * 🔴 `pending` は失敗ではない（仕様 §A4）。確認が停止してもジョブはサーバ側で継続し、
  *    文書は「処理中」で残る。呼出元はこれを赤い失敗として描かず、「確認待ち」として扱う。
  */
 export type RunBatchTranscriptionResult =
@@ -307,7 +320,7 @@ export async function resumeBatchTranscription(
     if (final.status === 'failed') {
         return { outcome: 'failed', success: false, jobId, docId, ...(final.error ? { error: final.error } : {}) };
     }
-    // running のまま上限に達した: 失敗ではない。文書は処理中で残る。
+    // running のまま確認が停止した: 失敗ではない。文書は処理中で残る。
     return { outcome: 'pending', success: false, pending: true, jobId, docId, lastStatus };
 }
 
@@ -494,6 +507,8 @@ export interface DocumentStatusWatchSnapshot {
     consecutiveFailures: number;
     /** 自動確認の起点（上限判定用） */
     startedAtMs: number;
+    /** Retry-After が指定した再送可能時刻（ms）。手動確認・環境復帰でもこの時刻まで待つ */
+    notBeforeMs?: number;
 }
 
 /** 可視性・回線・時計・タイマーの差し替え口（テストと、document の無い環境のため） */
@@ -519,7 +534,7 @@ export interface DocumentStatusWatchOptions {
 }
 
 export interface DocumentStatusWatch {
-    /** 手動「状態を確認」。実行中なら同じリクエストを返し、重複送信しない */
+    /** 手動「状態を確認」。実行中はリクエストを共有し、Retry-After の待機中は送信せず null を返す */
     checkNow: () => Promise<TranscribeStatusResponse | null>;
     /** 選択変更・画面離脱・owner 変更で呼ぶ。タイマーと購読を解き、以後 onChange を呼ばない */
     stop: () => void;
@@ -621,9 +636,19 @@ export function startDocumentStatusWatch(
         if (inflight) return inflight;
         if (snapshot.mode === 'terminal') return Promise.resolve(snapshot.lastResponse);
         clearTimer();
+        const now = env.now();
         // 上限で止まった後の手動確認は「同じジョブの確認を再開する」操作。上限の時計を仕切り直す。
-        const startedAtMs = manual && snapshot.mode === 'stopped_limit' ? env.now() : snapshot.startedAtMs;
-        publish({ mode: 'checking', startedAtMs });
+        const startedAtMs = manual && snapshot.mode === 'stopped_limit' ? now : snapshot.startedAtMs;
+        if (now - startedAtMs > maxDurationMs) {
+            publish({ mode: 'stopped_limit' });
+            return Promise.resolve(null);
+        }
+        snapshot = { ...snapshot, startedAtMs };
+        if (snapshot.notBeforeMs !== undefined && now < snapshot.notBeforeMs) {
+            schedule(snapshot.notBeforeMs - now);
+            return Promise.resolve(null);
+        }
+        publish({ mode: 'checking', notBeforeMs: undefined });
 
         const request = fetchStatusShared({ docId }, docId, controller.signal)
             .then((response): TranscribeStatusResponse | null => {
@@ -651,9 +676,14 @@ export function startDocumentStatusWatch(
                 if (disposed) return null;
                 const consecutiveFailures = snapshot.consecutiveFailures + 1;
                 const httpStatus = error instanceof TranscribeStatusError ? error.httpStatus : undefined;
+                const failedAtMs = env.now();
+                const retryAfterMs = error instanceof TranscribeStatusError && httpStatus === 429
+                    ? error.retryAfterMs
+                    : undefined;
                 snapshot = {
                     ...snapshot,
                     consecutiveFailures,
+                    notBeforeMs: retryAfterMs !== undefined ? failedAtMs + retryAfterMs : undefined,
                     lastError: {
                         message: describeStatusFailure(error),
                         ...(httpStatus !== undefined && { httpStatus }),
@@ -667,9 +697,10 @@ export function startDocumentStatusWatch(
                     publish({ mode: 'stopped_not_found' });
                     return null;
                 }
-                const retryAfterMs = error instanceof TranscribeStatusError && httpStatus === 429
-                    ? error.retryAfterMs
-                    : undefined;
+                if (failedAtMs - snapshot.startedAtMs > maxDurationMs) {
+                    publish({ mode: 'stopped_limit' });
+                    return null;
+                }
                 const backoffMs = retryIntervalsMs[Math.min(consecutiveFailures, retryIntervalsMs.length) - 1]
                     ?? intervalMs;
                 schedule(retryAfterMs ?? backoffMs);

--- a/src/hooks/batchTranscriptionClient.ts
+++ b/src/hooks/batchTranscriptionClient.ts
@@ -197,11 +197,35 @@ export interface PollOptions {
     onTick?: (status: TranscribeStatusResponse) => void;
     /** 分かっていれば渡す。同じ文書の他の確認と実行中リクエストを共有する */
     docId?: string;
-    /** テスト用: 待ちを差し替える */
-    wait?: (ms: number) => Promise<void>;
+    /** テスト用: 待ちを差し替える。signal は省略可（既存の注入は 1 引数のままでよい） */
+    wait?: (ms: number, signal?: AbortSignal) => Promise<void>;
 }
 
-const defaultWait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+/**
+ * バックオフ待ち。🔴 中止に即応する。
+ * 30→60 秒のバックオフ中に中止が来ても満了まで待つと、呼出側の停止待ち上限（30 秒）を超えて
+ * 強制破棄ダイアログに進み、ジョブ占有も解放されない（レビュー major）。中止時はタイマーとリスナーを
+ * 解放して中止理由で直ちに reject する。
+ */
+const defaultWait = (ms: number, signal?: AbortSignal): Promise<void> => new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+        reject(abortReason(signal));
+        return;
+    }
+    const cleanup = () => {
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', onAbort);
+    };
+    const onAbort = () => {
+        cleanup();
+        reject(abortReason(signal as AbortSignal));
+    };
+    const timer = setTimeout(() => {
+        cleanup();
+        resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+});
 
 /**
  * 終端（succeeded/failed）になるまでポーリングする。中止は例外を投げる。
@@ -250,7 +274,9 @@ export async function pollBatchStatus(jobId: string, options: PollOptions = {}):
             // ジョブは Azure 側で継続中。文書は「処理中」のまま残り、後で開けば確定できる。
             return lastStatus ?? { status: 'running', docId: docId ?? '' };
         }
-        await wait(waitMs);
+        // signal がある本番経路では中止に即応する（defaultWait が abort でタイマーを解放して reject）。
+        // signal 無し（テスト等）は従来どおり 1 引数で呼び、待ち差し替えの引数契約を保つ。
+        await (signal ? wait(waitMs, signal) : wait(waitMs));
     }
 }
 

--- a/src/hooks/batchTranscriptionClient.ts
+++ b/src/hooks/batchTranscriptionClient.ts
@@ -1,21 +1,32 @@
 /**
- * 非同期バッチ文字起こしのクライアント側（設計 §3.7 改訂・2026-09-05）。
+ * 非同期バッチ文字起こしのクライアント側（設計 §3.7 改訂・2026-09-05、進捗段階表示 仕様 §A・2026-09-05）。
  *
  * 流れ: 既にアップロード済みの音声パスで **提出** → **状態確認をポーリング** → 完了。
  * 🔴 文書はサーバが作って完成させる（タブ非依存）。クライアントは saveTranscription を呼ばない。
  * 🔴 認証は既存の生成 API と同じ形（firebase は遅延 import。モジュール先頭で読むと鍵の無い
  *    環境で Auth 初期化が落ちる）。未ログイン（ゲスト）はヘッダを付けない。
+ * 🔴 同一 docId の実行中 status リクエストは共有し、同じ画面内で二重 poll を作らない（仕様 §A2 手順3）。
+ *    状態確認は再提出ではない。このモジュールのどの確認経路も submit を呼ばない。
  */
 import { GENERATE_AUTH_HEADER } from '@/lib/generateApiContract';
 import {
     TRANSCRIBE_SUBMIT_PATH,
     TRANSCRIBE_STATUS_PATH,
+    type DocumentProcessingProgress,
+    type TranscribeProgressStage,
     type TranscribeSubmitRequest,
     type TranscribeSubmitResponse,
     type TranscribeStatusRequest,
     type TranscribeStatusResponse,
     type TranscribeBatchErrorBody,
 } from '@/lib/transcribeBatchContract';
+
+/** 状態確認の基本間隔（仕様 §A2 手順1・3。バッチは分単位なので細かく叩かない） */
+export const STATUS_POLL_INTERVAL_MS = 15_000;
+/** 自動確認の上限（仕様 §A2 手順5。超えても文書は「処理中」で残り、サーバ側の処理は継続する） */
+export const STATUS_POLL_TIMEOUT_MS = 90 * 60_000;
+/** HTTP 一時失敗時の間隔（仕様 §A2 手順4: 30 秒→60 秒。成功で基本間隔へ戻す） */
+export const STATUS_RETRY_INTERVALS_MS: readonly number[] = [30_000, 60_000];
 
 async function authHeaders(): Promise<Record<string, string>> {
     let token: string | null = null;
@@ -33,6 +44,42 @@ async function authHeaders(): Promise<Record<string, string>> {
 const messageFrom = (json: unknown, fallback: string): string => {
     const body = json as Partial<TranscribeBatchErrorBody> | null;
     return (body && typeof body.message === 'string' && body.message) || fallback;
+};
+
+/**
+ * 状態確認の HTTP 失敗。呼出元が 401/403/404/429 を区別して確認を止めたり間隔を延ばしたりできるよう、
+ * 文言だけでなく HTTP ステータスと Retry-After を持つ。
+ */
+export class TranscribeStatusError extends Error {
+    readonly httpStatus: number;
+    readonly code: string | undefined;
+    /** 429 などで指示された待ち時間（ms）。無ければ undefined */
+    readonly retryAfterMs: number | undefined;
+
+    constructor(
+        message: string,
+        details: { httpStatus: number; code?: string; retryAfterMs?: number },
+    ) {
+        super(message);
+        this.name = 'TranscribeStatusError';
+        this.httpStatus = details.httpStatus;
+        this.code = details.code;
+        this.retryAfterMs = details.retryAfterMs;
+    }
+}
+
+const parseRetryAfterMs = (response: Response, json: unknown): number | undefined => {
+    const body = json as Partial<TranscribeBatchErrorBody> | null;
+    if (body && typeof body.retryAfterSec === 'number' && Number.isFinite(body.retryAfterSec) && body.retryAfterSec >= 0) {
+        return Math.round(body.retryAfterSec * 1000);
+    }
+    // テストダブルは headers を持たないことがあるので、存在するときだけ読む。
+    const header = typeof response.headers?.get === 'function' ? response.headers.get('retry-after') : null;
+    if (!header) return undefined;
+    const seconds = Number(header);
+    if (Number.isFinite(seconds) && seconds >= 0) return Math.round(seconds * 1000);
+    const dateMs = Date.parse(header);
+    return Number.isFinite(dateMs) ? Math.max(0, dateMs - Date.now()) : undefined;
 };
 
 /** ジョブを提出。音声は既に Storage にある前提。短命に {jobId, docId} が返る。 */
@@ -53,29 +100,83 @@ export async function submitBatchTranscription(
     return json as TranscribeSubmitResponse;
 }
 
-async function fetchTranscriptionStatus(
-    request: TranscribeStatusRequest,
-    signal?: AbortSignal,
-): Promise<TranscribeStatusResponse> {
+async function fetchTranscriptionStatus(request: TranscribeStatusRequest): Promise<TranscribeStatusResponse> {
     const response = await fetch(TRANSCRIBE_STATUS_PATH, {
         method: 'POST',
         headers: await authHeaders(),
         body: JSON.stringify(request),
-        ...(signal ? { signal } : {}),
     });
     const json = await response.json().catch(() => null);
     if (!response.ok) {
-        throw new Error(messageFrom(json, `状態の確認に失敗しました (${response.status})`));
+        const body = json as Partial<TranscribeBatchErrorBody> | null;
+        throw new TranscribeStatusError(messageFrom(json, `状態の確認に失敗しました (${response.status})`), {
+            httpStatus: response.status,
+            ...(body && typeof body.error === 'string' ? { code: body.error } : {}),
+            ...(() => {
+                const retryAfterMs = parseRetryAfterMs(response, json);
+                return retryAfterMs !== undefined ? { retryAfterMs } : {};
+            })(),
+        });
     }
     return json as TranscribeStatusResponse;
 }
 
-/** ジョブの状態を 1 回問い合わせる。完了していればサーバがその場で文書を確定する。 */
+const abortReason = (signal: AbortSignal): unknown => signal.reason ?? new Error('中止しました');
+
+/**
+ * 共有リクエストを呼出元ごとの中止シグナルと競争させる。
+ * 🔴 fetch 自体には呼出元のシグナルを渡さない。渡すと、先に中止した 1 人のために、
+ *    同じ応答を待っている他の呼出元（一覧の再確定・詳細の継続確認）まで巻き添えで失敗する。
+ *    中止した側は結果を受け取らないだけで、リクエストはサーバ側で短命に完結する（冪等）。
+ */
+function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        if (signal.aborted) {
+            reject(abortReason(signal));
+            return;
+        }
+        const onAbort = () => reject(abortReason(signal));
+        signal.addEventListener('abort', onAbort, { once: true });
+        promise.then(
+            value => { signal.removeEventListener('abort', onAbort); resolve(value); },
+            error => { signal.removeEventListener('abort', onAbort); reject(error); },
+        );
+    });
+}
+
+/** 実行中の status リクエスト（共有キー = docId。jobId しか分からない経路は `job:` 接頭辞） */
+const inflightStatusRequests = new Map<string, Promise<TranscribeStatusResponse>>();
+
+function fetchStatusShared(
+    request: TranscribeStatusRequest,
+    shareKey: string,
+    signal?: AbortSignal,
+): Promise<TranscribeStatusResponse> {
+    if (signal?.aborted) return Promise.reject(abortReason(signal));
+    let inflight = inflightStatusRequests.get(shareKey);
+    if (!inflight) {
+        const started = fetchTranscriptionStatus(request).finally(() => {
+            if (inflightStatusRequests.get(shareKey) === started) inflightStatusRequests.delete(shareKey);
+        });
+        inflightStatusRequests.set(shareKey, started);
+        inflight = started;
+    }
+    return signal ? raceWithAbort(inflight, signal) : inflight;
+}
+
+/** テスト用: 共有中のリクエスト数（実装詳細。本番コードから参照しない） */
+export const countInflightStatusRequests = (): number => inflightStatusRequests.size;
+
+/**
+ * ジョブの状態を 1 回問い合わせる。完了していればサーバがその場で文書を確定する。
+ * docId が分かっていれば共有キーに使い、同じ文書の他の確認と実行中リクエストを共有する。
+ */
 export function fetchBatchStatus(
     jobId: string,
     signal?: AbortSignal,
+    docId?: string,
 ): Promise<TranscribeStatusResponse> {
-    return fetchTranscriptionStatus({ jobId }, signal);
+    return fetchStatusShared({ jobId }, docId ?? `job:${jobId}`, signal);
 }
 
 /** 文書を開いたときの 1 回限りの確認。running なら文書は変更せず、終端の保存はサーバが行う。 */
@@ -83,7 +184,7 @@ export function reconcileProcessingDocument(
     docId: string,
     signal?: AbortSignal,
 ): Promise<TranscribeStatusResponse> {
-    return fetchTranscriptionStatus({ docId }, signal);
+    return fetchStatusShared({ docId }, docId, signal);
 }
 
 export interface PollOptions {
@@ -94,6 +195,8 @@ export interface PollOptions {
     timeoutMs?: number;
     /** 毎回の状態を UI に伝える */
     onTick?: (status: TranscribeStatusResponse) => void;
+    /** 分かっていれば渡す。同じ文書の他の確認と実行中リクエストを共有する */
+    docId?: string;
     /** テスト用: 待ちを差し替える */
     wait?: (ms: number) => Promise<void>;
 }
@@ -110,25 +213,29 @@ const defaultWait = (ms: number) => new Promise<void>((resolve) => setTimeout(re
  *    だから状態確認の失敗は飲み込んで待ち、次の周回で再試行する。中止（abort）は即座に投げる。
  */
 export async function pollBatchStatus(jobId: string, options: PollOptions = {}): Promise<TranscribeStatusResponse> {
-    const { signal, intervalMs = 15_000, timeoutMs = 90 * 60_000, onTick, wait = defaultWait } = options;
+    const {
+        signal, intervalMs = STATUS_POLL_INTERVAL_MS, timeoutMs = STATUS_POLL_TIMEOUT_MS, onTick, docId, wait = defaultWait,
+    } = options;
     const startedAt = Date.now();
+    let lastStatus: TranscribeStatusResponse | null = null;
     for (;;) {
-        if (signal?.aborted) throw signal.reason ?? new Error('中止しました');
+        if (signal?.aborted) throw abortReason(signal);
         let status: TranscribeStatusResponse | null = null;
         try {
-            status = await fetchBatchStatus(jobId, signal);
+            status = await fetchBatchStatus(jobId, signal, docId);
         } catch (error) {
             // 中止はそのまま伝える。それ以外（502・回線断）は一時障害として次の周回で再試行。
             if (signal?.aborted) throw signal.reason ?? error;
             status = null;
         }
         if (status) {
+            lastStatus = status;
             onTick?.(status);
             if (status.status !== 'running') return status;
         }
         if (Date.now() - startedAt > timeoutMs) {
             // ジョブは Azure 側で継続中。文書は「処理中」のまま残り、後で開けば確定できる。
-            return status ?? { status: 'running', docId: '' };
+            return lastStatus ?? { status: 'running', docId: docId ?? '' };
         }
         await wait(intervalMs);
     }
@@ -144,22 +251,71 @@ export interface RunBatchTranscriptionInput {
     title?: string;
     signal?: AbortSignal;
     onTick?: (status: TranscribeStatusResponse) => void;
+    /**
+     * 提出が受け付けられた直後に {jobId, docId} を伝える（仕様 §A4）。
+     * 呼出元はこれを保持し、確認が止まった後の再開を**新規 submit ではなく同じ ID の確認**で行う。
+     */
+    onSubmitted?: (submitted: TranscribeSubmitResponse) => void;
     pollIntervalMs?: number;
 }
 
-export interface RunBatchTranscriptionResult {
-    success: boolean;
+/**
+ * 提出→確認の結果。
+ * 🔴 `pending` は失敗ではない（仕様 §A4）。確認の上限に達しただけで、ジョブはサーバ側で継続し、
+ *    文書は「処理中」で残る。呼出元はこれを赤い失敗として描かず、「確認待ち」として扱う。
+ */
+export type RunBatchTranscriptionResult =
+    | { outcome: 'succeeded'; success: true; jobId: string; docId: string }
+    | { outcome: 'failed'; success: false; jobId: string; docId: string; error?: string }
+    | {
+        outcome: 'pending';
+        success: false;
+        pending: true;
+        jobId: string;
+        docId: string;
+        /** 上限に達する前に受け取った最後の有効な応答（無ければ null） */
+        lastStatus: TranscribeStatusResponse | null;
+    };
+
+export interface AwaitBatchTranscriptionInput {
+    jobId: string;
     docId: string;
-    /** まだ処理中（ポーリング上限に達した）。文書は「処理中」のまま */
-    pending?: boolean;
-    error?: string;
+    signal?: AbortSignal;
+    onTick?: (status: TranscribeStatusResponse) => void;
+    pollIntervalMs?: number;
+}
+
+/**
+ * 既に提出済みのジョブの確認を（再）開する。**submit は呼ばない。**
+ * 確認停止・確認待ちからの再開はこの入口を使う（仕様 §A4「提出後の確認再開は保存した ID で行う」）。
+ */
+export async function resumeBatchTranscription(
+    input: AwaitBatchTranscriptionInput,
+): Promise<RunBatchTranscriptionResult> {
+    const { jobId, docId } = input;
+    let lastStatus: TranscribeStatusResponse | null = null;
+    const final = await pollBatchStatus(jobId, {
+        docId,
+        ...(input.signal ? { signal: input.signal } : {}),
+        ...(input.pollIntervalMs ? { intervalMs: input.pollIntervalMs } : {}),
+        onTick: (status) => {
+            lastStatus = status;
+            input.onTick?.(status);
+        },
+    });
+    if (final.status === 'succeeded') return { outcome: 'succeeded', success: true, jobId, docId };
+    if (final.status === 'failed') {
+        return { outcome: 'failed', success: false, jobId, docId, ...(final.error ? { error: final.error } : {}) };
+    }
+    // running のまま上限に達した: 失敗ではない。文書は処理中で残る。
+    return { outcome: 'pending', success: false, pending: true, jobId, docId, lastStatus };
 }
 
 /** 提出 → ポーリング → 結果。文書はサーバが保存済み。 */
 export async function runBatchTranscription(
     input: RunBatchTranscriptionInput,
 ): Promise<RunBatchTranscriptionResult> {
-    const { jobId, docId } = await submitBatchTranscription(
+    const submitted = await submitBatchTranscription(
         {
             storagePath: input.storagePath,
             fileName: input.fileName,
@@ -171,13 +327,388 @@ export async function runBatchTranscription(
         },
         input.signal,
     );
-    const final = await pollBatchStatus(jobId, {
+    input.onSubmitted?.(submitted);
+    return resumeBatchTranscription({
+        jobId: submitted.jobId,
+        docId: submitted.docId,
         ...(input.signal ? { signal: input.signal } : {}),
-        ...(input.pollIntervalMs ? { intervalMs: input.pollIntervalMs } : {}),
         ...(input.onTick ? { onTick: input.onTick } : {}),
+        ...(input.pollIntervalMs ? { pollIntervalMs: input.pollIntervalMs } : {}),
     });
-    if (final.status === 'succeeded') return { success: true, docId };
-    if (final.status === 'failed') return { success: false, docId, ...(final.error ? { error: final.error } : {}) };
-    // running のまま上限に達した: 失敗ではない。文書は処理中で残る。
-    return { success: false, docId, pending: true };
+}
+
+// ---------------------------------------------------------------------------------------------
+// 表示段階（仕様 §A1）。一覧・詳細・処理欄が同じ文言を使うため、ここに 1 か所で持つ。
+// 🔴 進捗パーセントは無い（Azure が返さない）。段階のみ。
+// ---------------------------------------------------------------------------------------------
+
+export const PROGRESS_STAGE_LABELS: Record<TranscribeProgressStage, string> = {
+    checking: '受付済み・状態を確認しています',
+    queued: '開始待ち',
+    transcribing: '文字起こし中',
+    importing: '結果を文書に取り込んでいます',
+    completed: '完了',
+    failed: '文字起こしに失敗しました',
+};
+
+const PROGRESS_STAGE_DETAIL_LABELS: Partial<Record<TranscribeProgressStage, string>> = {
+    queued: '文字起こしの開始を待っています',
+};
+
+/** 段階の主文言。`detail` は詳細画面向けの言い換え（開始待ち→文字起こしの開始を待っています） */
+export function describeProgressStage(
+    stage: TranscribeProgressStage,
+    variant: 'list' | 'detail' = 'list',
+): string {
+    return (variant === 'detail' && PROGRESS_STAGE_DETAIL_LABELS[stage]) || PROGRESS_STAGE_LABELS[stage];
+}
+
+/** 旧サーバの応答（stage 欠落）でも公開 3 値から終端だけは導く。running で stage が無ければ不明 */
+export function stageFromStatusResponse(response: TranscribeStatusResponse): TranscribeProgressStage | undefined {
+    if (response.stage) return response.stage;
+    if (response.status === 'succeeded') return 'completed';
+    if (response.status === 'failed') return 'failed';
+    return undefined;
+}
+
+export const isTerminalProgressStage = (stage: TranscribeProgressStage | undefined): boolean =>
+    stage === 'completed' || stage === 'failed';
+
+/** 一覧・詳細が描く「観測」。status 応答と文書投影のどちら由来かを持つ */
+export interface ProgressObservation {
+    stage: TranscribeProgressStage;
+    /** その段階を観測したサーバ時刻（ms）。不明なら undefined（checking など） */
+    observedAtMs?: number;
+    /** 受付（ジョブ作成）時刻の近似（ms） */
+    jobCreatedAtMs?: number;
+    source: 'status' | 'projection';
+}
+
+export function observationFromProjection(
+    progress: DocumentProcessingProgress | undefined | null,
+): ProgressObservation | null {
+    if (!progress) return null;
+    return {
+        stage: progress.stage,
+        ...(progress.stageObservedAtMs !== undefined && { observedAtMs: progress.stageObservedAtMs }),
+        ...(progress.jobCreatedAtMs !== undefined && { jobCreatedAtMs: progress.jobCreatedAtMs }),
+        source: 'projection',
+    };
+}
+
+export function observationFromStatus(
+    response: TranscribeStatusResponse | null | undefined,
+): ProgressObservation | null {
+    if (!response) return null;
+    const stage = stageFromStatusResponse(response);
+    if (!stage) return null;
+    return {
+        stage,
+        ...(response.azureStatusCheckedAtMs !== undefined && { observedAtMs: response.azureStatusCheckedAtMs }),
+        ...(response.createdAtMs !== undefined && { jobCreatedAtMs: response.createdAtMs }),
+        source: 'status',
+    };
+}
+
+/**
+ * API 応答と文書投影が前後して届いたときの採用規則（仕様 §A3）:
+ * 終端を最優先し、非終端では観測時刻が新しい段階を採用する。時刻が無ければ生きている応答を優先する。
+ */
+export function resolveProgressObservation(
+    projection: DocumentProcessingProgress | undefined | null,
+    response: TranscribeStatusResponse | null | undefined,
+): ProgressObservation | null {
+    const fromStatus = observationFromStatus(response);
+    const fromProjection = observationFromProjection(projection);
+    if (!fromStatus) return fromProjection;
+    if (!fromProjection) return fromStatus;
+    if (isTerminalProgressStage(fromStatus.stage)) return fromStatus;
+    if (isTerminalProgressStage(fromProjection.stage)) return fromProjection;
+    if (fromStatus.observedAtMs === undefined || fromProjection.observedAtMs === undefined) return fromStatus;
+    return fromProjection.observedAtMs > fromStatus.observedAtMs ? fromProjection : fromStatus;
+}
+
+/** 受付からの経過を分単位の日本語で。秒・パーセントは出さない（仕様 §A1） */
+export function describeElapsed(elapsedMs: number): string {
+    if (!Number.isFinite(elapsedMs) || elapsedMs < 60_000) return '1分未満';
+    const totalMinutes = Math.floor(elapsedMs / 60_000);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (hours === 0) return `${minutes}分`;
+    return minutes === 0 ? `${hours}時間` : `${hours}時間${minutes}分`;
+}
+
+export function formatClockTime(ms: number): string {
+    return new Intl.DateTimeFormat('ja-JP', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+        .format(new Date(ms));
+}
+
+/**
+ * 応答の serverNowMs を使い、端末時計のずれを抑えた「サーバ現在時刻の推定」を返す（仕様 §A1）。
+ * serverNowMs が無い旧応答では受信時刻を基準にする。
+ */
+export function estimateServerNowMs(
+    response: TranscribeStatusResponse | null | undefined,
+    receivedAtMs: number | null | undefined,
+    localNowMs: number,
+): number {
+    if (response?.serverNowMs !== undefined && receivedAtMs != null) {
+        return response.serverNowMs + Math.max(0, localNowMs - receivedAtMs);
+    }
+    return localNowMs;
+}
+
+// ---------------------------------------------------------------------------------------------
+// 選択中の処理中文書 1 件の継続確認（仕様 §A2 手順3〜5）。
+// ---------------------------------------------------------------------------------------------
+
+export type DocumentStatusWatchMode =
+    /** リクエスト実行中 */
+    | 'checking'
+    /** 次の自動確認を待っている */
+    | 'waiting'
+    /** 画面が非表示なので自動確認を止めている（表示に戻ると即時 1 回確認） */
+    | 'paused_hidden'
+    /** オフラインなので自動確認を止めている（回線復帰で即時 1 回確認） */
+    | 'paused_offline'
+    /** 確認上限（90 分）に達して自動確認を停止。手動確認で再開できる */
+    | 'stopped_limit'
+    /** 401/403: 権限・認証の問題。自動確認を停止 */
+    | 'stopped_auth'
+    /** 404: 文書またはジョブを確認できない。自動確認を停止し、再提出しない */
+    | 'stopped_not_found'
+    /** 終端応答（succeeded/failed）を受け取った。以後の確認は不要 */
+    | 'terminal'
+    /** stop() 済み */
+    | 'disposed';
+
+export interface DocumentStatusWatchSnapshot {
+    docId: string;
+    mode: DocumentStatusWatchMode;
+    /** 最後に受け取った有効な status 応答（終端含む）。通信失敗では更新しない */
+    lastResponse: TranscribeStatusResponse | null;
+    /** その応答をローカルで受信した時刻（ms）。Azure 観測時刻（azureStatusCheckedAtMs）とは別物 */
+    lastResponseAtMs: number | null;
+    /** 直近の確認失敗。成功で null に戻る */
+    lastError: { message: string; httpStatus?: number } | null;
+    consecutiveFailures: number;
+    /** 自動確認の起点（上限判定用） */
+    startedAtMs: number;
+}
+
+/** 可視性・回線・時計・タイマーの差し替え口（テストと、document の無い環境のため） */
+export interface DocumentStatusWatchEnvironment {
+    isVisible?: () => boolean;
+    isOnline?: () => boolean;
+    /** 可視性・回線の変化を購読し、解除関数を返す */
+    subscribe?: (onChange: () => void) => () => void;
+    now?: () => number;
+    setTimer?: (callback: () => void, ms: number) => unknown;
+    clearTimer?: (handle: unknown) => void;
+}
+
+export interface DocumentStatusWatchOptions {
+    intervalMs?: number;
+    retryIntervalsMs?: readonly number[];
+    maxDurationMs?: number;
+    /** 状態が変わるたびに最新のスナップショットを渡す（stop() 後は呼ばない） */
+    onChange?: (snapshot: DocumentStatusWatchSnapshot) => void;
+    /** 終端応答を受け取ったとき 1 回。呼出元は最新文書を取り直す */
+    onTerminal?: (response: TranscribeStatusResponse) => void;
+    environment?: DocumentStatusWatchEnvironment;
+}
+
+export interface DocumentStatusWatch {
+    /** 手動「状態を確認」。実行中なら同じリクエストを返し、重複送信しない */
+    checkNow: () => Promise<TranscribeStatusResponse | null>;
+    /** 選択変更・画面離脱・owner 変更で呼ぶ。タイマーと購読を解き、以後 onChange を呼ばない */
+    stop: () => void;
+    getSnapshot: () => DocumentStatusWatchSnapshot;
+}
+
+const defaultWatchEnvironment: Required<DocumentStatusWatchEnvironment> = {
+    isVisible: () => typeof document === 'undefined' || !document.hidden,
+    isOnline: () => typeof navigator === 'undefined' || navigator.onLine !== false,
+    subscribe: (onChange) => {
+        if (typeof document === 'undefined' || typeof window === 'undefined') return () => undefined;
+        document.addEventListener('visibilitychange', onChange);
+        window.addEventListener('online', onChange);
+        window.addEventListener('offline', onChange);
+        return () => {
+            document.removeEventListener('visibilitychange', onChange);
+            window.removeEventListener('online', onChange);
+            window.removeEventListener('offline', onChange);
+        };
+    },
+    now: () => Date.now(),
+    setTimer: (callback, ms) => setTimeout(callback, ms),
+    clearTimer: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+const describeStatusFailure = (error: unknown): string => {
+    if (error instanceof TranscribeStatusError) return error.message;
+    if (error instanceof TypeError) return '通信に失敗しました。';
+    if (error instanceof Error && error.message) return error.message;
+    return '状態を確認できませんでした。';
+};
+
+/**
+ * 選択中の processing 文書 1 件を、表示中・オンラインの間 15 秒間隔で確認し続ける。
+ *
+ * - リクエスト完了後に次のタイマーを設定し、同じジョブの呼び出しを積み重ねない。
+ * - 手動確認も同じ経路。実行中は重複送信できない。
+ * - HTTP 一時失敗は 30→60 秒へ延ばし、成功で基本間隔へ戻す。429 は Retry-After を尊重する。
+ * - 401/403/404 は自動確認を止める。勝手に再提出しない（このモジュールは submit を持たない）。
+ * - 非表示・オフラインで止め、復帰時に即時 1 回確認する。終端・90 分上限で止める。
+ * 🔴 通信失敗は処理段階でもジョブ失敗でもない。lastResponse は成功時だけ更新し、鮮度と失敗を区別する。
+ */
+export function startDocumentStatusWatch(
+    docId: string,
+    options: DocumentStatusWatchOptions = {},
+): DocumentStatusWatch {
+    const {
+        intervalMs = STATUS_POLL_INTERVAL_MS,
+        retryIntervalsMs = STATUS_RETRY_INTERVALS_MS,
+        maxDurationMs = STATUS_POLL_TIMEOUT_MS,
+        onChange,
+        onTerminal,
+    } = options;
+    const env: Required<DocumentStatusWatchEnvironment> = { ...defaultWatchEnvironment, ...options.environment };
+
+    let snapshot: DocumentStatusWatchSnapshot = {
+        docId,
+        mode: 'waiting',
+        lastResponse: null,
+        lastResponseAtMs: null,
+        lastError: null,
+        consecutiveFailures: 0,
+        startedAtMs: env.now(),
+    };
+    let timer: unknown = null;
+    let inflight: Promise<TranscribeStatusResponse | null> | null = null;
+    let disposed = false;
+    const controller = new AbortController();
+
+    const publish = (patch: Partial<DocumentStatusWatchSnapshot>): void => {
+        snapshot = { ...snapshot, ...patch };
+        if (!disposed) onChange?.(snapshot);
+    };
+    const clearTimer = (): void => {
+        if (timer === null) return;
+        env.clearTimer(timer);
+        timer = null;
+    };
+    const pausedMode = (): 'paused_hidden' | 'paused_offline' | null =>
+        !env.isVisible() ? 'paused_hidden' : !env.isOnline() ? 'paused_offline' : null;
+
+    const schedule = (ms: number): void => {
+        clearTimer();
+        if (disposed) return;
+        const paused = pausedMode();
+        if (paused) {
+            publish({ mode: paused });
+            return;
+        }
+        publish({ mode: 'waiting' });
+        timer = env.setTimer(() => {
+            timer = null;
+            void runCheck(false);
+        }, ms);
+    };
+
+    const runCheck = (manual: boolean): Promise<TranscribeStatusResponse | null> => {
+        if (disposed) return Promise.resolve(null);
+        if (inflight) return inflight;
+        if (snapshot.mode === 'terminal') return Promise.resolve(snapshot.lastResponse);
+        clearTimer();
+        // 上限で止まった後の手動確認は「同じジョブの確認を再開する」操作。上限の時計を仕切り直す。
+        const startedAtMs = manual && snapshot.mode === 'stopped_limit' ? env.now() : snapshot.startedAtMs;
+        publish({ mode: 'checking', startedAtMs });
+
+        const request = fetchStatusShared({ docId }, docId, controller.signal)
+            .then((response): TranscribeStatusResponse | null => {
+                if (disposed) return null;
+                const receivedAtMs = env.now();
+                snapshot = {
+                    ...snapshot,
+                    lastResponse: response,
+                    lastResponseAtMs: receivedAtMs,
+                    lastError: null,
+                    consecutiveFailures: 0,
+                };
+                if (response.status !== 'running') {
+                    publish({ mode: 'terminal' });
+                    onTerminal?.(response);
+                    return response;
+                }
+                if (receivedAtMs - snapshot.startedAtMs > maxDurationMs) {
+                    publish({ mode: 'stopped_limit' });
+                    return response;
+                }
+                schedule(intervalMs);
+                return response;
+            }, (error: unknown): null => {
+                if (disposed) return null;
+                const consecutiveFailures = snapshot.consecutiveFailures + 1;
+                const httpStatus = error instanceof TranscribeStatusError ? error.httpStatus : undefined;
+                snapshot = {
+                    ...snapshot,
+                    consecutiveFailures,
+                    lastError: {
+                        message: describeStatusFailure(error),
+                        ...(httpStatus !== undefined && { httpStatus }),
+                    },
+                };
+                if (httpStatus === 401 || httpStatus === 403) {
+                    publish({ mode: 'stopped_auth' });
+                    return null;
+                }
+                if (httpStatus === 404) {
+                    publish({ mode: 'stopped_not_found' });
+                    return null;
+                }
+                const retryAfterMs = error instanceof TranscribeStatusError && httpStatus === 429
+                    ? error.retryAfterMs
+                    : undefined;
+                const backoffMs = retryIntervalsMs[Math.min(consecutiveFailures, retryIntervalsMs.length) - 1]
+                    ?? intervalMs;
+                schedule(retryAfterMs ?? backoffMs);
+                return null;
+            })
+            .finally(() => {
+                if (inflight === request) inflight = null;
+            });
+        inflight = request;
+        return request;
+    };
+
+    const handleEnvironmentChange = (): void => {
+        if (disposed) return;
+        const paused = pausedMode();
+        if (paused) {
+            clearTimer();
+            if (snapshot.mode === 'waiting' || snapshot.mode === 'checking') publish({ mode: paused });
+            return;
+        }
+        // 表示・回線の復帰: 対象は呼出元が再検証済み（選択が変われば stop される）。即時に 1 回確認する。
+        if (snapshot.mode === 'paused_hidden' || snapshot.mode === 'paused_offline') void runCheck(false);
+    };
+    const unsubscribe = env.subscribe(handleEnvironmentChange);
+
+    const pausedAtStart = pausedMode();
+    if (pausedAtStart) publish({ mode: pausedAtStart });
+    else void runCheck(false);
+
+    return {
+        checkNow: () => runCheck(true),
+        stop: () => {
+            if (disposed) return;
+            disposed = true;
+            clearTimer();
+            unsubscribe();
+            controller.abort(new Error('状態確認を停止しました'));
+            snapshot = { ...snapshot, mode: 'disposed' };
+        },
+        getSnapshot: () => snapshot,
+    };
 }

--- a/src/hooks/useVideoProcessing.test.ts
+++ b/src/hooks/useVideoProcessing.test.ts
@@ -17,6 +17,18 @@ const serviceMocks = vi.hoisted(() => ({
     validatePromptPermission: vi.fn(),
 }));
 
+// 全文文字起こし（バッチ）の提出・確認再開だけを差し替える。段階のヘルパは実物を使う。
+const batchMocks = vi.hoisted(() => ({
+    runBatchTranscription: vi.fn(),
+    resumeBatchTranscription: vi.fn(),
+}));
+
+vi.mock('@/hooks/batchTranscriptionClient', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/hooks/batchTranscriptionClient')>()),
+    runBatchTranscription: batchMocks.runBatchTranscription,
+    resumeBatchTranscription: batchMocks.resumeBatchTranscription,
+}));
+
 vi.mock('react', () => ({
     useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback,
     useEffect: () => undefined,
@@ -74,6 +86,8 @@ import {
     resolveSavePendingPromptIds,
     useVideoProcessing,
 } from './useVideoProcessing';
+import { TRANSCRIPT_PROMPT_ID } from '@/lib/transcriptPrompt';
+import type { RunBatchTranscriptionInput, RunBatchTranscriptionResult } from './batchTranscriptionClient';
 
 const FILE_ID = 'file-1';
 
@@ -1091,5 +1105,133 @@ describe('useVideoProcessing サーバ経由の文書生成 (#4)', () => {
         expect(serviceMocks.generateDocument).not.toHaveBeenCalled();
         expect(getCurrentStatus()).toMatchObject({ status: 'error', failedPhase: 'text_generation' });
         expect(getCurrentStatus().error).toContain('[デバッグ]');
+    });
+});
+
+describe('useVideoProcessing 全文文字起こし（バッチ）の確認待ちと再開（仕様 §A4）', () => {
+    const transcriptPrompt = createPrompt(TRANSCRIPT_PROMPT_ID, '全文文字起こし');
+    const audioBlob = new Blob(['audio'], { type: 'audio/mpeg' });
+    const submitted = { jobId: 'job-1', docId: 'doc-1' };
+    const pendingResult: RunBatchTranscriptionResult = {
+        outcome: 'pending', success: false, pending: true, ...submitted, lastStatus: null,
+    };
+    const succeededResult: RunBatchTranscriptionResult = { outcome: 'succeeded', success: true, ...submitted };
+
+    beforeEach(() => {
+        batchMocks.runBatchTranscription.mockReset();
+        batchMocks.resumeBatchTranscription.mockReset();
+    });
+
+    it('🔴 確認上限の pending は赤い失敗にせず「確認待ち」にし、段階と ID を処理欄へ残す', async () => {
+        batchMocks.runBatchTranscription.mockImplementation(async (input: RunBatchTranscriptionInput) => {
+            input.onSubmitted?.(submitted);
+            input.onTick?.({ status: 'running', docId: 'doc-1', stage: 'queued' });
+            input.onTick?.({ status: 'running', docId: 'doc-1', stage: 'transcribing', azureStatusCheckedAtMs: 1_700_000_000_000 });
+            return pendingResult;
+        });
+        const hook = useProcessingHarness([transcriptPrompt]);
+
+        await hook.processTranscription(createJob(createFile([TRANSCRIPT_PROMPT_ID])), audioBlob, '192k', 44100);
+
+        const status = getCurrentStatus();
+        expect(status.status).toBe('pending_confirmation');
+        expect(status.phase).toBe('awaiting_confirmation');
+        expect(status.error).toBeUndefined();
+        expect(status.failedPhase).toBeUndefined();
+        expect(status.promptStates[TRANSCRIPT_PROMPT_ID]).toBe('awaiting_confirmation');
+        expect(status.batch).toMatchObject({
+            jobId: 'job-1', docId: 'doc-1', promptId: TRANSCRIPT_PROMPT_ID,
+            stage: 'transcribing', observedAtMs: 1_700_000_000_000, confirmation: 'pending',
+        });
+        expect(status.completedPromptIds).toEqual([]);
+        expect(serviceMocks.saveTranscription).not.toHaveBeenCalled();
+    });
+
+    it('🔴 確認待ちからの再開は保存した ID で確認を再開し、submit も音声の再アップロードもしない', async () => {
+        batchMocks.runBatchTranscription.mockImplementation(async (input: RunBatchTranscriptionInput) => {
+            input.onSubmitted?.(submitted);
+            return pendingResult;
+        });
+        batchMocks.resumeBatchTranscription.mockResolvedValue(succeededResult);
+        const hook = useProcessingHarness([transcriptPrompt]);
+        const file = createFile([TRANSCRIPT_PROMPT_ID]);
+
+        await hook.processTranscription(createJob(file), audioBlob, '192k', 44100);
+        expect(getCurrentStatus().status).toBe('pending_confirmation');
+        expect(serviceMocks.uploadAudioToStorage).toHaveBeenCalledTimes(1);
+
+        await hook.processTranscriptionResume(createJob(file), audioBlob, [], '192k', 44100);
+
+        expect(batchMocks.runBatchTranscription).toHaveBeenCalledTimes(1);
+        expect(serviceMocks.uploadAudioToStorage).toHaveBeenCalledTimes(1);
+        expect(batchMocks.resumeBatchTranscription).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({ jobId: 'job-1', docId: 'doc-1', signal: expect.any(AbortSignal) }),
+        );
+        expect(getCurrentStatus()).toMatchObject({
+            status: 'completed',
+            transcriptionCount: 1,
+            completedPromptIds: [TRANSCRIPT_PROMPT_ID],
+        });
+        expect(getCurrentStatus().batch).toMatchObject({ jobId: 'job-1', stage: 'completed', confirmation: 'done' });
+    });
+
+    it('提出後の中止は「この画面での確認の停止」として ID と段階を残し、再開でも submit しない', async () => {
+        batchMocks.runBatchTranscription.mockImplementation((input: RunBatchTranscriptionInput) => {
+            input.onSubmitted?.(submitted);
+            input.onTick?.({ status: 'running', docId: 'doc-1', stage: 'transcribing' });
+            return new Promise<RunBatchTranscriptionResult>((_resolve, reject) => {
+                input.signal?.addEventListener('abort', () => reject(input.signal?.reason), { once: true });
+            });
+        });
+        const hook = useProcessingHarness([transcriptPrompt]);
+        const file = createFile([TRANSCRIPT_PROMPT_ID]);
+
+        const processing = hook.processTranscription(createJob(file), audioBlob, '192k', 44100);
+        await vi.waitFor(() => expect(batchMocks.runBatchTranscription).toHaveBeenCalledTimes(1));
+        hook.cancelJob(FILE_ID, 'この画面での確認を停止しました。');
+        await processing;
+
+        expect(getCurrentStatus()).toMatchObject({ status: 'canceled', phase: 'canceled' });
+        expect(getCurrentStatus().batch).toMatchObject({ jobId: 'job-1', stage: 'transcribing', confirmation: 'stopped' });
+
+        batchMocks.resumeBatchTranscription.mockResolvedValue(succeededResult);
+        await hook.processTranscriptionResume(createJob(file), audioBlob, [], '192k', 44100);
+
+        expect(batchMocks.runBatchTranscription).toHaveBeenCalledTimes(1);
+        expect(batchMocks.resumeBatchTranscription).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({ jobId: 'job-1', docId: 'doc-1' }),
+        );
+        expect(getCurrentStatus().status).toBe('completed');
+    });
+
+    it('サーバが失敗を確定した場合はこれまでどおり理由つきの失敗にする', async () => {
+        batchMocks.runBatchTranscription.mockImplementation(async (input: RunBatchTranscriptionInput) => {
+            input.onSubmitted?.(submitted);
+            return { outcome: 'failed', success: false, ...submitted, error: '音声が長すぎます' };
+        });
+        const hook = useProcessingHarness([transcriptPrompt]);
+
+        await hook.processTranscription(createJob(createFile([TRANSCRIPT_PROMPT_ID])), audioBlob, '192k', 44100);
+
+        expect(getCurrentStatus()).toMatchObject({ status: 'error', failedPhase: 'text_generation' });
+        expect(getCurrentStatus().error).toContain('音声が長すぎます');
+    });
+
+    it('成功時は batch を完了で閉じ、再開しても submit も確認再開も呼ばない（冪等）', async () => {
+        batchMocks.runBatchTranscription.mockImplementation(async (input: RunBatchTranscriptionInput) => {
+            input.onSubmitted?.(submitted);
+            input.onTick?.({ status: 'succeeded', docId: 'doc-1', stage: 'completed' });
+            return succeededResult;
+        });
+        const hook = useProcessingHarness([transcriptPrompt]);
+        const file = createFile([TRANSCRIPT_PROMPT_ID]);
+
+        await hook.processTranscription(createJob(file), audioBlob, '192k', 44100);
+        expect(getCurrentStatus()).toMatchObject({ status: 'completed', transcriptionCount: 1 });
+        expect(getCurrentStatus().batch).toMatchObject({ stage: 'completed', confirmation: 'done' });
+
+        await hook.processTranscriptionResume(createJob(file), audioBlob, [TRANSCRIPT_PROMPT_ID], '192k', 44100);
+        expect(batchMocks.runBatchTranscription).toHaveBeenCalledTimes(1);
+        expect(batchMocks.resumeBatchTranscription).not.toHaveBeenCalled();
     });
 });

--- a/src/hooks/useVideoProcessing.ts
+++ b/src/hooks/useVideoProcessing.ts
@@ -5,6 +5,7 @@ import { saveTranscription } from '@/lib/firestore';
 import { uploadAudioToStorage } from '@/lib/storage';
 import { GENERATE_MAX_MEDIA_BYTES } from '@/lib/generateApiContract';
 import {
+    BatchTranscriptionProgress,
     FileProcessingStatus,
     FileWithPrompts,
     DebugErrorMode,
@@ -14,7 +15,13 @@ import {
 } from '@/types/processing';
 import { Prompt } from '@/lib/prompts';
 import { isTranscriptPrompt } from '@/lib/transcriptPrompt';
-import { runBatchTranscription } from '@/hooks/batchTranscriptionClient';
+import {
+    resumeBatchTranscription,
+    runBatchTranscription,
+    stageFromStatusResponse,
+    type RunBatchTranscriptionResult,
+} from '@/hooks/batchTranscriptionClient';
+import type { TranscribeStatusResponse } from '@/lib/transcribeBatchContract';
 import { validatePromptPermission } from '@/lib/promptPermissions';
 import { getCurrentUserId } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
@@ -198,6 +205,10 @@ export const useVideoProcessing = (
     const savedKeysRef = useRef<Set<string>>(new Set());
     // 生成済みで保存だけが残っている下書き。保存のみの再試行に使う
     const draftsRef = useRef<Map<string, GeneratedDraft>>(new Map());
+    // 提出済みの全文文字起こしジョブ {jobId, docId}（(fileId, promptId) 単位）。
+    // 🔴 確認停止・確認待ちからの「再開」は新規 submit ではなく、この ID の確認再開で行う（仕様 §A4）。
+    //    完了の確定で消す。ここに無い＝まだ提出していない、だけが submit の条件
+    const batchJobsRef = useRef<Map<string, { jobId: string; docId: string }>>(new Map());
 
     const updateStatus = useCallback((
         fileId: string,
@@ -288,6 +299,7 @@ export const useVideoProcessing = (
     const clearProcessingState = useCallback(() => {
         savedKeysRef.current.clear();
         draftsRef.current.clear();
+        batchJobsRef.current.clear();
         setProcessingStatuses([]);
         setIsProcessing(false);
         setIsCanceling(false);
@@ -329,7 +341,7 @@ export const useVideoProcessing = (
     /** 待機中のまま中止されたファイルなど、ジョブ本体を通らない経路から終端状態を書く */
     const markJobCanceled = useCallback((fileId: string, message: string) => {
         updateStatus(fileId, status => (
-            status.status === 'completed' || status.status === 'error'
+            status.status === 'completed' || status.status === 'error' || status.status === 'pending_confirmation'
                 ? status
                 : {
                     ...withPromptStates(status, cancelPromptStates(status.promptStates)),
@@ -400,6 +412,8 @@ export const useVideoProcessing = (
 
         const savedPromptIds = [...alreadyCompletedPromptIds];
         const failures: string[] = [];
+        // バッチ提出済みで、確認の上限に達して決着を確認できなかったプロンプト（失敗ではない）
+        const pendingConfirmationPromptIds: string[] = [];
         let failedPhase: ProcessingFailedPhase = 'text_generation';
 
         const failJob = (phase: ProcessingFailedPhase, messages: string[]) => {
@@ -418,6 +432,9 @@ export const useVideoProcessing = (
                 status: 'canceled',
                 phase: 'canceled',
                 error: message,
+                // 提出後の中止は「この画面での確認の停止」であって Azure ジョブの取消ではない（仕様 §A4）。
+                // ID は batchJobsRef に残り、再開は同じジョブの確認から始まる
+                ...(status.batch && { batch: { ...status.batch, confirmation: 'stopped' as const } }),
             }));
         };
 
@@ -511,9 +528,11 @@ export const useVideoProcessing = (
             });
 
             const originalFileType = file.file.type.startsWith('video/') ? 'video' as const : 'audio' as const;
-            // H7: 生成済みの下書きしか残っていないなら、アップロードをやり直さず保存だけ再試行する
+            // H7: 生成済みの下書きしか残っていないなら、アップロードをやり直さず保存だけ再試行する。
+            // 提出済みのバッチ（確認の再開だけが残る）も同様に、音声を上げ直さない
             const needsGeneration = remainingPrompts.some(
                 prompt => !draftsRef.current.has(`${fileId}::${prompt.id}`)
+                    && !batchJobsRef.current.has(`${fileId}::${prompt.id}`)
             );
 
             updateStatus(fileId, status => ({
@@ -607,33 +626,92 @@ export const useVideoProcessing = (
                 if (isTranscriptPrompt(prompt)) {
                     if (!savedKeysRef.current.has(idempotencyKey)) {
                         throwIfAborted();
-                        const media = uploadedMedia;
-                        if (!media) {
-                            throw new PromptPhaseError(
-                                'upload',
-                                '送信用の音声データが準備されていません。音声変換からやり直してください。'
-                            );
-                        }
+                        // 段階（仕様 §A1）を処理欄へ届ける。%・チャンク数は無い。観測時刻と受信時刻は別に持つ
+                        const applyBatchTick = (response: TranscribeStatusResponse) => {
+                            const stage = stageFromStatusResponse(response);
+                            updateStatus(fileId, status => (status.batch?.promptId === promptId
+                                ? {
+                                    ...status,
+                                    batch: {
+                                        ...status.batch,
+                                        ...(stage && { stage }),
+                                        ...(response.azureStatusCheckedAtMs !== undefined
+                                            && { observedAtMs: response.azureStatusCheckedAtMs }),
+                                        lastCheckedAtMs: Date.now(),
+                                    },
+                                }
+                                : status));
+                        };
+                        const setBatch = (batch: BatchTranscriptionProgress) =>
+                            updateStatus(fileId, status => ({ ...status, batch }));
+
                         markPromptState(fileId, promptId, 'generating');
-                        const result = await runBatchTranscription({
-                            storagePath: media.storagePath,
-                            fileName: file.file.name,
-                            mimeType: media.mimeType,
-                            audioSec: estimateAudioSec(audioBlob, bitrate),
-                            promptName: prompt.name,
-                            originalFileType,
-                            signal,
-                        });
-                        if (!result.success) {
+                        const knownJob = batchJobsRef.current.get(idempotencyKey);
+                        let result: RunBatchTranscriptionResult;
+                        if (knownJob) {
+                            // 🔴 確認停止・確認待ちからの再開。submit は呼ばず、保存した ID の確認だけを再開する
+                            //    （仕様 §A4。再 submit は二重課金と重複文書を生む）。前回の段階は引き継ぐ
+                            updateStatus(fileId, status => ({
+                                ...status,
+                                batch: {
+                                    ...(status.batch?.jobId === knownJob.jobId ? status.batch : {}),
+                                    ...knownJob,
+                                    promptId,
+                                    confirmation: 'polling',
+                                },
+                            }));
+                            result = await resumeBatchTranscription({ ...knownJob, signal, onTick: applyBatchTick });
+                        } else {
+                            const media = uploadedMedia;
+                            if (!media) {
+                                throw new PromptPhaseError(
+                                    'upload',
+                                    '送信用の音声データが準備されていません。音声変換からやり直してください。'
+                                );
+                            }
+                            result = await runBatchTranscription({
+                                storagePath: media.storagePath,
+                                fileName: file.file.name,
+                                mimeType: media.mimeType,
+                                audioSec: estimateAudioSec(audioBlob, bitrate),
+                                promptName: prompt.name,
+                                originalFileType,
+                                signal,
+                                onTick: applyBatchTick,
+                                onSubmitted: ({ jobId, docId }) => {
+                                    batchJobsRef.current.set(idempotencyKey, { jobId, docId });
+                                    setBatch({ jobId, docId, promptId, stage: 'checking', confirmation: 'polling' });
+                                },
+                            });
+                        }
+                        if (result.outcome === 'pending') {
+                            // 🔴 確認の上限に達しただけで失敗ではない（仕様 §A4）。ジョブはサーバで継続し、
+                            //    文書は「処理中」で残る。赤い失敗にせず「確認待ち」として残し、再開は同じ ID で行う
+                            pendingConfirmationPromptIds.push(promptId);
+                            updateStatus(fileId, status => ({
+                                ...withPromptStates(status, {
+                                    ...status.promptStates,
+                                    [promptId]: 'awaiting_confirmation',
+                                }),
+                                ...(status.batch && { batch: { ...status.batch, confirmation: 'pending' as const } }),
+                            }));
+                            return;
+                        }
+                        if (result.outcome === 'failed') {
                             // 🔴 失敗しても文書は消えない（サーバが理由つきで残す）。ここでは経過を伝える。
                             throw new PromptPhaseError(
                                 'text_generation',
-                                result.pending
-                                    ? '文字起こしがまだ完了していません。しばらくしてから文書一覧でご確認ください。'
-                                    : (result.error || '文字起こしに失敗しました。')
+                                result.error || '文字起こしに失敗しました。'
                             );
                         }
                         savedKeysRef.current.add(idempotencyKey);
+                        batchJobsRef.current.delete(idempotencyKey);
+                        updateStatus(fileId, status => ({
+                            ...status,
+                            ...(status.batch && {
+                                batch: { ...status.batch, stage: 'completed' as const, confirmation: 'done' as const },
+                            }),
+                        }));
                     }
                     savedPromptIds.push(promptId);
                     updateStatus(fileId, status => ({
@@ -819,6 +897,19 @@ export const useVideoProcessing = (
                     failedPhase: undefined,
                     transcriptionCount: savedCount,
                     totalTranscriptions: plannedCount,
+                }));
+                return;
+            }
+
+            if (failures.length === 0 && pendingConfirmationPromptIds.length > 0) {
+                // 🔴 全文文字起こしの確認上限（仕様 §A4）。失敗ではないので error にしない。
+                //    文書は「処理中」で残り、サーバ側の文字起こしは継続する。「確認を再開する」は同じ ID の確認再開
+                updateStatus(fileId, status => ({
+                    ...status,
+                    status: 'pending_confirmation',
+                    phase: 'awaiting_confirmation',
+                    error: undefined,
+                    failedPhase: undefined,
                 }));
                 return;
             }

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -17,12 +17,38 @@ import {
     serverTimestamp,
 } from 'firebase/firestore';
 import { getCurrentUserId, getOwnerType } from './auth';
+import type { DocumentProcessingProgress } from './transcribeBatchContract';
 import { logAudit } from './auditLog';
 import { validateDocumentSize } from './adminSettings';
 import { updateUserStats } from './userManagement';
 import { createLogger } from './logger';
 
 const firestoreLogger = createLogger('firestore');
+
+
+/**
+ * 文書に保存された進捗投影を読取境界で正規化する（設計 §A3）。
+ * 保存側は stageObservedAt を Firestore Timestamp で書くので、ここで ms へ直す。
+ * 不正・欠損は undefined を返し、UI 側は投影なしとして扱う。
+ */
+const normalizeProcessingProgress = (raw: unknown): DocumentProcessingProgress | undefined => {
+    if (!raw || typeof raw !== 'object') return undefined;
+    const r = raw as Record<string, unknown>;
+    const stage = r.stage;
+    const validStages = ['checking', 'queued', 'transcribing', 'importing', 'completed', 'failed'];
+    if (typeof stage !== 'string' || !validStages.includes(stage)) return undefined;
+    const observed = r.stageObservedAt;
+    const stageObservedAtMs = observed instanceof Timestamp ? observed.toMillis()
+        : typeof (observed as { toMillis?: () => number })?.toMillis === 'function'
+            ? (observed as { toMillis: () => number }).toMillis()
+            : typeof observed === 'number' ? observed : undefined;
+    return {
+        stage: stage as DocumentProcessingProgress['stage'],
+        ...(typeof stageObservedAtMs === 'number' && { stageObservedAtMs }),
+        ...(typeof r.jobCreatedAtMs === 'number' && { jobCreatedAtMs: r.jobCreatedAtMs }),
+        ...(typeof r.audioSec === 'number' && { audioSec: r.audioSec }),
+    };
+};
 
 export interface TranscriptionDocument {
     id?: string;
@@ -32,6 +58,8 @@ export interface TranscriptionDocument {
     transcription: string;
     status?: string;
     jobId?: string;
+    /** 表示専用の進捗投影（設計 §A3・processing 文書のみ・サーバが書く） */
+    processingProgress?: DocumentProcessingProgress;
     promptName: string; // 使用したプロンプト名
     generatedByModel?: string;
     generatedByThinkingLevel?: string;
@@ -54,6 +82,7 @@ export interface Transcription {
     text: string; // transcription のエイリアス
     status?: string;
     jobId?: string;
+    processingProgress?: DocumentProcessingProgress;
     promptName: string;
     originalFileType?: string;
     generatedByModel?: string;
@@ -272,6 +301,7 @@ export async function getTranscriptionDocuments(limitCount: number = 20): Promis
                 transcription: data.transcription ?? data.text ?? '',
                 status: data.status,
                 jobId: data.jobId,
+                processingProgress: normalizeProcessingProgress(data.processingProgress),
                 promptName: data.promptName || '不明',
                 generatedByModel: data.generatedByModel,
                 generatedByThinkingLevel: data.generatedByThinkingLevel,
@@ -355,6 +385,7 @@ export async function getTranscriptions(
                 text: data.transcription ?? data.text ?? '', // transcription を text にマッピング
                 status: data.status,
                 jobId: data.jobId,
+                processingProgress: normalizeProcessingProgress(data.processingProgress),
                 promptName: data.promptName || '不明',
                 originalFileType: data.originalFileType,
                 generatedByModel: data.generatedByModel,
@@ -401,6 +432,7 @@ export async function getTranscriptionsByOwnerId(ownerId: string, limitCount: nu
                 text: data.transcription ?? data.text ?? '',
                 status: data.status,
                 jobId: data.jobId,
+                processingProgress: normalizeProcessingProgress(data.processingProgress),
                 promptName: data.promptName || '不明',
                 originalFileType: data.originalFileType,
                 generatedByModel: data.generatedByModel,

--- a/src/lib/transcribeBatchContract.ts
+++ b/src/lib/transcribeBatchContract.ts
@@ -32,11 +32,47 @@ export type TranscribeStatusRequest =
 
 export type TranscribeJobPublicStatus = 'running' | 'succeeded' | 'failed';
 
+/**
+ * 表示専用の進捗段階（設計 §A1・2026-09-05）。公開 status（running/succeeded/failed）とは別物で、
+ * 「今どの段階か」を利用者に見せるための派生値。🔴 Azure は進捗パーセントを返さないので段階のみ。
+ * - checking: 受付済み・Azure の有効状態をまだ観測していない
+ * - queued: 最後の観測が NotStarted（開始待ち）
+ * - transcribing: 最後の観測が Running（文字起こし中）
+ * - importing: Azure Succeeded を観測し、結果取り込み中（終端確定はまだ）
+ * - completed / failed: サーバが文書とジョブを終端確定済み
+ * 🔴 内部の finalizing は「取り込み中」ではない（開始待ちでも一時的に finalizing になる）。段階に使わない。
+ */
+export type TranscribeProgressStage =
+    | 'checking' | 'queued' | 'transcribing' | 'importing' | 'completed' | 'failed';
+
+/**
+ * 文書に載せる小さな進捗投影（一覧が API 応答を待たずに段階を読めるようにする・設計 §A3）。
+ * Firestore には stageObservedAt を Timestamp で保存し、クライアント読取境界で ms へ正規化する。
+ */
+export interface DocumentProcessingProgress {
+    stage: TranscribeProgressStage;
+    /** その段階を観測したサーバ時刻（ms）。最新照会時刻ではない */
+    stageObservedAtMs?: number;
+    /** 受付からの経過の近似起点（ジョブ作成時刻・ms） */
+    jobCreatedAtMs?: number;
+    /** 音声長（秒・概算含む）。推定残り時間の後続版で使う */
+    audioSec?: number;
+}
+
 export interface TranscribeStatusResponse {
     status: TranscribeJobPublicStatus;
     docId: string;
     /** 失敗時のみ。利用者向けの短い理由 */
     error?: string;
+    /** 表示段階（設計 §A1）。終端 status を優先。旧サーバ応答では欠落し得る */
+    stage?: TranscribeProgressStage;
+    /** 有効な Azure 観測の鮮度（ms）。HTTP 応答受信時刻とは区別する */
+    azureStatusCheckedAtMs?: number;
+    /** 既存 job の値を公開（受付からの経過推定に使う）。旧データ・不正値は省略 */
+    createdAtMs?: number;
+    audioSec?: number;
+    /** 応答生成時刻（ms）。クライアント時計のずれを抑え、受信後はローカル経過を足す */
+    serverNowMs?: number;
 }
 
 export interface TranscribeBatchErrorBody {

--- a/src/server/transcriptionDocument.test.ts
+++ b/src/server/transcriptionDocument.test.ts
@@ -2,33 +2,48 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const doubles = vi.hoisted(() => ({
     document: undefined as Record<string, unknown> | undefined,
+    job: undefined as Record<string, unknown> | undefined,
     get: vi.fn(),
     set: vi.fn(),
     doc: vi.fn(),
+    jobDoc: vi.fn(),
     runTransaction: vi.fn(),
 }));
 
 vi.mock('@/lib/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn() }) }));
-vi.mock('firebase-admin/firestore', () => ({ FieldValue: { serverTimestamp: () => 'SERVER_TS' } }));
+vi.mock('firebase-admin/firestore', () => ({
+    FieldValue: { serverTimestamp: () => 'SERVER_TS', delete: () => 'DELETE_FIELD' },
+}));
 vi.mock('./firebaseAdmin', () => ({
     getAdminFirestore: () => ({
-        collection: () => ({ doc: doubles.doc }),
+        collection: (name: string) => ({ doc: name === 'transcriptionJobs' ? doubles.jobDoc : doubles.doc }),
         runTransaction: doubles.runTransaction,
     }),
 }));
 
-import { attachJobToDocument, createProcessingDocument } from './transcriptionDocument';
+import {
+    attachJobToDocument,
+    completeTranscriptionDocument,
+    createProcessingDocument,
+    failTranscriptionDocument,
+    writeProcessingProgress,
+} from './transcriptionDocument';
 
 beforeEach(() => {
     vi.clearAllMocks();
     doubles.document = { ownerId: 'synthetic-owner', title: '合成の文書', status: 'processing' };
+    doubles.job = { ownerId: 'synthetic-owner', docId: 'synthetic-doc' };
     doubles.doc.mockReturnValue({ id: 'synthetic-doc', get: doubles.get, set: doubles.set });
-    doubles.get.mockImplementation(async () => ({
-        exists: doubles.document !== undefined,
-        data: () => doubles.document,
-    }));
+    doubles.jobDoc.mockReturnValue({ id: 'synthetic-job' });
+    doubles.get.mockImplementation(async (ref?: { id: string }) => {
+        const data = ref?.id === 'synthetic-job' ? doubles.job : doubles.document;
+        return { exists: data !== undefined, data: () => data };
+    });
     doubles.set.mockImplementation((data, options) => {
         doubles.document = options?.merge ? { ...doubles.document, ...data } : data;
+        for (const key of Object.keys(doubles.document!)) {
+            if (doubles.document![key] === 'DELETE_FIELD') delete doubles.document![key];
+        }
     });
     // runTransaction は tx.get / tx.set を同じ doubles.document に対して動かす（本物の意味論を模す）
     doubles.runTransaction.mockImplementation(async (fn) => fn({
@@ -78,5 +93,106 @@ describe('createProcessingDocument', () => {
         await createProcessingDocument(input);
         expect(doubles.document).not.toHaveProperty('jobId');
         expect(doubles.document).toMatchObject({ ownerId: 'synthetic-owner', status: 'processing' });
+    });
+});
+
+describe('writeProcessingProgress', () => {
+    const progress = { jobId: 'synthetic-job', stage: 'transcribing' as const, jobCreatedAtMs: 1_700_000_000_000, audioSec: 120.5 };
+
+    beforeEach(() => {
+        doubles.document = {
+            ...doubles.document, jobId: 'synthetic-job', transcription: '合成の本文', updatedAt: 'UNCHANGED_TS',
+        };
+    });
+
+    it.each(['checking', 'queued', 'transcribing', 'importing'] as const)('%s をサーバ時刻付きで投影し、本文と updatedAt を保持する', async (stage) => {
+        await writeProcessingProgress('synthetic-doc', 'synthetic-owner', { ...progress, stage });
+        expect(doubles.runTransaction).toHaveBeenCalledTimes(1);
+        expect(doubles.set).toHaveBeenCalledExactlyOnceWith({
+            processingProgress: {
+                stage, stageObservedAt: 'SERVER_TS', jobCreatedAtMs: progress.jobCreatedAtMs, audioSec: progress.audioSec,
+            },
+        }, { merge: true });
+        expect(doubles.document).toMatchObject({ transcription: '合成の本文', updatedAt: 'UNCHANGED_TS', status: 'processing' });
+        expect(doubles.jobDoc).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        { name: '削除済み', patch: undefined },
+        { name: '別 owner', patch: { ownerId: 'synthetic-other-owner' } },
+        { name: 'owner 未設定', patch: { ownerId: undefined } },
+        { name: '完了済み', patch: { status: 'completed' } },
+        { name: '失敗済み', patch: { status: 'failed' } },
+        { name: 'status 未設定', patch: { status: undefined } },
+        { name: '別 jobId', patch: { jobId: 'synthetic-other-job' } },
+        { name: '不正 jobId', patch: { jobId: null } },
+    ])('$name の文書には投影を書かず復活させない', async ({ patch }) => {
+        doubles.document = patch === undefined ? undefined : { ...doubles.document, ...patch };
+        const original = doubles.document;
+        await writeProcessingProgress('synthetic-doc', 'synthetic-owner', progress);
+        expect(doubles.set).not.toHaveBeenCalled();
+        expect(doubles.document).toEqual(original);
+    });
+
+    it('同じ段階の poll は何も書かず、段階の観測時刻と付随情報を据え置く', async () => {
+        const previous = { stage: 'transcribing', stageObservedAt: 'PREVIOUS_TS', audioSec: 90 };
+        doubles.document!.processingProgress = previous;
+        await writeProcessingProgress('synthetic-doc', 'synthetic-owner', progress);
+        expect(doubles.set).not.toHaveBeenCalled();
+        expect(doubles.document!.processingProgress).toEqual(previous);
+    });
+
+    it('旧文書の jobId を同じ transaction で検証し、投影と原子的に補う', async () => {
+        delete doubles.document!.jobId;
+        await writeProcessingProgress('synthetic-doc', 'synthetic-owner', progress);
+        expect(doubles.get).toHaveBeenCalledTimes(2);
+        expect(doubles.jobDoc).toHaveBeenCalledWith('synthetic-job');
+        expect(doubles.runTransaction).toHaveBeenCalledTimes(1);
+        expect(doubles.set).toHaveBeenCalledExactlyOnceWith({
+            jobId: 'synthetic-job',
+            processingProgress: {
+                stage: 'transcribing', stageObservedAt: 'SERVER_TS', jobCreatedAtMs: progress.jobCreatedAtMs, audioSec: progress.audioSec,
+            },
+        }, { merge: true });
+    });
+
+    it.each([
+        { name: 'ジョブ未登録', job: undefined },
+        { name: 'ジョブの owner 不一致', job: { ownerId: 'synthetic-other-owner', docId: 'synthetic-doc' } },
+        { name: 'ジョブの docId 不一致', job: { ownerId: 'synthetic-owner', docId: 'synthetic-other-doc' } },
+        { name: '不正な旧ジョブ', job: {} },
+    ])('$name なら旧文書に jobId も投影も書かない', async ({ job }) => {
+        delete doubles.document!.jobId;
+        doubles.job = job;
+        await writeProcessingProgress('synthetic-doc', 'synthetic-owner', progress);
+        expect(doubles.set).not.toHaveBeenCalled();
+        expect(doubles.document).not.toHaveProperty('jobId');
+        expect(doubles.document).not.toHaveProperty('processingProgress');
+    });
+
+    it.each([undefined, NaN, Infinity, -Infinity, -1, 0])('旧データ・不正な付随値 %s を Firestore に書かない', async (value) => {
+        await writeProcessingProgress('synthetic-doc', 'synthetic-owner', {
+            ...progress, jobCreatedAtMs: value, audioSec: value,
+        });
+        expect(doubles.document!.processingProgress).toEqual({ stage: 'transcribing', stageObservedAt: 'SERVER_TS' });
+    });
+});
+
+describe('文書単独の終端更新', () => {
+    it('完成本文と status を保存する際に進捗投影を削除する', async () => {
+        doubles.document!.processingProgress = { stage: 'importing', stageObservedAt: 'PREVIOUS_TS' };
+        await completeTranscriptionDocument('synthetic-doc', '合成の完成本文', 'synthetic-model', 'synthetic-owner');
+        expect(doubles.set).toHaveBeenCalledWith(expect.objectContaining({ processingProgress: 'DELETE_FIELD' }), { merge: true });
+        expect(doubles.document).toMatchObject({ status: 'completed', transcription: '合成の完成本文' });
+        expect(doubles.document).not.toHaveProperty('processingProgress');
+    });
+
+    it('失敗理由と status を保存する際に進捗投影を削除し、文書は残す', async () => {
+        doubles.document!.processingProgress = { stage: 'checking', stageObservedAt: 'PREVIOUS_TS' };
+        await failTranscriptionDocument('synthetic-doc', '合成の失敗理由', 'synthetic-owner');
+        expect(doubles.set).toHaveBeenCalledWith(expect.objectContaining({ processingProgress: 'DELETE_FIELD' }), { merge: true });
+        expect(doubles.document).toMatchObject({ status: 'failed', title: '合成の文書' });
+        expect(doubles.document!.transcription).toContain('合成の失敗理由');
+        expect(doubles.document).not.toHaveProperty('processingProgress');
     });
 });

--- a/src/server/transcriptionDocument.ts
+++ b/src/server/transcriptionDocument.ts
@@ -10,6 +10,7 @@
 import { FieldValue } from 'firebase-admin/firestore';
 import { getAdminFirestore } from './firebaseAdmin';
 import { createLogger } from '@/lib/logger';
+import type { TranscribeProgressStage } from '@/lib/transcribeBatchContract';
 
 const logger = createLogger('server/transcriptionDocument');
 
@@ -67,6 +68,53 @@ export async function attachJobToDocument(docId: string, jobId: string, expected
     });
 }
 
+export interface ProcessingProgressInput {
+    jobId: string;
+    stage: Exclude<TranscribeProgressStage, 'completed' | 'failed'>;
+    jobCreatedAtMs?: number;
+    audioSec?: number;
+}
+
+/** 段階が変わったときだけ小さな投影を更新する。本文・更新日時・一覧の並び順には触れない。 */
+export async function writeProcessingProgress(
+    docId: string,
+    expectedOwnerId: string,
+    progress: ProcessingProgressInput,
+): Promise<void> {
+    const db = getAdminFirestore();
+    const ref = db.collection(TRANSCRIPTIONS_COLLECTION).doc(docId);
+    await db.runTransaction(async (tx) => {
+        const snap = await tx.get(ref);
+        const doc = snap.data();
+        if (!snap.exists || doc?.ownerId !== expectedOwnerId || doc.status !== 'processing') return;
+        if (doc.jobId !== undefined && doc.jobId !== progress.jobId) return;
+        if (doc.processingProgress?.stage === progress.stage) return;
+
+        const needsJobId = doc.jobId === undefined;
+        if (needsJobId) {
+            // ジョブ未登録の提出途中は次回確認へ回す。循環 import を避け、同じコレクションを直接読む。
+            const jobRef = db.collection('transcriptionJobs').doc(progress.jobId);
+            const jobSnap = await tx.get(jobRef);
+            const job = jobSnap.data();
+            if (!jobSnap.exists || job?.docId !== docId || job.ownerId !== expectedOwnerId) return;
+        }
+
+        tx.set(ref, {
+            ...(needsJobId && { jobId: progress.jobId }),
+            processingProgress: {
+                stage: progress.stage,
+                stageObservedAt: FieldValue.serverTimestamp(),
+                ...(typeof progress.jobCreatedAtMs === 'number'
+                    && Number.isFinite(progress.jobCreatedAtMs) && progress.jobCreatedAtMs > 0
+                    && { jobCreatedAtMs: progress.jobCreatedAtMs }),
+                ...(typeof progress.audioSec === 'number'
+                    && Number.isFinite(progress.audioSec) && progress.audioSec > 0
+                    && { audioSec: progress.audioSec }),
+            },
+        }, { merge: true });
+    });
+}
+
 /** 完了: 本文を書き込み、status を completed にする。 */
 export async function completeTranscriptionDocument(
     docId: string,
@@ -95,6 +143,7 @@ export async function completeTranscriptionDocument(
             transcription,
             generatedByModel,
             status: 'completed' satisfies TranscriptionDocStatus,
+            processingProgress: FieldValue.delete(),
             updatedAt: FieldValue.serverTimestamp(),
         }, { merge: true });
         return true;
@@ -127,6 +176,7 @@ export async function failTranscriptionDocument(docId: string, reason: string, e
         tx.set(ref, {
             transcription: `文字起こしに失敗しました。\n\n理由: ${reason}\n\nお手数ですが、もう一度お試しください。`,
             status: 'failed' satisfies TranscriptionDocStatus,
+            processingProgress: FieldValue.delete(),
             updatedAt: FieldValue.serverTimestamp(),
         }, { merge: true });
         return true;

--- a/src/server/transcriptionJob.test.ts
+++ b/src/server/transcriptionJob.test.ts
@@ -23,19 +23,26 @@ const doubles = vi.hoisted(() => ({
 
 vi.mock('@/lib/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: doubles.warn, error: vi.fn() }) }));
 vi.mock('firebase-admin/firestore', () => ({
-    FieldValue: { serverTimestamp: () => 'SERVER_TS' },
+    FieldValue: { serverTimestamp: () => 'SERVER_TS', delete: () => 'SERVER_DELETE' },
 }));
 vi.mock('./firebaseAdmin', () => ({
     getAdminFirestore: () => ({
         collection: (name: string) => ({
-            doc: (id: string) => ({ id: `${name}/${id}` }),
+            doc: (id: string) => ({
+                id: `${name}/${id}`,
+                get: async () => {
+                    const data = doubles.jobs.get(`${name}/${id}`);
+                    return { exists: data !== undefined, data: () => data };
+                },
+            }),
             where: doubles.where,
         }),
         runTransaction: doubles.runTransaction,
     }),
 }));
 
-import { claimJobForFinalize, commitTerminalOutcome, FINALIZE_LEASE_MS, getTranscriptionJobByDocId, type TerminalOutcome } from './transcriptionJob';
+import { claimJobForFinalize, commitTerminalOutcome, FINALIZE_LEASE_MS, getTranscriptionJob, getTranscriptionJobByDocId, recordAzureObservation, updateTranscriptionJob, type TerminalOutcome } from './transcriptionJob';
+import type { AzureBatchStatus } from '@/lib/azureBatchContract';
 
 const NOW_MS = 1_800_000_000_000;
 const JOB_ID = 'synthetic-job';
@@ -91,26 +98,27 @@ beforeEach(() => {
             const value = await fn({
                 get: async ref => {
                     if (pendingUpdates.length > 0) throw new Error('Firestore reads must precede writes');
-                    doubles.get(ref);
+                    doubles.get({ id: ref.id });
                     const data = doubles.jobs.get(ref.id);
                     return { exists: data !== undefined, data: () => data };
                 },
                 update: (ref, patch) => {
-                    doubles.update(ref, patch);
+                    doubles.update({ id: ref.id }, patch);
                     pendingUpdates.push({ ref, patch });
                 },
                 set: (ref, patch, options) => {
-                    doubles.set(ref, patch, options);
+                    doubles.set({ id: ref.id }, patch, options);
                     pendingUpdates.push({ ref, patch });
                 },
             });
             if (doubles.commitError) throw doubles.commitError;
             for (const { ref, patch } of pendingUpdates) {
-                doubles.jobs.set(ref.id, {
-                    ...doubles.jobs.get(ref.id),
-                    ...patch,
-                    updatedAt: patch.updatedAt === 'SERVER_TS' ? { toMillis: () => NOW_MS } : patch.updatedAt,
-                });
+                const next = { ...doubles.jobs.get(ref.id) };
+                for (const [key, value] of Object.entries(patch)) {
+                    if (value === 'SERVER_DELETE') delete next[key];
+                    else next[key] = value === 'SERVER_TS' ? { toMillis: () => NOW_MS } : value;
+                }
+                doubles.jobs.set(ref.id, next);
             }
             return value;
         });
@@ -121,6 +129,100 @@ beforeEach(() => {
 
 afterEach(() => {
     vi.restoreAllMocks();
+});
+
+describe('Azure 観測の読み取り', () => {
+    it.each(['NotStarted', 'Running', 'Succeeded', 'Failed'] as const)('%s と Timestamp を読み取る', async azureStatus => {
+        doubles.jobs.set(JOB_PATH, makeJob({ azureStatus, azureStatusCheckedAt: { toMillis: () => NOW_MS - 1000 } }));
+        await expect(getTranscriptionJob(JOB_ID)).resolves.toMatchObject({ azureStatus, azureStatusCheckedAtMs: NOW_MS - 1000 });
+    });
+
+    it('観測のない旧ジョブには観測状態・観測時刻を補わない', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob());
+        const job = await getTranscriptionJob(JOB_ID);
+        expect(job).not.toHaveProperty('azureStatus');
+        expect(job).not.toHaveProperty('azureStatusCheckedAtMs');
+    });
+
+    it.each([
+        undefined, null, 0, -1, Number.NaN, Number.POSITIVE_INFINITY, 'synthetic-date',
+        { toMillis: () => Number.NaN }, { toMillis: () => 'synthetic-date' },
+        { toMillis: () => { throw new Error('synthetic timestamp'); } },
+    ])('不正な観測値 %s を省略する', async azureStatusCheckedAt => {
+        doubles.jobs.set(JOB_PATH, makeJob({ azureStatus: 'Unknown', azureStatusCheckedAt }));
+        const job = await getTranscriptionJob(JOB_ID);
+        expect(job).not.toHaveProperty('azureStatus');
+        expect(job).not.toHaveProperty('azureStatusCheckedAtMs');
+    });
+
+    it('既存の数値形式の時刻もミリ秒として読み取る', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob({ azureStatus: 'Running', azureStatusCheckedAt: NOW_MS }));
+        await expect(getTranscriptionJob(JOB_ID)).resolves.toMatchObject({ azureStatusCheckedAtMs: NOW_MS });
+    });
+});
+
+describe('recordAzureObservation', () => {
+    it.each(['NotStarted', 'Running', 'Succeeded', 'Failed'] as const)('%s の観測だけを merge し、リース時計を変更しない', async azureStatus => {
+        const before = makeJob({ status: 'finalizing' });
+        doubles.jobs.set(JOB_PATH, before);
+        await expect(recordAzureObservation(JOB_ID, azureStatus)).resolves.toMatchObject({
+            azureStatus, azureStatusCheckedAtMs: NOW_MS, status: 'finalizing', updatedAtMs: NOW_MS - 30_000,
+        });
+        expect(doubles.set).toHaveBeenCalledExactlyOnceWith(
+            { id: JOB_PATH }, { azureStatus, azureStatusCheckedAt: 'SERVER_TS' }, { merge: true },
+        );
+        expect(doubles.update).not.toHaveBeenCalled();
+        expect(doubles.jobs.get(JOB_PATH)?.updatedAt).toBe(before.updatedAt);
+    });
+
+    it('同じ段階でも有効観測時刻を更新する', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob({ azureStatus: 'Running', azureStatusCheckedAt: NOW_MS - 1000 }));
+        await expect(recordAzureObservation(JOB_ID, 'Running')).resolves.toMatchObject({ azureStatusCheckedAtMs: NOW_MS });
+        expect(doubles.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('存在しないジョブを復活させない', async () => {
+        await expect(recordAzureObservation(JOB_ID, 'Running')).resolves.toBeNull();
+        expect(doubles.set).not.toHaveBeenCalled();
+        expect(doubles.jobs.size).toBe(0);
+    });
+
+    it.each(['succeeded', 'failed'])('終端 %s に遅れた観測を書かない', async status => {
+        const before = makeJob({ status, azureStatus: 'Succeeded', azureStatusCheckedAt: NOW_MS - 1000 });
+        doubles.jobs.set(JOB_PATH, before);
+        await expect(recordAzureObservation(JOB_ID, 'Running')).resolves.toMatchObject({ status, azureStatus: 'Succeeded', azureStatusCheckedAtMs: NOW_MS - 1000 });
+        expect(doubles.set).not.toHaveBeenCalled();
+        expect(doubles.jobs.get(JOB_PATH)).toBe(before);
+    });
+
+    it.each(['NotStarted', 'Running', 'Failed'] as const)('Succeeded 観測後の %s で逆戻り・鮮度更新をしない', async azureStatus => {
+        const before = makeJob({ azureStatus: 'Succeeded', azureStatusCheckedAt: NOW_MS - 1000 });
+        doubles.jobs.set(JOB_PATH, before);
+        await expect(recordAzureObservation(JOB_ID, azureStatus)).resolves.toMatchObject({ azureStatus: 'Succeeded', azureStatusCheckedAtMs: NOW_MS - 1000 });
+        expect(doubles.set).not.toHaveBeenCalled();
+        expect(doubles.jobs.get(JOB_PATH)).toBe(before);
+    });
+
+    it('未知の状態で有効観測を置き換えない', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob({ azureStatus: 'Running', azureStatusCheckedAt: NOW_MS - 1000 }));
+        await expect(recordAzureObservation(JOB_ID, 'Unknown' as AzureBatchStatus)).resolves.toMatchObject({
+            azureStatus: 'Running', azureStatusCheckedAtMs: NOW_MS - 1000,
+        });
+        expect(doubles.set).not.toHaveBeenCalled();
+    });
+
+    it('観測が重なっても Succeeded を Running に戻さない', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob());
+        await Promise.all([recordAzureObservation(JOB_ID, 'Succeeded'), recordAzureObservation(JOB_ID, 'Running')]);
+        expect(doubles.jobs.get(JOB_PATH)?.azureStatus).toBe('Succeeded');
+        expect(doubles.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('観測後も元のリース期限で再取得できる', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob({ status: 'finalizing', updatedAt: NOW_MS - FINALIZE_LEASE_MS - 1 }));
+        await recordAzureObservation(JOB_ID, 'Running');
+        await expect(claimJobForFinalize(JOB_ID)).resolves.toMatchObject({ status: 'finalizing', updatedAtMs: NOW_MS });
+    });
 });
 
 describe('getTranscriptionJobByDocId', () => {
@@ -148,6 +250,37 @@ describe('getTranscriptionJobByDocId', () => {
             { id: JOB_ID, data: () => makeJob() },
         ] });
         await expect(getTranscriptionJobByDocId(DOC_ID)).resolves.toMatchObject({ id: JOB_ID, docId: DOC_ID });
+    });
+});
+
+describe('updateTranscriptionJob の非終端更新', () => {
+    it.each(['running', 'finalizing'] as const)('%s への通常更新は従来どおり updatedAt を更新する', async status => {
+        doubles.jobs.set(JOB_PATH, makeJob({ status: 'finalizing' }));
+        await updateTranscriptionJob(JOB_ID, { status });
+        expect(doubles.set).toHaveBeenCalledExactlyOnceWith(
+            { id: JOB_PATH }, { status, updatedAt: 'SERVER_TS' }, { merge: true },
+        );
+        await expect(getTranscriptionJob(JOB_ID)).resolves.toMatchObject({ status, updatedAtMs: NOW_MS });
+    });
+
+    it.each([undefined, 'succeeded', 'failed'])('遅い running への解放は %s のジョブを復活させない', async status => {
+        if (status !== undefined) doubles.jobs.set(JOB_PATH, makeJob({ status }));
+        const before = new Map(doubles.jobs);
+        await updateTranscriptionJob(JOB_ID, { status: 'running' });
+        expect(doubles.set).not.toHaveBeenCalled();
+        expect(doubles.jobs).toEqual(before);
+    });
+
+    it('終端確定と重なった遅い解放は成功済み状態を保持する', async () => {
+        doubles.jobs.set(JOB_PATH, makeJob({ status: 'finalizing' }));
+        doubles.jobs.set(DOC_PATH, makeDocument());
+        await Promise.all([
+            commitTerminalOutcome(terminalParams(successOutcome)),
+            updateTranscriptionJob(JOB_ID, { status: 'running' }),
+        ]);
+        expect(doubles.jobs.get(JOB_PATH)?.status).toBe('succeeded');
+        expect(doubles.jobs.get(DOC_PATH)?.status).toBe('completed');
+        expect(doubles.set).toHaveBeenCalledTimes(2);
     });
 });
 
@@ -221,6 +354,7 @@ describe('commitTerminalOutcome', () => {
             transcription: successOutcome.transcription,
             generatedByModel: successOutcome.generatedByModel,
             status: 'completed',
+            processingProgress: 'SERVER_DELETE',
             updatedAt: 'SERVER_TS',
         }, { merge: true });
         expect(doubles.set).toHaveBeenNthCalledWith(2, { id: JOB_PATH }, {
@@ -241,7 +375,7 @@ describe('commitTerminalOutcome', () => {
         expect(doubles.set).toHaveBeenCalledTimes(2);
         expect(doubles.set).toHaveBeenNthCalledWith(1, { id: DOC_PATH }, {
             transcription: `文字起こしに失敗しました。\n\n理由: ${failureOutcome.reason}\n\nお手数ですが、もう一度お試しください。`,
-            status: 'failed', updatedAt: 'SERVER_TS',
+            status: 'failed', processingProgress: 'SERVER_DELETE', updatedAt: 'SERVER_TS',
         }, { merge: true });
         expect(doubles.set).toHaveBeenNthCalledWith(2, { id: JOB_PATH }, {
             status: 'failed', error: failureOutcome.reason, updatedAt: 'SERVER_TS',
@@ -268,6 +402,7 @@ describe('commitTerminalOutcome', () => {
         it.each([
             { name: '削除済み', document: undefined },
             { name: '所有者が異なる', document: makeDocument({ ownerId: 'synthetic-other-owner' }) },
+            { name: 'jobId が異なる', document: makeDocument({ jobId: 'synthetic-other-job' }) },
             { name: 'completed', document: makeDocument({ status: 'completed', transcription: '利用者の合成編集' }) },
             { name: 'failed', document: makeDocument({ status: 'failed', transcription: '既存の合成失敗理由' }) },
             { name: 'status 未設定', document: makeDocument({ status: undefined }) },
@@ -311,6 +446,16 @@ describe('commitTerminalOutcome', () => {
             await expect(commitTerminalOutcome(terminalParams(successOutcome))).resolves.toBe('not_owner');
             expect(doubles.jobs).toEqual(committed);
             expect(doubles.set).not.toHaveBeenCalled();
+        });
+
+        it('終端確定で処理中の段階投影を削除し、本文と status を保存する', async () => {
+            doubles.jobs.set(DOC_PATH, makeDocument({
+                jobId: JOB_ID,
+                processingProgress: { stage: 'importing', stageObservedAt: NOW_MS - 1000 },
+            }));
+            await expect(commitTerminalOutcome(terminalParams(outcome))).resolves.toBe('committed');
+            expect(doubles.jobs.get(DOC_PATH)).not.toHaveProperty('processingProgress');
+            expect(doubles.jobs.get(DOC_PATH)?.status).toBe(outcome.kind === 'succeeded' ? 'completed' : 'failed');
         });
     });
 

--- a/src/server/transcriptionJob.ts
+++ b/src/server/transcriptionJob.ts
@@ -12,6 +12,7 @@ import { FieldValue, type Firestore } from 'firebase-admin/firestore';
 import { getAdminFirestore } from './firebaseAdmin';
 import { TRANSCRIPTIONS_COLLECTION, type TranscriptionDocStatus } from './transcriptionDocument';
 import { createLogger } from '@/lib/logger';
+import type { AzureBatchStatus } from '@/lib/azureBatchContract';
 
 const logger = createLogger('server/transcriptionJob');
 
@@ -45,6 +46,10 @@ export interface TranscriptionJob {
     speakers?: number;
     createdAtMs: number;
     updatedAtMs: number;
+    /** 最後に取得した有効な Azure 状態。内部の finalizing とは区別する。 */
+    azureStatus?: AzureBatchStatus;
+    /** 有効観測のサーバ時刻。updatedAt のリース時計には使わない。 */
+    azureStatusCheckedAtMs?: number;
 }
 
 export interface CreateTranscriptionJobInput {
@@ -64,15 +69,23 @@ export type TerminalOutcome =
 const db = (): Firestore => getAdminFirestore();
 
 const toMs = (v: unknown): number => {
-    if (v && typeof v === 'object' && typeof (v as { toMillis?: () => number }).toMillis === 'function') {
-        return (v as { toMillis: () => number }).toMillis();
+    try {
+        const ms = v && typeof v === 'object' && typeof (v as { toMillis?: () => number }).toMillis === 'function'
+            ? (v as { toMillis: () => number }).toMillis()
+            : v;
+        return typeof ms === 'number' && Number.isFinite(ms) && ms > 0 ? ms : 0;
+    } catch {
+        return 0;
     }
-    return typeof v === 'number' ? v : 0;
 };
+
+const isAzureBatchStatus = (value: unknown): value is AzureBatchStatus =>
+    value === 'NotStarted' || value === 'Running' || value === 'Succeeded' || value === 'Failed';
 
 const parseJob = (id: string, data: FirebaseFirestore.DocumentData | undefined): TranscriptionJob | null => {
     if (!data) return null;
     if (typeof data.azureSelfUrl !== 'string' || typeof data.docId !== 'string') return null;
+    const azureStatusCheckedAtMs = toMs(data.azureStatusCheckedAt);
     return {
         id,
         ownerId: String(data.ownerId ?? ''),
@@ -87,6 +100,8 @@ const parseJob = (id: string, data: FirebaseFirestore.DocumentData | undefined):
         ...(typeof data.speakers === 'number' && { speakers: data.speakers }),
         createdAtMs: toMs(data.createdAt),
         updatedAtMs: toMs(data.updatedAt),
+        ...(isAzureBatchStatus(data.azureStatus) && { azureStatus: data.azureStatus }),
+        ...(azureStatusCheckedAtMs > 0 && { azureStatusCheckedAtMs }),
     };
 };
 
@@ -106,6 +121,25 @@ export async function createTranscriptionJob(input: CreateTranscriptionJobInput)
 export async function getTranscriptionJob(jobId: string): Promise<TranscriptionJob | null> {
     const snap = await db().collection(TRANSCRIPTION_JOBS_COLLECTION).doc(jobId).get();
     return parseJob(jobId, snap.exists ? snap.data() : undefined);
+}
+
+/**
+ * 有効な Azure 観測だけを保存する。進捗確認で finalizing のリース時計 updatedAt を延ばさない。
+ * 遅延したリクエストが終端状態や既に得た Azure 終端観測を巻き戻すことも防ぐ。
+ */
+export async function recordAzureObservation(jobId: string, azureStatus: AzureBatchStatus): Promise<TranscriptionJob | null> {
+    const firestore = db();
+    const ref = firestore.collection(TRANSCRIPTION_JOBS_COLLECTION).doc(jobId);
+    return firestore.runTransaction(async tx => {
+        const snap = await tx.get(ref);
+        const job = parseJob(jobId, snap.exists ? snap.data() : undefined);
+        if (!job || job.status === 'succeeded' || job.status === 'failed' || !isAzureBatchStatus(azureStatus)) return job;
+        if ((job.azureStatus === 'Succeeded' || job.azureStatus === 'Failed') && job.azureStatus !== azureStatus) return job;
+
+        tx.set(ref, { azureStatus, azureStatusCheckedAt: FieldValue.serverTimestamp() }, { merge: true });
+        // serverTimestamp は commit 時に確定するため、応答にはサーバでの観測時刻を使う。
+        return { ...job, azureStatus, azureStatusCheckedAtMs: Date.now() };
+    });
 }
 
 /** jobId 未付与の既存文書も、docId から最新のジョブを引けるようにする。 */
@@ -162,15 +196,19 @@ export async function commitTerminalOutcome(params: {
             logger.warn('所有者が異なる文書の終端更新をスキップ', { docId });
         } else if (doc.status !== 'processing') {
             logger.warn('処理中でない文書の終端更新をスキップ', { docId });
+        } else if (doc.jobId !== undefined && doc.jobId !== jobId) {
+            logger.warn('ジョブが異なる文書の終端更新をスキップ', { docId });
         } else {
             tx.set(docRef, outcome.kind === 'succeeded' ? {
                 transcription: outcome.transcription,
                 generatedByModel: outcome.generatedByModel,
                 status: 'completed' satisfies TranscriptionDocStatus,
+                processingProgress: FieldValue.delete(),
                 updatedAt,
             } : {
                 transcription: `文字起こしに失敗しました。\n\n理由: ${outcome.reason}\n\nお手数ですが、もう一度お試しください。`,
                 status: 'failed' satisfies TranscriptionDocStatus,
+                processingProgress: FieldValue.delete(),
                 updatedAt,
             }, { merge: true });
         }
@@ -193,7 +231,19 @@ export async function updateTranscriptionJob(
     jobId: string,
     patch: Partial<Pick<TranscriptionJob, 'status' | 'error' | 'speakers'>>,
 ): Promise<void> {
-    await db().collection(TRANSCRIPTION_JOBS_COLLECTION).doc(jobId).set(
+    const firestore = db();
+    const ref = firestore.collection(TRANSCRIPTION_JOBS_COLLECTION).doc(jobId);
+    if (patch.status === 'running' || patch.status === 'finalizing') {
+        // 遅れて届いた確定権の解放で、削除済み・終端化済みのジョブを復活させない。
+        await firestore.runTransaction(async tx => {
+            const snap = await tx.get(ref);
+            const status = snap.data()?.status;
+            if (!snap.exists || status === 'succeeded' || status === 'failed') return;
+            tx.set(ref, { ...patch, updatedAt: FieldValue.serverTimestamp() }, { merge: true });
+        });
+        return;
+    }
+    await ref.set(
         { ...patch, updatedAt: FieldValue.serverTimestamp() },
         { merge: true },
     );

--- a/src/types/processing.ts
+++ b/src/types/processing.ts
@@ -1,3 +1,5 @@
+import type { TranscribeProgressStage } from '@/lib/transcribeBatchContract';
+
 export interface SegmentStatus {
     segmentIndex: number;
     startTime: number;
@@ -18,6 +20,8 @@ export type ProcessingPhase =
     | 'uploading'
     | 'text_generation'
     | 'saving'
+    /** 全文文字起こし（バッチ）の確認上限に達し、この画面での自動確認を止めている。失敗ではない */
+    | 'awaiting_confirmation'
     | 'completed'
     | 'canceled';
 
@@ -35,13 +39,36 @@ export type PromptJobState =
     | 'saving'
     | 'saved'
     | 'failed'
-    | 'canceled';
+    | 'canceled'
+    /** バッチ提出済みで、完了の確認だけがこの画面で止まっている（仕様 §A4「確認待ち」） */
+    | 'awaiting_confirmation';
+
+/** 状態確認の状態。polling=確認中 / pending=上限で停止（確認待ち） / stopped=利用者が停止 / done=終端確定 */
+export type BatchConfirmationState = 'polling' | 'pending' | 'stopped' | 'done';
+
+/**
+ * 全文文字起こし（非同期バッチ）の進捗（仕様 §A4）。
+ * 🔴 音声変換の区間（segments）・生成件数とは別物。段階だけを持ち、%・チャンク数は持たない。
+ */
+export interface BatchTranscriptionProgress {
+    jobId: string;
+    docId: string;
+    promptId: string;
+    /** 最後に観測した表示段階。旧サーバ応答では更新されないことがある */
+    stage?: TranscribeProgressStage;
+    /** 有効な Azure 観測の鮮度（サーバ時刻・ms） */
+    observedAtMs?: number;
+    /** 最後に status 応答を受信したローカル時刻（ms） */
+    lastCheckedAtMs?: number;
+    confirmation: BatchConfirmationState;
+}
 
 export interface FileProcessingStatus {
     /** ファイルの同一性を表す不変ID。配列インデックスは追加・削除でずれるため参照に使わない */
     fileId: string;
     fileName: string;
-    status: 'waiting' | 'converting' | 'transcribing' | 'completed' | 'error' | 'canceled';
+    /** pending_confirmation: バッチの確認上限に達した「確認待ち」。error（失敗）と区別する */
+    status: 'waiting' | 'converting' | 'transcribing' | 'pending_confirmation' | 'completed' | 'error' | 'canceled';
     phase: ProcessingPhase;
     audioConversionProgress: number; // 音声変換の進捗（0-100）
     transcriptionCount: number; // 保存が完了した文書数
@@ -55,6 +82,8 @@ export interface FileProcessingStatus {
     isResuming?: boolean; // 再開処理中かどうか
     /** ジョブ開始時に固定した所有者UID。保存直前にこの値と現在のUIDを照合する */
     ownerUid?: string;
+    /** 全文文字起こし（バッチ）を提出した後の進捗。提出前は無い */
+    batch?: BatchTranscriptionProgress;
 
     // 区間管理用
     totalDuration?: number; // 動画の総時間（秒）


### PR DESCRIPTION
## 概要

全文文字起こしの**進捗段階表示（PR1・A最小版）**を追加します。仕様書「進捗粒度表示と区間再確認」の A のうち、段階表示のみ（数値ETAは PR4）。

これまで処理中は静的なプレースホルダ本文を出すだけでしたが、「今どの段階か」を利用者に見せます。

## エージェントチーム分担
- **継ぎ目（lead 先行コミット）**: 契約の段階/応答型と、文書投影の型・Timestamp→ms 読取正規化。両レーンはこれを介してのみ結合（編集ファイルは完全分離）。
- **サーバ（gpt-6-astra）**: Azure 観測の記録・文書の進捗投影・状態確認APIでの段階導出と返却。
- **UI/クライアント（Fable 5.1）**: 段階表示・一覧バッジ・詳細の状態カード・選択文書の継続確認。

## 主な内容
- サーバ: ジョブに Azure 観測を専用トランザクションで記録（リース時計は触らない）。文書に進捗投影を書き（存在/所有者/processing/jobId 確認・同段階skip・終端でdelete）、状態確認APIが Azure 観測から段階を導出（内部 finalizing は使わない）。応答に stage・鮮度・作成時刻・音声長・serverNowMs を追加。
- UI: 段階表示（「生成 0/1」「区間」「チャンク」は出さない）、一覧の再利用判定が進捗投影を見て再描画、詳細は processing 中に状態カードを出し編集/PDFを無効化。選択文書を表示中・オンラインの間だけ継続確認。
- pending（確認上限）を赤い失敗にせず「確認待ち」とし、再開は submit なしで同じジョブの確認から。

## レビュー
- Codex（GPT-6 Astra・ultra）レビューを3ラウンド。poll/watch のレジリエンスで major を段階的に是正（401/403/404 停止・429 Retry-After 全入口尊重・失敗継続時の上限停止・バックオフ中の中止即応）。最終レビュー **NO BLOCKING FINDINGS**。
- 全体テスト **1,753 passed / 0 failed**。tsc・lint 緑。lead が5つの要所をコード直読で確認。

## 含めないもの（後続）
PR2 要確認候補データ・PR3 要確認UI・PR4 推定残り時間。100MB上限の緩和（別件）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
