### PR TITLE
feat(文字起こし): 要確認候補のデータ層（PR2）

### DIFF
--- a/src/app/api/transcribe/batch.contract.test.ts
+++ b/src/app/api/transcribe/batch.contract.test.ts
@@ -102,7 +102,7 @@ vi.mock('@/server/transcriptionJob', async (importActual) => {
 
 vi.mock('@/server/reviewCandidates', async (importActual) => {
     const actual = await importActual<typeof import('@/server/reviewCandidates')>();
-    return { ...actual, buildReviewCandidates: vi.fn(actual.buildReviewCandidates) };
+    return { ...actual, buildReviewCandidatesSafe: vi.fn(actual.buildReviewCandidatesSafe) };
 });
 
 import { POST as submitPOST } from './submit/route';
@@ -114,7 +114,7 @@ import { attachJobToDocument, createProcessingDocument, writeProcessingProgress 
 import { claimJobForFinalize, commitTerminalOutcome, recordAzureObservation, type TranscriptionJob, FINALIZE_LEASE_MS, createTranscriptionJob, getTranscriptionJob, getTranscriptionJobByDocId, updateTranscriptionJob } from '@/server/transcriptionJob';
 import { getTranscriptionDocuments, getTranscriptions, getTranscriptionsByOwnerId, restoreTranscription } from '@/lib/firestore';
 import * as finalization from '@/server/finalizeTranscription';
-import { buildReviewCandidates, phraseIdFor } from '@/server/reviewCandidates';
+import { buildReviewCandidatesSafe, buildUnavailableReview, measureReviewJsonBytes, phraseIdFor } from '@/server/reviewCandidates';
 import type { TranscriptReview } from '@/lib/transcriptReviewContract';
 
 const syntheticNowMs = 1_788_000_000_000;
@@ -142,6 +142,15 @@ const mergeFirestorePatch = (data: Record<string, unknown> | undefined, patch: R
         } else result[key] = value;
     }
     return result;
+};
+
+/** Firestore Admin SDK は undefined 値を拒否する。保存する review に undefined のキーが無いことの検査用 */
+const hasUndefinedDeep = (value: unknown): boolean => {
+    if (Array.isArray(value)) return value.some(hasUndefinedDeep);
+    if (value && typeof value === 'object') {
+        return Object.values(value as Record<string, unknown>).some((v) => v === undefined || hasUndefinedDeep(v));
+    }
+    return false;
 };
 
 const guest = { kind: 'guest' as const };
@@ -853,10 +862,11 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         const res = await statusPOST(req({ jobId: 'job-1' }));
         expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
 
-        // 抽出側には全句の品質素材を元 index 順で渡す（判定はこちらでしない）
-        expect(buildReviewCandidates).toHaveBeenCalledTimes(1);
-        const [phrases, sourceJobId, sourceTextHash] = vi.mocked(buildReviewCandidates).mock.calls[0];
+        // 抽出側（安全版）には全句の品質素材を元 index 順で渡す（判定はこちらでしない）。音声長は >0 のときだけ渡す
+        expect(buildReviewCandidatesSafe).toHaveBeenCalledTimes(1);
+        const [phrases, sourceJobId, sourceTextHash, options] = vi.mocked(buildReviewCandidatesSafe).mock.calls[0];
         expect(sourceJobId).toBe('job-1');
+        expect(options).toEqual({ threshold: 0.75, audioSec: 60 });
         expect(phrases.map((p) => p.index)).toEqual([0, 1, 2, 3]);
         expect(phrases[1]).toMatchObject({ text: 'ええと。', confidence: 0.4, recognitionStatus: 'Success', speaker: 'spk:1', startSec: 2, endSec: 3 });
         expect(phrases[3]).toMatchObject({ text: '', recognitionStatus: 'NoMatch', speaker: 'spk:2' });
@@ -867,6 +877,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         expect(sourceTextHash).toBe(finalization.sourceTextHashOf(outcome.transcription));
         expect(review).toMatchObject({ version: 1, sourceJobId: 'job-1', sourceTextHash, availability: 'complete' });
         expect(review.summary.totalPhrases).toBe(4);
+        expect(hasUndefinedDeep(review)).toBe(false);
         // 低信頼句（index 1）は 1 段落目（1 行目）、非 Success（index 3）は 2 段落目（3 行目）
         const lines = outcome.transcription.split('\n');
         expect(lines[0]).toContain('ええと。');
@@ -888,27 +899,72 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         expect(deleteBatchJob).toHaveBeenCalledTimes(1);
     });
 
-    it('🔴 候補生成が失敗しても本文が読めれば completed にし、unavailable と理由だけを保存する（設計 B4）', async () => {
-        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
-        vi.mocked(fetchBatchResult).mockResolvedValue(reviewAzureResult());
-        vi.mocked(buildReviewCandidates).mockImplementationOnce(() => { throw new Error('合成の抽出エラー'); });
-        const res = await statusPOST(req({ jobId: 'job-1' }));
-        expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
-        expect(documentDb.data).toMatchObject({
-            status: 'completed',
-            transcription: expect.stringContaining('よろしくお願いします'),
-            transcriptReview: {
-                version: 1, threshold: 0.75, sourceJobId: 'job-1', availability: 'unavailable',
-                unavailableReason: 'internal_error', candidates: [],
-            },
-        });
-        const saved = documentDb.data?.transcriptReview as TranscriptReview;
-        expect(saved.sourceTextHash).toBe(finalization.sourceTextHashOf(documentDb.data?.transcription as string));
-        expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
-        expect(documentDb.jobData).not.toHaveProperty('transcriptReview');
-        expect(deleteBatchJob).toHaveBeenCalledTimes(1);
-        expect(documentDb.warn).toHaveBeenCalledWith('要確認候補の生成に失敗（本文は完成させる）', { jobId: 'job-1', reason: '合成の抽出エラー' });
-    });
+    it.each(['抽出側が例外を投げる', '抽出側が unavailable を返す'] as const)(
+        '🔴 %s場合も本文が読めれば completed にし、unavailable と理由だけを保存する（設計 B4）', async (failure) => {
+            vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+            vi.mocked(fetchBatchResult).mockResolvedValue(reviewAzureResult());
+            if (failure === '抽出側が例外を投げる') {
+                vi.mocked(buildReviewCandidatesSafe).mockImplementationOnce(() => { throw new Error('合成の抽出エラー'); });
+            } else {
+                vi.mocked(buildReviewCandidatesSafe).mockImplementationOnce((_phrases, jobId, hash) =>
+                    buildUnavailableReview(jobId, hash, 'internal_error'));
+            }
+            const res = await statusPOST(req({ jobId: 'job-1' }));
+            expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
+            expect(documentDb.data).toMatchObject({
+                status: 'completed',
+                transcription: expect.stringContaining('よろしくお願いします'),
+                transcriptReview: {
+                    version: 1, threshold: 0.75, sourceJobId: 'job-1', availability: 'unavailable',
+                    unavailableReason: 'internal_error', candidates: [],
+                },
+            });
+            const saved = documentDb.data?.transcriptReview as TranscriptReview;
+            expect(saved.sourceTextHash).toBe(finalization.sourceTextHashOf(documentDb.data?.transcription as string));
+            expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
+            expect(documentDb.jobData).not.toHaveProperty('transcriptReview');
+            expect(deleteBatchJob).toHaveBeenCalledTimes(1);
+            expect(documentDb.warn).toHaveBeenCalledWith(
+                failure === '抽出側が例外を投げる' ? '要確認候補の生成に失敗（本文は完成させる）' : '要確認候補を作れなかった（本文は完成させる）',
+                { jobId: 'job-1', reason: failure === '抽出側が例外を投げる' ? '合成の抽出エラー' : 'internal_error' },
+            );
+        },
+    );
+
+    it.each(['minimal', 'omitted'] as const)(
+        '🔴 本文が長く文書全体の保存予算に候補が収まらないときは %s にし、本文は切り詰めず completed にする', async (mode) => {
+            // 本文サイズ = 1 MiB − 見込み − 余白。minimal: 最小形だけ収まる余白／omitted: 最小形も収まらない
+            const minimalBytes = measureReviewJsonBytes(buildUnavailableReview('job-1', 'x'.repeat(64), 'storage_budget', 0.75));
+            const limit = finalization.FIRESTORE_MAX_DOCUMENT_BYTES - finalization.DOCUMENT_OVERHEAD_HEADROOM_BYTES;
+            const prefix = '[00:00](#t=0) **spk:1** ';
+            const bodyChars = mode === 'minimal' ? limit - (minimalBytes + 100) - prefix.length : limit - prefix.length + 1;
+            vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+            vi.mocked(fetchBatchResult).mockResolvedValue({
+                durationMilliseconds: 60_000,
+                recognizedPhrases: [{
+                    offsetMilliseconds: 0, durationMilliseconds: 2000, speaker: 1, recognitionStatus: 'Success',
+                    nBest: [{ display: 'a'.repeat(bodyChars), confidence: 0.4 }],
+                }],
+            });
+            const res = await statusPOST(req({ jobId: 'job-1' }));
+            expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
+            expect(documentDb.data).toMatchObject({ status: 'completed' });
+            expect((documentDb.data?.transcription as string).length).toBe(prefix.length + bodyChars);
+            if (mode === 'minimal') {
+                expect(documentDb.data?.transcriptReview).toMatchObject({
+                    availability: 'unavailable', unavailableReason: 'storage_budget', candidates: [], sourceJobId: 'job-1',
+                });
+                expect(documentDb.warn).toHaveBeenCalledWith('要確認候補が文書の保存予算に収まらないため最小形にする',
+                    expect.objectContaining({ jobId: 'job-1', candidates: 1 }));
+            } else {
+                expect(documentDb.data).not.toHaveProperty('transcriptReview');
+                expect(documentDb.warn).toHaveBeenCalledWith('最小形でも収まらないため要確認候補を省く（本文は保存する）',
+                    expect.objectContaining({ jobId: 'job-1' }));
+            }
+            expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
+            expect(deleteBatchJob).toHaveBeenCalledTimes(1);
+        },
+    );
 
     it('commit 失敗後の再確定でも要確認候補は同じ入力から同じ内容になる（append しない）', async () => {
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });

--- a/src/app/api/transcribe/batch.contract.test.ts
+++ b/src/app/api/transcribe/batch.contract.test.ts
@@ -100,6 +100,11 @@ vi.mock('@/server/transcriptionJob', async (importActual) => {
     };
 });
 
+vi.mock('@/server/reviewCandidates', async (importActual) => {
+    const actual = await importActual<typeof import('@/server/reviewCandidates')>();
+    return { ...actual, buildReviewCandidates: vi.fn(actual.buildReviewCandidates) };
+});
+
 import { POST as submitPOST } from './submit/route';
 import { POST as statusPOST } from './status/route';
 import { resolveRequestSubject } from '@/server/auth';
@@ -109,6 +114,8 @@ import { attachJobToDocument, createProcessingDocument, writeProcessingProgress 
 import { claimJobForFinalize, commitTerminalOutcome, recordAzureObservation, type TranscriptionJob, FINALIZE_LEASE_MS, createTranscriptionJob, getTranscriptionJob, getTranscriptionJobByDocId, updateTranscriptionJob } from '@/server/transcriptionJob';
 import { getTranscriptionDocuments, getTranscriptions, getTranscriptionsByOwnerId, restoreTranscription } from '@/lib/firestore';
 import * as finalization from '@/server/finalizeTranscription';
+import { buildReviewCandidates, phraseIdFor } from '@/server/reviewCandidates';
+import type { TranscriptReview } from '@/lib/transcriptReviewContract';
 
 const syntheticNowMs = 1_788_000_000_000;
 const syntheticCreatedAtMs = syntheticNowMs - 600_000;
@@ -146,6 +153,17 @@ const sampleAzureResult = (): AzureBatchResult => ({
     recognizedPhrases: [
         { offsetMilliseconds: 0, durationMilliseconds: 2000, speaker: 1, nBest: [{ display: 'こんにちは。' }] },
         { offsetMilliseconds: 3000, durationMilliseconds: 2000, speaker: 2, nBest: [{ display: 'よろしくお願いします。' }] },
+    ],
+});
+
+/** 要確認候補の素材を含む合成結果: 低信頼句（index 1）と非 Success の句（index 3・表示テキスト空）。 */
+const reviewAzureResult = (): AzureBatchResult => ({
+    durationMilliseconds: 60_000,
+    recognizedPhrases: [
+        { offsetMilliseconds: 0, durationMilliseconds: 2000, speaker: 1, recognitionStatus: 'Success', nBest: [{ display: 'こんにちは。', confidence: 0.9 }] },
+        { offsetMilliseconds: 2000, durationMilliseconds: 1000, speaker: 1, recognitionStatus: 'Success', nBest: [{ display: 'ええと。', confidence: 0.4 }] },
+        { offsetMilliseconds: 3000, durationMilliseconds: 2000, speaker: 2, recognitionStatus: 'Success', nBest: [{ display: 'よろしくお願いします。', confidence: 0.95 }] },
+        { offsetMilliseconds: 5000, durationMilliseconds: 500, speaker: 2, recognitionStatus: 'NoMatch', nBest: [{ display: '' }] },
     ],
 });
 
@@ -504,6 +522,10 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
             outcome: {
                 kind: 'succeeded', transcription: expect.stringContaining('よろしくお願いします'),
                 generatedByModel: expect.stringContaining('Azure'), speakers: 2,
+                // 要確認候補は本文と同じ commit に載る（設計 B2/B4）
+                review: expect.objectContaining({
+                    version: 1, sourceJobId: 'job-1', sourceTextHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+                }),
             },
         });
         expect(documentDb.data).toMatchObject({
@@ -699,7 +721,7 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
             } else if (stage === '結果解析') {
                 vi.mocked(fetchBatchResult).mockResolvedValueOnce(null as unknown as AzureBatchResult);
             } else if (stage === 'Markdown 化') {
-                vi.spyOn(finalization, 'buildTranscriptMarkdownFromBatch').mockImplementationOnce(() => {
+                vi.spyOn(finalization, 'buildTranscriptWithAnchors').mockImplementationOnce(() => {
                     throw new Error('合成の整形エラー');
                 });
             }
@@ -825,6 +847,90 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         },
     );
 
+    it('🔴 Succeeded の確定で要確認候補を本文と同じ commit に渡し、段落開始行と本文ハッシュを付けて文書に保存する', async () => {
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+        vi.mocked(fetchBatchResult).mockResolvedValue(reviewAzureResult());
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
+
+        // 抽出側には全句の品質素材を元 index 順で渡す（判定はこちらでしない）
+        expect(buildReviewCandidates).toHaveBeenCalledTimes(1);
+        const [phrases, sourceJobId, sourceTextHash] = vi.mocked(buildReviewCandidates).mock.calls[0];
+        expect(sourceJobId).toBe('job-1');
+        expect(phrases.map((p) => p.index)).toEqual([0, 1, 2, 3]);
+        expect(phrases[1]).toMatchObject({ text: 'ええと。', confidence: 0.4, recognitionStatus: 'Success', speaker: 'spk:1', startSec: 2, endSec: 3 });
+        expect(phrases[3]).toMatchObject({ text: '', recognitionStatus: 'NoMatch', speaker: 'spk:2' });
+
+        const { outcome } = vi.mocked(commitTerminalOutcome).mock.calls[0][0];
+        if (outcome.kind !== 'succeeded') throw new Error('succeeded 以外の outcome');
+        const review = outcome.review as TranscriptReview;
+        expect(sourceTextHash).toBe(finalization.sourceTextHashOf(outcome.transcription));
+        expect(review).toMatchObject({ version: 1, sourceJobId: 'job-1', sourceTextHash, availability: 'complete' });
+        expect(review.summary.totalPhrases).toBe(4);
+        // 低信頼句（index 1）は 1 段落目（1 行目）、非 Success（index 3）は 2 段落目（3 行目）
+        const lines = outcome.transcription.split('\n');
+        expect(lines[0]).toContain('ええと。');
+        expect(lines[2]).toContain('よろしくお願いします。');
+        const low = review.candidates.find((c) => c.phraseId === phraseIdFor(1));
+        const flagged = review.candidates.find((c) => c.phraseId === phraseIdFor(3));
+        expect(low).toMatchObject({ reasons: expect.arrayContaining(['low_confidence']), confidence: 0.4, paragraphStartLine: 1 });
+        expect(flagged).toMatchObject({ paragraphStartLine: 3 });
+        expect(review.candidates.find((c) => c.phraseId === phraseIdFor(0))).toBeUndefined();
+        expect(review.candidates.find((c) => c.phraseId === phraseIdFor(2))).toBeUndefined();
+
+        // 文書に本文と同じ set で保存され、job には複製しない
+        expect(documentDb.tx.set).toHaveBeenCalledWith(documentDb.ref, expect.objectContaining({
+            transcription: outcome.transcription, transcriptReview: review, status: 'completed',
+        }), { merge: true });
+        expect(documentDb.data).toMatchObject({ status: 'completed', transcriptReview: review });
+        expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
+        expect(documentDb.jobData).not.toHaveProperty('transcriptReview');
+        expect(deleteBatchJob).toHaveBeenCalledTimes(1);
+    });
+
+    it('🔴 候補生成が失敗しても本文が読めれば completed にし、unavailable と理由だけを保存する（設計 B4）', async () => {
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+        vi.mocked(fetchBatchResult).mockResolvedValue(reviewAzureResult());
+        vi.mocked(buildReviewCandidates).mockImplementationOnce(() => { throw new Error('合成の抽出エラー'); });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
+        expect(documentDb.data).toMatchObject({
+            status: 'completed',
+            transcription: expect.stringContaining('よろしくお願いします'),
+            transcriptReview: {
+                version: 1, threshold: 0.75, sourceJobId: 'job-1', availability: 'unavailable',
+                unavailableReason: 'internal_error', candidates: [],
+            },
+        });
+        const saved = documentDb.data?.transcriptReview as TranscriptReview;
+        expect(saved.sourceTextHash).toBe(finalization.sourceTextHashOf(documentDb.data?.transcription as string));
+        expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
+        expect(documentDb.jobData).not.toHaveProperty('transcriptReview');
+        expect(deleteBatchJob).toHaveBeenCalledTimes(1);
+        expect(documentDb.warn).toHaveBeenCalledWith('要確認候補の生成に失敗（本文は完成させる）', { jobId: 'job-1', reason: '合成の抽出エラー' });
+    });
+
+    it('commit 失敗後の再確定でも要確認候補は同じ入力から同じ内容になる（append しない）', async () => {
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+        vi.mocked(fetchBatchResult).mockResolvedValue(reviewAzureResult());
+        documentDb.commitError = new Error('合成の commit エラー');
+        expect((await statusPOST(req({ jobId: 'job-1' }))).status).toBe(502);
+        expect(documentDb.data).not.toHaveProperty('transcriptReview');
+        expect(documentDb.data).toMatchObject({ status: 'processing' });
+
+        vi.mocked(getTranscriptionJob).mockResolvedValueOnce({
+            ...runningJob, status: 'finalizing', updatedAtMs: Date.now() - FINALIZE_LEASE_MS - 1,
+        });
+        const retried = await statusPOST(req({ jobId: 'job-1' }));
+        expect(await retried.json()).toEqual(expectedStatus('succeeded', { observed: true }));
+        const outcomes = vi.mocked(commitTerminalOutcome).mock.calls.map(([params]) => params.outcome);
+        expect(outcomes).toHaveLength(2);
+        expect(outcomes[1]).toEqual(outcomes[0]);
+        expect(documentDb.data).toMatchObject({
+            status: 'completed', transcriptReview: expect.objectContaining({ availability: 'complete', sourceJobId: 'job-1' }),
+        });
+    });
+
     it('他人のジョブは 403', async () => {
         vi.mocked(getTranscriptionJob).mockResolvedValue({ ...runningJob, ownerId: 'someuser', ownerType: 'user' });
         const res = await statusPOST(req({ jobId: 'job-1' }));
@@ -919,6 +1025,34 @@ describe('処理中の文書の読取・復元とバッチ確定', () => {
         })).resolves.toBe('committed');
         expect(documentDb.data).toMatchObject({ status: 'completed', jobId: 'job-1', transcription: '復元後の合成本文' });
         expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
+    });
+
+    it.each(readers)('%s は completed 文書の transcriptReview をそのまま載せ、旧文書・不正な形では undefined', async (_name, read) => {
+        const savedReview: TranscriptReview = {
+            version: 1, threshold: 0.75, sourceTextHash: 'a'.repeat(64), sourceJobId: 'job-1',
+            summary: {
+                totalPhrases: 4, lowConfidence: 1, recognitionFlagged: 1, candidateTotal: 2,
+                unknownConfidence: 1, unknownRecognitionStatus: 0, noTimeCandidates: 0, savedCandidates: 2,
+            },
+            availability: 'complete',
+            candidates: [
+                { phraseId: 'p1', reasons: ['low_confidence'], excerpt: 'ええと。', excerptTruncated: false, confidence: 0.4, paragraphStartLine: 1 },
+                { phraseId: 'p3', reasons: ['recognition_status'], excerpt: '', excerptTruncated: false, recognitionStatus: 'NoMatch', paragraphStartLine: 3 },
+            ],
+        };
+        const base = { fileName: 'synthetic.mp3', promptName: '合成プロンプト', originalFileType: 'audio', ownerType: 'guest', ownerId: 'GUEST', transcription: '合成本文' };
+        clientDb.getDocs.mockResolvedValue({
+            forEach: (fn: (snapshot: { id: string; data: () => Record<string, unknown> }) => void) => {
+                fn({ id: 'doc-1', data: () => ({ ...base, title: '完成文書', status: 'completed', transcriptReview: savedReview }) });
+                fn({ id: 'legacy', data: () => ({ ...base, title: '旧文書' }) });
+                fn({ id: 'broken', data: () => ({ ...base, title: '壊れた形', transcriptReview: 'not-an-object' }) });
+            },
+        });
+        const documents = await read();
+        expect(documents).toHaveLength(3);
+        expect(documents[0].transcriptReview).toEqual(savedReview);
+        expect(documents[1].transcriptReview).toBeUndefined();
+        expect(documents[2].transcriptReview).toBeUndefined();
     });
 
     it.each(readers)('%s は旧文書の status と jobId を undefined として読み、復元 payload に追加しない', async (_name, read) => {

--- a/src/app/api/transcribe/status/route.ts
+++ b/src/app/api/transcribe/status/route.ts
@@ -13,6 +13,7 @@ import type {
     TranscribeProgressStage,
 } from '@/lib/transcribeBatchContract';
 import { isTerminalBatchStatus, type AzureBatchStatus } from '@/lib/azureBatchContract';
+import { LOW_CONFIDENCE_THRESHOLD, type TranscriptReview } from '@/lib/transcriptReviewContract';
 import { resolveRequestSubject } from '@/server/auth';
 import { GenerateApiError } from '@/server/errors';
 import { isOwnedBySubject } from '@/server/mediaSource';
@@ -24,8 +25,21 @@ import {
     fetchBatchResult,
     deleteBatchJob,
     parseBatchResult,
+    type ParsedBatch,
 } from '@/server/azureBatchTranscribe';
-import { buildTranscriptMarkdownFromBatch, describeBatchModel } from '@/server/finalizeTranscription';
+import {
+    buildTranscriptWithAnchors,
+    describeBatchModel,
+    fitReviewToDocumentBudget,
+    sourceTextHashOf,
+    withParagraphAnchors,
+} from '@/server/finalizeTranscription';
+import {
+    buildReviewCandidates,
+    buildUnavailableReview,
+    phraseIdFor,
+    type ReviewPhraseInput,
+} from '@/server/reviewCandidates';
 import {
     claimJobForFinalize,
     commitTerminalOutcome,
@@ -114,9 +128,68 @@ export function validateStatusBody(raw: unknown): TranscribeStatusRequest {
     return { docId: raw.docId };
 }
 
+/** 句の品質素材を候補抽出の入力へ（本文に載った句＋時刻が読めず落とした句・元 index 順）。判定はしない。 */
+const toReviewPhrases = (parsed: ParsedBatch): ReviewPhraseInput[] =>
+    [...parsed.annotations, ...parsed.droppedAnnotations]
+        .flatMap((a): ReviewPhraseInput[] => typeof a.phraseIndex !== 'number' ? [] : [{
+            index: a.phraseIndex,
+            text: a.text ?? '',
+            ...(a.confidence !== undefined && { confidence: a.confidence }),
+            ...(a.recognitionStatus !== undefined && { recognitionStatus: a.recognitionStatus }),
+            ...(a.speaker !== undefined && { speaker: a.speaker }),
+            ...(a.startSec !== undefined && { startSec: a.startSec }),
+            ...(a.endSec !== undefined && { endSec: a.endSec }),
+        }])
+        .sort((a, b) => a.index - b.index);
+
+/**
+ * 要確認候補を作る（設計 B2/B4）。判定ロジックは抽出側（reviewCandidates）のものを呼ぶだけ。
+ * 🔴 候補の生成・アンカー付与・保存予算で何が起きても**本文は完成させる**: 例外は availability='unavailable'＋理由に落とし、
+ *    予算に収まらなければ review 自体を省く（undefined＝フィールドを書かない）。文書を failed にするのは本文側の失敗だけ。
+ */
+function buildReviewForDocument(
+    job: TranscriptionJob,
+    parsed: ParsedBatch,
+    markdown: string,
+    phraseLineByIndex: ReadonlyMap<number, number>,
+): TranscriptReview | undefined {
+    const sourceTextHash = sourceTextHashOf(markdown);
+    let review: TranscriptReview;
+    try {
+        const extracted = buildReviewCandidates(toReviewPhrases(parsed), job.id, sourceTextHash, {
+            threshold: LOW_CONFIDENCE_THRESHOLD,
+            // 結果音声長を超える不正時刻を再生に使わない（0 は長さ不明として無視される）
+            audioSec: parsed.audioSec,
+        });
+        // 段落アンカーは句 index → phraseId で引く（抽出側の採番関数を使う。ID 形式は推測しない）
+        const lineByPhraseId = new Map<string, number>();
+        for (const [phraseIndex, line] of phraseLineByIndex) lineByPhraseId.set(phraseIdFor(phraseIndex), line);
+        review = withParagraphAnchors(extracted, lineByPhraseId);
+    } catch (error) {
+        logger.warn('要確認候補の生成に失敗（本文は完成させる）', {
+            jobId: job.id, reason: error instanceof Error ? error.message : String(error),
+        });
+        review = buildUnavailableReview(job.id, sourceTextHash, 'internal_error', LOW_CONFIDENCE_THRESHOLD);
+    }
+    try {
+        const fitted = fitReviewToDocumentBudget(review, Buffer.byteLength(markdown, 'utf8'));
+        if (fitted.adjustment !== 'none') {
+            logger.warn('要確認候補を保存予算に合わせて調整', {
+                jobId: job.id, adjustment: fitted.adjustment, candidates: review.candidates.length,
+            });
+        }
+        return fitted.review;
+    } catch (error) {
+        logger.warn('要確認候補の保存予算の判定に失敗（候補を省いて本文を完成させる）', {
+            jobId: job.id, reason: error instanceof Error ? error.message : String(error),
+        });
+        return undefined;
+    }
+}
+
 /**
  * Azure が終端に達していれば確定処理（呼び出し側が CAS で確定権を取得済み）。
- * 成功: 結果 → Markdown → 文書とジョブを原子的に確定 → Azure ジョブ削除。
+ * 成功: 結果 → Markdown（＋段落アンカー）→ 要確認候補 → 本文＋候補＋文書とジョブを原子的に確定 → Azure ジョブ削除。
  * 失敗: 文書に理由を残してジョブと原子的に確定。取り込み失敗では Azure の結果を残す。
  * 未完: ジョブを running に戻し、次の poll で再確認する。
  */
@@ -173,13 +246,14 @@ async function finalizeIfTerminal(job: TranscriptionJob): Promise<Response> {
         return statusResponse({ ...job, status: 'failed', error: reason });
     }
     // Succeeded
-    let parsed: ReturnType<typeof parseBatchResult>;
+    let parsed: ParsedBatch;
     let markdown: string;
+    let phraseLineByIndex: ReadonlyMap<number, number>;
     let generatedByModel: string;
     try {
         const result = await fetchBatchResult(job.azureSelfUrl, credentials);
         parsed = parseBatchResult(result);
-        markdown = buildTranscriptMarkdownFromBatch(parsed);
+        ({ markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed));
         generatedByModel = describeBatchModel(parsed);
     } catch {
         const reason = '文字起こし結果の取り込みに失敗しました。もう一度お試しください。';
@@ -194,16 +268,30 @@ async function finalizeIfTerminal(job: TranscriptionJob): Promise<Response> {
         // 未取り込みの結果は削除せず、Azure 側の TTL に任せる。
         return statusResponse({ ...job, status: 'failed', error: reason });
     }
+    // 要確認候補（設計 B4）: 本文が読めるなら候補側の失敗で文書を failed にしない。再確定でも同じ入力から決定的に作り直す。
+    const review = buildReviewForDocument(job, parsed, markdown, phraseLineByIndex);
     // 保存失敗は取り込み失敗として確定せず、finalizing のリース切れ後に再試行する。
     const committed = await commitTerminalOutcome({
         jobId: job.id,
         docId: job.docId,
         expectedOwnerId: job.ownerId,
-        outcome: { kind: 'succeeded', transcription: markdown, generatedByModel, speakers: parsed.speakers },
+        outcome: {
+            kind: 'succeeded',
+            transcription: markdown,
+            generatedByModel,
+            speakers: parsed.speakers,
+            ...(review !== undefined && { review }),
+        },
     });
     if (committed === 'not_owner') return getCurrentPublicStatus(job.id);
     await deleteBatchJob(job.azureSelfUrl, credentials);
-    logger.info('文字起こしを確定', { jobId: job.id, speakers: parsed.speakers, chars: markdown.length });
+    logger.info('文字起こしを確定', {
+        jobId: job.id,
+        speakers: parsed.speakers,
+        chars: markdown.length,
+        reviewAvailability: review?.availability ?? 'omitted',
+        reviewCandidates: review?.candidates.length ?? 0,
+    });
     return statusResponse({ ...job, status: 'succeeded' });
 }
 

--- a/src/app/api/transcribe/status/route.ts
+++ b/src/app/api/transcribe/status/route.ts
@@ -30,12 +30,13 @@ import {
 import {
     buildTranscriptWithAnchors,
     describeBatchModel,
-    fitReviewToDocumentBudget,
+    reviewFitsDocument,
     sourceTextHashOf,
     withParagraphAnchors,
 } from '@/server/finalizeTranscription';
 import {
-    buildReviewCandidates,
+    applyReviewBudget,
+    buildReviewCandidatesSafe,
     buildUnavailableReview,
     phraseIdFor,
     type ReviewPhraseInput,
@@ -143,9 +144,13 @@ const toReviewPhrases = (parsed: ParsedBatch): ReviewPhraseInput[] =>
         .sort((a, b) => a.index - b.index);
 
 /**
- * 要確認候補を作る（設計 B2/B4）。判定ロジックは抽出側（reviewCandidates）のものを呼ぶだけ。
- * 🔴 候補の生成・アンカー付与・保存予算で何が起きても**本文は完成させる**: 例外は availability='unavailable'＋理由に落とし、
- *    予算に収まらなければ review 自体を省く（undefined＝フィールドを書かない）。文書を failed にするのは本文側の失敗だけ。
+ * 要確認候補を作る（設計 B2/B4・lead 裁定 2026-09-05）。判定・候補予算の規則は抽出側（reviewCandidates）のものを呼ぶだけ。
+ * 手順: buildReviewCandidatesSafe → withParagraphAnchors → applyReviewBudget → 文書全体の保存見積り。
+ * 🔴 applyReviewBudget はアンカーを補った**後**に再適用する（1 件あたり数十バイト増えるので、抽出時に上限ぎりぎりだと
+ *    最終形で 128 KiB を超え得る）。予算規則は applyReviewBudget が単一の正（ここで独自に候補を選び直さない）。
+ * 🔴 候補側で何が起きても**本文は完成させる**: 例外は unavailable（internal_error）、文書全体の予算に収まらなければ
+ *    最小形（storage_budget）、最小形でも収まらなければ review 自体を省く（undefined＝フィールドを書かない）。
+ *    文書を failed にするのは本文側の失敗だけ。
  */
 function buildReviewForDocument(
     job: TranscriptionJob,
@@ -156,35 +161,36 @@ function buildReviewForDocument(
     const sourceTextHash = sourceTextHashOf(markdown);
     let review: TranscriptReview;
     try {
-        const extracted = buildReviewCandidates(toReviewPhrases(parsed), job.id, sourceTextHash, {
+        const extracted = buildReviewCandidatesSafe(toReviewPhrases(parsed), job.id, sourceTextHash, {
             threshold: LOW_CONFIDENCE_THRESHOLD,
-            // 結果音声長を超える不正時刻を再生に使わない（0 は長さ不明として無視される）
-            audioSec: parsed.audioSec,
+            // 結果音声長を超える不正時刻を再生に使わない。長さ不明（0）は渡さない
+            ...(parsed.audioSec > 0 && { audioSec: parsed.audioSec }),
         });
+        if (extracted.availability === 'unavailable') {
+            logger.warn('要確認候補を作れなかった（本文は完成させる）', { jobId: job.id, reason: extracted.unavailableReason });
+        }
         // 段落アンカーは句 index → phraseId で引く（抽出側の採番関数を使う。ID 形式は推測しない）
         const lineByPhraseId = new Map<string, number>();
         for (const [phraseIndex, line] of phraseLineByIndex) lineByPhraseId.set(phraseIdFor(phraseIndex), line);
-        review = withParagraphAnchors(extracted, lineByPhraseId);
+        review = applyReviewBudget(withParagraphAnchors(extracted, lineByPhraseId));
     } catch (error) {
         logger.warn('要確認候補の生成に失敗（本文は完成させる）', {
             jobId: job.id, reason: error instanceof Error ? error.message : String(error),
         });
         review = buildUnavailableReview(job.id, sourceTextHash, 'internal_error', LOW_CONFIDENCE_THRESHOLD);
     }
-    try {
-        const fitted = fitReviewToDocumentBudget(review, Buffer.byteLength(markdown, 'utf8'));
-        if (fitted.adjustment !== 'none') {
-            logger.warn('要確認候補を保存予算に合わせて調整', {
-                jobId: job.id, adjustment: fitted.adjustment, candidates: review.candidates.length,
-            });
-        }
-        return fitted.review;
-    } catch (error) {
-        logger.warn('要確認候補の保存予算の判定に失敗（候補を省いて本文を完成させる）', {
-            jobId: job.id, reason: error instanceof Error ? error.message : String(error),
+    const markdownBytes = Buffer.byteLength(markdown, 'utf8');
+    if (!reviewFitsDocument(review, markdownBytes)) {
+        logger.warn('要確認候補が文書の保存予算に収まらないため最小形にする', {
+            jobId: job.id, candidates: review.candidates.length, markdownBytes,
         });
-        return undefined;
+        review = buildUnavailableReview(job.id, sourceTextHash, 'storage_budget', LOW_CONFIDENCE_THRESHOLD);
+        if (!reviewFitsDocument(review, markdownBytes)) {
+            logger.warn('最小形でも収まらないため要確認候補を省く（本文は保存する）', { jobId: job.id, markdownBytes });
+            return undefined;
+        }
     }
+    return review;
 }
 
 /**

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -18,6 +18,7 @@ import {
 } from 'firebase/firestore';
 import { getCurrentUserId, getOwnerType } from './auth';
 import type { DocumentProcessingProgress } from './transcribeBatchContract';
+import type { TranscriptReview } from './transcriptReviewContract';
 import { logAudit } from './auditLog';
 import { validateDocumentSize } from './adminSettings';
 import { updateUserStats } from './userManagement';
@@ -50,6 +51,18 @@ const normalizeProcessingProgress = (raw: unknown): DocumentProcessingProgress |
     };
 };
 
+/**
+ * 完成文書に保存された要確認候補（設計 B2）。サーバが生成時に本文と同時に書く。旧文書ではフィールドごと無い。
+ * 読取境界では形の最小確認だけ行い（object かつ version が数値・availability が文字列）、中身の再評価や補正はしない。
+ * 本文との対応は UI 側が sourceTextHash の一致で判定する。
+ */
+const normalizeTranscriptReview = (raw: unknown): TranscriptReview | undefined => {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+    const r = raw as { version?: unknown; availability?: unknown };
+    if (typeof r.version !== 'number' || typeof r.availability !== 'string') return undefined;
+    return raw as TranscriptReview;
+};
+
 export interface TranscriptionDocument {
     id?: string;
     title: string; // 文書タイトル（デフォルトはfileName）
@@ -60,6 +73,8 @@ export interface TranscriptionDocument {
     jobId?: string;
     /** 表示専用の進捗投影（設計 §A3・processing 文書のみ・サーバが書く） */
     processingProgress?: DocumentProcessingProgress;
+    /** 要確認候補（設計 B2・completed 文書のみ・サーバが生成時に書く）。旧文書では無い */
+    transcriptReview?: TranscriptReview;
     promptName: string; // 使用したプロンプト名
     generatedByModel?: string;
     generatedByThinkingLevel?: string;
@@ -83,6 +98,7 @@ export interface Transcription {
     status?: string;
     jobId?: string;
     processingProgress?: DocumentProcessingProgress;
+    transcriptReview?: TranscriptReview;
     promptName: string;
     originalFileType?: string;
     generatedByModel?: string;
@@ -302,6 +318,7 @@ export async function getTranscriptionDocuments(limitCount: number = 20): Promis
                 status: data.status,
                 jobId: data.jobId,
                 processingProgress: normalizeProcessingProgress(data.processingProgress),
+                transcriptReview: normalizeTranscriptReview(data.transcriptReview),
                 promptName: data.promptName || '不明',
                 generatedByModel: data.generatedByModel,
                 generatedByThinkingLevel: data.generatedByThinkingLevel,
@@ -386,6 +403,7 @@ export async function getTranscriptions(
                 status: data.status,
                 jobId: data.jobId,
                 processingProgress: normalizeProcessingProgress(data.processingProgress),
+                transcriptReview: normalizeTranscriptReview(data.transcriptReview),
                 promptName: data.promptName || '不明',
                 originalFileType: data.originalFileType,
                 generatedByModel: data.generatedByModel,
@@ -433,6 +451,7 @@ export async function getTranscriptionsByOwnerId(ownerId: string, limitCount: nu
                 status: data.status,
                 jobId: data.jobId,
                 processingProgress: normalizeProcessingProgress(data.processingProgress),
+                transcriptReview: normalizeTranscriptReview(data.transcriptReview),
                 promptName: data.promptName || '不明',
                 originalFileType: data.originalFileType,
                 generatedByModel: data.generatedByModel,

--- a/src/lib/transcribeApiContract.ts
+++ b/src/lib/transcribeApiContract.ts
@@ -92,6 +92,16 @@ export interface TranscriptAnnotation {
     /** `"spk:0"` など。話者分離が効いていなければ null/undefined */
     speaker?: string | null;
     type?: string;
+    /**
+     * バッチ経路の品質素材（設計 B2・2026-09-05）。同期チャンク経路では付かない。
+     * 🔴 `nBest[0].confidence` の**有限数かつ 0〜1** だけ持つ。欠損・範囲外・非数値は undefined（0 埋め・文字列変換しない）。
+     *    高い値は正確さの保証ではない（話者誤り・発話抜けは検出できない）。
+     */
+    confidence?: number;
+    /** 句の `recognitionStatus`（`Success` 等）。ジョブの status とは別物。未取得は undefined */
+    recognitionStatus?: string;
+    /** 元 `recognizedPhrases` の配列 index。要確認候補の決定的 ID の素材（同一結果の再取り込みで同じ値） */
+    phraseIndex?: number;
 }
 
 /**

--- a/src/lib/transcriptReviewContract.ts
+++ b/src/lib/transcriptReviewContract.ts
@@ -1,0 +1,80 @@
+/**
+ * 「要確認箇所」（低信頼・認識結果要確認の句）のデータ契約（設計 §B2・2026-09-05）。
+ *
+ * 🔴 バッチは部分再実行ができないので、これは「再試行」ではなく**要確認箇所の可視化**の素材。
+ *    Azure 結果の句ごとの confidence / recognitionStatus から生成時に作り、完成文書に保存する。
+ * 🔴 「低信頼＝誤り」「候補ゼロ＝正確」とは表現しない。高信頼の誤りも話者誤り・発話抜けも検出できない。
+ *
+ * この型は 2 レーン（抽出＝pure／永続化＝seam）が共有する凍結契約。両レーンとも編集しない。
+ */
+
+/** 現在の候補抽出・アンカー形式の版。閾値やアンカー方式を変えたら上げる。 */
+export const TRANSCRIPT_REVIEW_VERSION = 1;
+
+/** 低信頼と判定する confidence の暫定閾値（未校正・誤認識の実測境界ではない）。ちょうどは含めない。 */
+export const LOW_CONFIDENCE_THRESHOLD = 0.75;
+
+/** 原文抜粋の初期上限（文字）。超えたら省略フラグを立てる。 */
+export const REVIEW_EXCERPT_MAX_CHARS = 300;
+
+/** 保存する候補の初期上限（件）。UI の初期予算であって Azure の制約ではない。 */
+export const REVIEW_MAX_CANDIDATES = 200;
+
+/** transcriptReview の UTF-8 JSON サイズ上限（バイト）。Firestore 1MiB 文書の一部としての予算。 */
+export const REVIEW_MAX_JSON_BYTES = 128 * 1024;
+
+/** 候補が要確認になった理由。1 句に複数付き得るが件数は 1。 */
+export type ReviewReason =
+    | 'low_confidence'       // recognitionStatus=Success かつ confidence < 閾値
+    | 'recognition_status'   // 既知の非 Success の recognitionStatus
+    | 'empty_text'           // Success だが表示テキストが空
+    | 'unknown_confidence';  // recognitionStatus 不明だが confidence も無く自動評価不能ではない補助
+
+/** 要確認候補 1 件。confidence/時刻/話者は取れたときだけ持つ。 */
+export interface ReviewCandidate {
+    /** 元 recognizedPhrases の配列 index から決定的に採番（同一結果の再取り込みで同じ ID） */
+    phraseId: string;
+    reasons: ReviewReason[];
+    /** 句の原文抜粋（REVIEW_EXCERPT_MAX_CHARS まで）。取得不能なら空文字＋truncated=false */
+    excerpt: string;
+    /** 抜粋が上限で切られたか。実際の認識欠落と混同しない */
+    excerptTruncated: boolean;
+    confidence?: number;
+    recognitionStatus?: string;
+    speaker?: string | null;
+    startSec?: number;
+    endSec?: number;
+    /** 生成 Markdown 上の該当段落の開始行（1 始まり）。対応が確定しない句は付けない */
+    paragraphStartLine?: number;
+}
+
+/** 候補件数の内訳。カテゴリに重複があるため候補総数は ID の和集合で数える。 */
+export interface ReviewSummary {
+    totalPhrases: number;
+    lowConfidence: number;
+    recognitionFlagged: number;
+    /** 重複を除いた候補総数（ID の和集合） */
+    candidateTotal: number;
+    unknownConfidence: number;
+    unknownRecognitionStatus: number;
+    noTimeCandidates: number;
+    /** 実際に保存できた候補件数（上限で減ることがある） */
+    savedCandidates: number;
+}
+
+export type ReviewAvailability = 'complete' | 'partial' | 'unavailable';
+
+/** 完成文書に保存する要確認データ。旧文書ではフィールドごと無い。 */
+export interface TranscriptReview {
+    version: number;
+    threshold: number;
+    /** 保存した生成 Markdown の UTF-8 バイト列に対する SHA-256（改行含む厳密一致判定用） */
+    sourceTextHash: string;
+    /** どの生成結果に属するか（新ジョブと旧候補を混ぜない） */
+    sourceJobId: string;
+    summary: ReviewSummary;
+    availability: ReviewAvailability;
+    /** availability==='unavailable' のときだけ短い理由コード */
+    unavailableReason?: string;
+    candidates: ReviewCandidate[];
+}

--- a/src/server/azureBatchTranscribe.test.ts
+++ b/src/server/azureBatchTranscribe.test.ts
@@ -69,7 +69,10 @@ describe('parseBatchResult', () => {
             startSec: 0.5,
             endSec: 3.5,
             speaker: 'spk:1',
+            phraseIndex: 0,
         }]);
+        expect(parsed.annotations[0]).not.toHaveProperty('confidence');
+        expect(parsed.annotations[0]).not.toHaveProperty('recognitionStatus');
         expect(parsed.droppedPhrases).toBe(0);
     });
 
@@ -139,6 +142,104 @@ describe('parseBatchResult', () => {
         expect(parsed.annotations).toHaveLength(0);
         expect(parsed.audioSec).toBe(0);
         expect(parsed.text).toBe('');
+        expect(parsed.droppedAnnotations).toEqual([]);
+    });
+});
+
+/**
+ * 要確認候補の品質素材（設計 B2）。confidence は有限 0〜1 のときだけ、recognitionStatus は文字列のときだけ載せる。
+ * 欠損・範囲外は undefined のまま（0 埋め・文字列変換しない）。phraseIndex は元配列の index。
+ */
+describe('parseBatchResult の品質素材', () => {
+    const phraseAt = (offsetMs: number, patch: Record<string, unknown> = {}, nBest: Record<string, unknown> = {}) => ({
+        offsetMilliseconds: offsetMs,
+        durationMilliseconds: 1000,
+        speaker: 1,
+        recognitionStatus: 'Success',
+        nBest: [{ display: '合成の句', confidence: 0.9, ...nBest }],
+        ...patch,
+    });
+
+    it('confidence・recognitionStatus・phraseIndex を句ごとに載せる', () => {
+        const parsed = parseBatchResult(sampleResult());
+        expect(parsed.annotations[0]).toMatchObject({ phraseIndex: 0, confidence: 0.9, recognitionStatus: 'Success' });
+        expect(parsed.annotations[1]).toMatchObject({ phraseIndex: 1, confidence: 0.88, recognitionStatus: 'Success' });
+        // 既存の本文・時刻・話者は変わらない
+        expect(parsed.annotations[0]).toMatchObject({ text: 'こんにちは。', startSec: 0.5, endSec: 3.5, speaker: 'spk:1' });
+        expect(parsed.text).toBe('こんにちは。よろしくお願いします。');
+        expect(parsed.droppedAnnotations).toEqual([]);
+    });
+
+    it.each([0, 0.749, 0.75, 1])('境界値 %s の confidence はそのまま載せる（丸めない）', (confidence) => {
+        const parsed = parseBatchResult({ recognizedPhrases: [phraseAt(0, {}, { confidence })] });
+        expect(parsed.annotations[0].confidence).toBe(confidence);
+    });
+
+    it.each([
+        ['欠損', undefined], ['null', null], ['文字列', '0.9'], ['NaN', Number.NaN],
+        ['Infinity', Number.POSITIVE_INFINITY], ['負', -0.01], ['1 超', 1.01],
+    ])('🔴 confidence が%s なら載せない（0 にも高信頼にも置換しない）', (_label, confidence) => {
+        const parsed = parseBatchResult({ recognizedPhrases: [phraseAt(0, {}, { confidence })] });
+        expect(parsed.annotations).toHaveLength(1);
+        expect(parsed.annotations[0]).not.toHaveProperty('confidence');
+        expect(parsed.annotations[0]).toMatchObject({ text: '合成の句', phraseIndex: 0, recognitionStatus: 'Success' });
+    });
+
+    it.each([['欠損', undefined], ['null', null], ['数値', 5]])(
+        'recognitionStatus が%s なら載せない（Success に置換しない）', (_label, recognitionStatus) => {
+            const parsed = parseBatchResult({ recognizedPhrases: [phraseAt(0, { recognitionStatus })] });
+            expect(parsed.annotations[0]).not.toHaveProperty('recognitionStatus');
+            expect(parsed.annotations[0]).toMatchObject({ confidence: 0.9, phraseIndex: 0 });
+        },
+    );
+
+    it('非 Success の recognitionStatus と空の表示テキストもそのまま載せる（正規化しない）', () => {
+        const parsed = parseBatchResult({
+            recognizedPhrases: [phraseAt(0, { recognitionStatus: 'NoMatch' }, { display: '' })],
+        });
+        expect(parsed.annotations[0]).toMatchObject({ text: '', recognitionStatus: 'NoMatch', phraseIndex: 0 });
+    });
+
+    it('nBest が無い句は本文空・confidence 無しで残す', () => {
+        const parsed = parseBatchResult({ recognizedPhrases: [phraseAt(0, { nBest: undefined })] });
+        expect(parsed.annotations[0]).toMatchObject({ text: '', phraseIndex: 0, recognitionStatus: 'Success' });
+        expect(parsed.annotations[0]).not.toHaveProperty('confidence');
+    });
+
+    it('🔴 phraseIndex は元配列の index（前の句が落ちても詰めない）。落ちた句の品質素材は droppedAnnotations に残す', () => {
+        const parsed = parseBatchResult({
+            recognizedPhrases: [
+                // 時刻が読めない（offset 欠落）。品質素材だけ残る
+                { durationMilliseconds: 1000, speaker: 3, recognitionStatus: 'Success', nBest: [{ display: '時刻不明の句', confidence: 0.3 }] },
+                phraseAt(2000),
+            ],
+        });
+        expect(parsed.annotations).toHaveLength(1);
+        expect(parsed.annotations[0]).toMatchObject({ phraseIndex: 1, startSec: 2, endSec: 3 });
+        expect(parsed.droppedPhrases).toBe(1);
+        expect(parsed.droppedAnnotations).toEqual([{
+            text: '時刻不明の句', speaker: 'spk:3', phraseIndex: 0, confidence: 0.3, recognitionStatus: 'Success',
+        }]);
+        expect(parsed.droppedAnnotations[0]).not.toHaveProperty('startSec');
+        expect(parsed.droppedAnnotations[0]).not.toHaveProperty('endSec');
+        // 落ちた句の話者は本文の話者数に数えない（従来どおり）。本文にも載らない
+        expect(parsed.speakers).toBe(1);
+        expect(parsed.text).not.toContain('時刻不明の句');
+    });
+
+    it('droppedAnnotations の件数は常に droppedPhrases と一致する', () => {
+        const parsed = parseBatchResult({
+            recognizedPhrases: [
+                { nBest: [{ display: 'a' }] },
+                phraseAt(0),
+                { offsetMilliseconds: 'invalid', offsetInTicks: 'invalid', nBest: [{ display: 'b' }] },
+                null,
+            ],
+        });
+        expect(parsed.droppedPhrases).toBe(3);
+        expect(parsed.droppedAnnotations).toHaveLength(3);
+        expect(parsed.droppedAnnotations.map((a) => a.phraseIndex)).toEqual([0, 2, 3]);
+        expect(parsed.annotations.map((a) => a.phraseIndex)).toEqual([1]);
     });
 });
 

--- a/src/server/azureBatchTranscribe.ts
+++ b/src/server/azureBatchTranscribe.ts
@@ -175,6 +175,12 @@ export interface ParsedBatch {
     speakers: number;
     /** 単語時刻は落とした語も数える（黙って減らさない） */
     droppedPhrases: number;
+    /**
+     * 時刻が読めず本文・時刻リンクから落とした句の品質素材（text / confidence / recognitionStatus / phraseIndex / speaker・時刻なし）。
+     * 🔴 本文には使わない。要確認候補の集計にだけ使う（設計 B2: 品質集計は時刻不正による除外より前に行い、時刻不明の候補も数える）。
+     *    常に `droppedAnnotations.length === droppedPhrases`。
+     */
+    droppedAnnotations: TranscriptAnnotation[];
 }
 
 /**
@@ -182,6 +188,9 @@ export interface ParsedBatch {
  * 🔴 単語全部を注釈にすると 2 時間で ~15,000 語になり Firestore の 1 MiB ドキュメント上限に当たる。
  *    UI は段落先頭に時刻リンクを張る方式なので、句単位で十分（設計 §6.4・データモデルの注意）。
  * 🔴 時刻が読めなかった句は落とし、件数を返す（0 埋めでカバレッジを偽らない）。
+ * 🔴 品質素材（設計 B2）: `nBest[0].confidence` は有限かつ 0〜1 のときだけ載せる（欠損・範囲外は undefined のまま。0 埋め・
+ *    文字列変換しない）。`recognitionStatus` は文字列のときだけ。`phraseIndex` は元配列の index（要確認候補の決定的 ID の素材）。
+ *    時刻が読めなかった句の品質素材は `droppedAnnotations` に残す（本文には使わない）。
  */
 export function parseBatchResult(result: AzureBatchResult): ParsedBatch {
     const audioSec = (num(result.durationMilliseconds) ?? 0) / 1000;
@@ -190,31 +199,44 @@ export function parseBatchResult(result: AzureBatchResult): ParsedBatch {
         : [];
 
     const annotations: TranscriptAnnotation[] = [];
+    const droppedAnnotations: TranscriptAnnotation[] = [];
     const speakerSet = new Set<string>();
     let droppedPhrases = 0;
 
-    for (const phrase of phrases) {
-        const offsetTicks = num(asRecord(phrase)?.offsetInTicks);
-        const durationTicks = num(asRecord(phrase)?.durationInTicks);
+    for (let phraseIndex = 0; phraseIndex < phrases.length; phraseIndex += 1) {
+        const phrase = asRecord(phrases[phraseIndex]);
+        const nBest = Array.isArray(phrase?.nBest) ? (phrase.nBest[0] as AzureBatchNBest | undefined) : undefined;
+        const text = str(nBest?.display) ?? '';
+        const confidence = num(nBest?.confidence);
+        const recognitionStatus = str(phrase?.recognitionStatus);
+        const speaker = num(phrase?.speaker);
+        const speakerLabel = speaker !== undefined ? `spk:${speaker}` : null;
+        // 品質素材は時刻の可否より前に確定する（時刻不明の句も要確認候補の集計に含めるため）
+        const quality: TranscriptAnnotation = {
+            text,
+            speaker: speakerLabel,
+            phraseIndex,
+            ...(confidence !== undefined && confidence >= 0 && confidence <= 1 && { confidence }),
+            ...(recognitionStatus !== undefined && { recognitionStatus }),
+        };
+
+        const offsetTicks = num(phrase?.offsetInTicks);
+        const durationTicks = num(phrase?.durationInTicks);
         // Azure の ticks は 100 ns 単位。ms が読めなければ ticks から補う。
-        const offsetMs = num(phrase.offsetMilliseconds)
+        const offsetMs = num(phrase?.offsetMilliseconds)
             ?? (offsetTicks !== undefined ? offsetTicks / 10_000 : undefined);
-        const durationMs = num(phrase.durationMilliseconds)
+        const durationMs = num(phrase?.durationMilliseconds)
             ?? (durationTicks !== undefined ? durationTicks / 10_000 : undefined);
         if (offsetMs === undefined || durationMs === undefined) {
             droppedPhrases += 1;
+            droppedAnnotations.push(quality);
             continue;
         }
-        const nBest = Array.isArray(phrase.nBest) ? (phrase.nBest[0] as AzureBatchNBest | undefined) : undefined;
-        const text = str(nBest?.display) ?? '';
-        const speaker = num(phrase.speaker);
-        const speakerLabel = speaker !== undefined ? `spk:${speaker}` : null;
         if (speakerLabel) speakerSet.add(speakerLabel);
         annotations.push({
-            text,
+            ...quality,
             startSec: offsetMs / 1000,
             endSec: (offsetMs + durationMs) / 1000,
-            speaker: speakerLabel,
         });
     }
 
@@ -235,5 +257,6 @@ export function parseBatchResult(result: AzureBatchResult): ParsedBatch {
         audioSec,
         speakers: speakerSet.size,
         droppedPhrases,
+        droppedAnnotations,
     };
 }

--- a/src/server/finalizeTranscription.test.ts
+++ b/src/server/finalizeTranscription.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import type { TranscriptAnnotation } from '@/lib/transcribeApiContract';
+import {
+    LOW_CONFIDENCE_THRESHOLD,
+    REVIEW_MAX_JSON_BYTES,
+    TRANSCRIPT_REVIEW_VERSION,
+    type ReviewCandidate,
+    type TranscriptReview,
+} from '@/lib/transcriptReviewContract';
+import type { ParsedBatch } from './azureBatchTranscribe';
+import {
+    buildTranscriptMarkdownFromBatch,
+    buildTranscriptWithAnchors,
+    DOCUMENT_OVERHEAD_HEADROOM_BYTES,
+    FIRESTORE_MAX_DOCUMENT_BYTES,
+    fitReviewToDocumentBudget,
+    sourceTextHashOf,
+    withParagraphAnchors,
+} from './finalizeTranscription';
+import { buildUnavailableReview } from './reviewCandidates';
+
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
+vi.mock('@/lib/logger', () => ({ createLogger: () => ({ warn: warnMock, info: vi.fn(), error: vi.fn() }) }));
+
+/** 合成の句（架空の会話）。phraseIndex は元 recognizedPhrases の配列 index。 */
+const phrase = (
+    phraseIndex: number,
+    text: string,
+    startSec: number,
+    endSec: number,
+    speaker: string | null,
+    extra: Partial<TranscriptAnnotation> = {},
+): TranscriptAnnotation => ({ text, startSec, endSec, speaker, phraseIndex, ...extra });
+
+const parsedOf = (annotations: TranscriptAnnotation[], patch: Partial<ParsedBatch> = {}): ParsedBatch => ({
+    status: 'completed',
+    text: annotations.map((a) => a.text ?? '').join('\n'),
+    annotations,
+    audioSec: 60,
+    speakers: 2,
+    droppedPhrases: 0,
+    droppedAnnotations: [],
+    ...patch,
+});
+
+const twoSpeakers = (): ParsedBatch => parsedOf([
+    phrase(0, 'こんにちは。', 0.5, 2, 'spk:1'),
+    phrase(1, '本日はよろしくお願いします。', 2, 4, 'spk:1'),
+    phrase(2, 'こちらこそ。', 4.2, 5, 'spk:2'),
+    phrase(3, 'では始めます。', 5.5, 7, 'spk:1'),
+    phrase(4, '資料をご覧ください。', 7, 9, 'spk:1'),
+]);
+
+describe('buildTranscriptWithAnchors', () => {
+    it('Markdown は buildTranscriptMarkdownFromBatch と同一（見た目の回帰なし）', () => {
+        const parsed = twoSpeakers();
+        expect(buildTranscriptWithAnchors(parsed).markdown).toBe(buildTranscriptMarkdownFromBatch(parsed));
+    });
+
+    it('同一話者の連続句は 1 段落に畳まれ、各句はその段落の開始行（1 始まり）に対応する', () => {
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(twoSpeakers());
+        const lines = markdown.split('\n');
+        // 段落は空行 1 行で区切られる: 1 行目 spk:1、3 行目 spk:2、5 行目 spk:1
+        expect(lines).toHaveLength(5);
+        expect(lines[0]).toBe('[00:00](#t=0) **spk:1** こんにちは。本日はよろしくお願いします。');
+        expect(lines[1]).toBe('');
+        expect(lines[2]).toBe('[00:04](#t=4) **spk:2** こちらこそ。');
+        expect(lines[3]).toBe('');
+        expect(lines[4]).toBe('[00:05](#t=5) **spk:1** では始めます。資料をご覧ください。');
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [1, 1], [2, 3], [3, 5], [4, 5]]);
+    });
+
+    it('話者ラベルの無い句も段落として対応する', () => {
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf([
+            phrase(0, '話者なしの句', 0, 1, null),
+            phrase(1, '続きの句', 1, 2, null),
+        ], { speakers: 0 }));
+        expect(markdown).toBe('[00:00](#t=0) 話者なしの句続きの句');
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [1, 1]]);
+    });
+
+    it('英数字の境目に空白が入る段落でも対応は段落開始行', () => {
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf([
+            phrase(0, 'ABC', 0, 1, 'spk:1'),
+            phrase(1, 'DEF', 1, 2, 'spk:1'),
+        ]));
+        expect(markdown).toBe('[00:00](#t=0) **spk:1** ABC DEF');
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [1, 1]]);
+    });
+
+    it('空の表示テキストの句も段落に属し対応を持つ（empty_text 候補の移動先）', () => {
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf([
+            phrase(0, '', 0, 1, 'spk:1'),
+            phrase(1, '本文', 1, 2, 'spk:2'),
+        ]));
+        expect(markdown.split('\n')[0]).toBe('[00:00](#t=0) **spk:1** ');
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [1, 3]]);
+    });
+
+    it('🔴 本文に改行を含む段落の句には対応を付けず、後続の段落の行番号はずらさない', () => {
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf([
+            phrase(0, '一段落目。', 0, 1, 'spk:1'),
+            phrase(1, '改行を\n含む句。', 1, 2, 'spk:2'),
+            phrase(2, '三段落目。', 2, 3, 'spk:1'),
+        ]));
+        const lines = markdown.split('\n');
+        // 2 段落目は 2 行（3・4 行目）。空行を挟んで 3 段落目は 6 行目
+        expect(lines[2]).toBe('[00:01](#t=1) **spk:2** 改行を');
+        expect(lines[3]).toBe('含む句。');
+        expect(lines[4]).toBe('');
+        expect(lines[5]).toBe('[00:02](#t=2) **spk:1** 三段落目。');
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [2, 6]]);
+    });
+
+    it('同一話者の連続句のどこかに改行があれば、その段落全体の句に対応を付けない', () => {
+        const { phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf([
+            phrase(0, '先頭。', 0, 1, 'spk:1'),
+            phrase(1, '途中\n改行。', 1, 2, 'spk:1'),
+            phrase(2, '次の話者。', 2, 3, 'spk:2'),
+        ]));
+        expect([...phraseLineByIndex.entries()]).toEqual([[2, 4]]);
+    });
+
+    it('phraseIndex の無い注釈は対応に入れない（他の句は付ける）', () => {
+        const { phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf([
+            { text: '旧形式の注釈', startSec: 0, endSec: 1, speaker: 'spk:1' },
+            phrase(7, '新形式の句', 1, 2, 'spk:2'),
+        ]));
+        expect([...phraseLineByIndex.entries()]).toEqual([[7, 3]]);
+    });
+
+    it('結合で捨てられる句（中点がチャンク開始より前）は対応に入れず、残りの行は正しい', () => {
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf([
+            phrase(0, '負の時刻の句', -5, -1, 'spk:1'),
+            phrase(1, '有効な句', 0, 1, 'spk:1'),
+        ]));
+        expect(markdown).toBe('[00:00](#t=0) **spk:1** 有効な句');
+        expect([...phraseLineByIndex.entries()]).toEqual([[1, 1]]);
+    });
+
+    it('注釈が無ければ空の Markdown と空の対応', () => {
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf([], { speakers: 0 }));
+        expect(markdown).toBe('');
+        expect(phraseLineByIndex.size).toBe(0);
+    });
+
+    it('多数の段落でも行番号が実際の行と一致する（検算）', () => {
+        const annotations = Array.from({ length: 200 }, (_, i) => phrase(i, `句${i}。`, i, i + 1, `spk:${i % 3}`));
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf(annotations, { speakers: 3 }));
+        const lines = markdown.split('\n');
+        expect(phraseLineByIndex.size).toBe(200);
+        for (const [phraseIndex, line] of phraseLineByIndex) {
+            expect(lines[line - 1]).toBe(`[${String(Math.floor(phraseIndex / 60)).padStart(2, '0')}:${String(phraseIndex % 60).padStart(2, '0')}](#t=${phraseIndex}) **spk:${phraseIndex % 3}** 句${phraseIndex}。`);
+        }
+    });
+
+    it('アンカー算出の内部エラーは本文に影響させず、警告して対応なしにする（設計 B4）', () => {
+        const poisoned = new Proxy(phrase(1, '句', 1, 2, 'spk:1'), {
+            get: (target, key) => {
+                if (key === 'phraseIndex') throw new Error('合成の内部エラー');
+                return Reflect.get(target, key);
+            },
+        });
+        const parsed = parsedOf([phrase(0, '先頭', 0, 1, 'spk:2'), poisoned]);
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+        expect(markdown).toBe(buildTranscriptMarkdownFromBatch(parsed));
+        expect(phraseLineByIndex.size).toBe(0);
+        expect(warnMock).toHaveBeenCalledWith('段落アンカーの算出に失敗（本文は保存・アンカー無し）', { reason: '合成の内部エラー' });
+    });
+});
+
+describe('sourceTextHashOf', () => {
+    it('UTF-8 バイト列の SHA-256（hex）', () => {
+        expect(sourceTextHashOf('')).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+        expect(sourceTextHashOf('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+        expect(sourceTextHashOf('日本語\n')).toBe(createHash('sha256').update(Buffer.from('日本語\n', 'utf8')).digest('hex'));
+    });
+
+    it('改行 1 文字の違いでも一致しない（本文の厳密一致判定用）', () => {
+        expect(sourceTextHashOf('本文')).not.toBe(sourceTextHashOf('本文\n'));
+    });
+});
+
+const candidate = (phraseId: string, patch: Partial<ReviewCandidate> = {}): ReviewCandidate => ({
+    phraseId,
+    reasons: ['low_confidence'],
+    excerpt: `抜粋 ${phraseId}`,
+    excerptTruncated: false,
+    ...patch,
+});
+
+const reviewOf = (candidates: ReviewCandidate[], patch: Partial<TranscriptReview> = {}): TranscriptReview => ({
+    version: TRANSCRIPT_REVIEW_VERSION,
+    threshold: LOW_CONFIDENCE_THRESHOLD,
+    sourceTextHash: 'f'.repeat(64),
+    sourceJobId: 'synthetic-job',
+    summary: {
+        totalPhrases: 10,
+        lowConfidence: candidates.length,
+        recognitionFlagged: 0,
+        candidateTotal: candidates.length,
+        unknownConfidence: 0,
+        unknownRecognitionStatus: 0,
+        noTimeCandidates: 0,
+        savedCandidates: candidates.length,
+    },
+    availability: 'complete',
+    candidates,
+    ...patch,
+});
+
+const jsonBytes = (value: unknown): number => Buffer.byteLength(JSON.stringify(value), 'utf8');
+
+describe('withParagraphAnchors', () => {
+    it('対応のある候補にだけ paragraphStartLine を付け、順序・件数・他の項目は変えない', () => {
+        const review = reviewOf([candidate('p0'), candidate('p1'), candidate('p2')]);
+        const result = withParagraphAnchors(review, new Map([['p0', 1], ['p2', 5], ['p9', 7]]));
+        expect(result.candidates.map((c) => c.paragraphStartLine)).toEqual([1, undefined, 5]);
+        expect(result.candidates[1]).not.toHaveProperty('paragraphStartLine');
+        expect(result.candidates.map((c) => c.phraseId)).toEqual(['p0', 'p1', 'p2']);
+        expect(result.summary).toEqual(review.summary);
+        expect(result.availability).toBe('complete');
+        // 入力は変更しない
+        expect(review.candidates[0]).not.toHaveProperty('paragraphStartLine');
+    });
+});
+
+describe('fitReviewToDocumentBudget', () => {
+    it('予算内なら内容そのまま（none）。undefined 値だけ落とす（Admin SDK は undefined を拒否する）', () => {
+        const review = reviewOf([candidate('p0', { paragraphStartLine: 3, confidence: undefined })]);
+        const fitted = fitReviewToDocumentBudget(review, 10_000);
+        expect(fitted.adjustment).toBe('none');
+        expect(fitted.review).toEqual(reviewOf([candidate('p0', { paragraphStartLine: 3 })]));
+        expect(fitted.review?.candidates[0]).not.toHaveProperty('confidence');
+        expect(JSON.stringify(fitted.review)).toBe(JSON.stringify(review));
+    });
+
+    it('🔴 アンカー込みで 128 KiB を超えるなら抽出側の規則で末尾候補を落とし partial にする（総件数とアンカーは保つ）', () => {
+        // 抽出側の予算（アンカー無し）ちょうど 128 KiB に合わせ、アンカーを足すと超える形を作る
+        const base = Array.from({ length: 100 }, (_, i) => candidate(`p${i}`, { excerpt: 'あ'.repeat(100), startSec: i, endSec: i + 1 }));
+        const padding = REVIEW_MAX_JSON_BYTES - jsonBytes(reviewOf(base));
+        expect(padding).toBeGreaterThan(0);
+        const padded = reviewOf(base.map((c, i) => i === 0 ? { ...c, excerpt: c.excerpt + 'x'.repeat(padding) } : c));
+        expect(jsonBytes(padded)).toBe(REVIEW_MAX_JSON_BYTES);
+        const anchored = withParagraphAnchors(padded, new Map(base.map((c, i) => [c.phraseId, i * 2 + 1] as const)));
+        expect(jsonBytes(anchored)).toBeGreaterThan(REVIEW_MAX_JSON_BYTES);
+
+        const fitted = fitReviewToDocumentBudget(anchored, 10_000);
+        expect(fitted.adjustment).toBe('trimmed');
+        const saved = fitted.review!;
+        expect(saved.availability).toBe('partial');
+        expect(saved.candidates.length).toBeLessThan(100);
+        expect(saved.candidates.length).toBeGreaterThan(0);
+        expect(saved.summary.savedCandidates).toBe(saved.candidates.length);
+        expect(saved.summary.candidateTotal).toBe(100);
+        // 先頭からの並びを保ち、残った候補のアンカーは残る
+        expect(saved.candidates.map((c) => c.phraseId)).toEqual(anchored.candidates.slice(0, saved.candidates.length).map((c) => c.phraseId));
+        expect(saved.candidates.every((c) => typeof c.paragraphStartLine === 'number')).toBe(true);
+        expect(jsonBytes(saved)).toBeLessThanOrEqual(REVIEW_MAX_JSON_BYTES);
+    });
+
+    it('unavailable はそのまま通す（summary(0) を complete に化けさせない）', () => {
+        const unavailable = buildUnavailableReview('synthetic-job', 'f'.repeat(64), 'internal_error');
+        expect(fitReviewToDocumentBudget(unavailable, 10_000)).toEqual({ review: unavailable, adjustment: 'none' });
+    });
+
+    it('本文＋候補＋見込みが Firestore 上限を超えるなら unavailable（storage_budget）。本文は切り詰めない', () => {
+        const review = reviewOf([candidate('p0', { paragraphStartLine: 1 })]);
+        const limit = FIRESTORE_MAX_DOCUMENT_BYTES - DOCUMENT_OVERHEAD_HEADROOM_BYTES;
+        // ちょうど収まる
+        expect(fitReviewToDocumentBudget(review, limit - jsonBytes(review)).adjustment).toBe('none');
+        // 1 バイト超えると最小形へ
+        const fitted = fitReviewToDocumentBudget(review, limit - jsonBytes(review) + 1);
+        expect(fitted.adjustment).toBe('unavailable');
+        expect(fitted.review).toEqual(buildUnavailableReview('synthetic-job', 'f'.repeat(64), 'storage_budget', LOW_CONFIDENCE_THRESHOLD));
+    });
+
+    it('最小形でも収まらなければ review 自体を省く（omitted）', () => {
+        const review = reviewOf([candidate('p0')]);
+        const fitted = fitReviewToDocumentBudget(review, FIRESTORE_MAX_DOCUMENT_BYTES - DOCUMENT_OVERHEAD_HEADROOM_BYTES);
+        expect(fitted).toEqual({ review: undefined, adjustment: 'omitted' });
+    });
+});

--- a/src/server/finalizeTranscription.test.ts
+++ b/src/server/finalizeTranscription.test.ts
@@ -14,7 +14,7 @@ import {
     buildTranscriptWithAnchors,
     DOCUMENT_OVERHEAD_HEADROOM_BYTES,
     FIRESTORE_MAX_DOCUMENT_BYTES,
-    fitReviewToDocumentBudget,
+    reviewFitsDocument,
     sourceTextHashOf,
     withParagraphAnchors,
 } from './finalizeTranscription';
@@ -226,59 +226,27 @@ describe('withParagraphAnchors', () => {
     });
 });
 
-describe('fitReviewToDocumentBudget', () => {
-    it('予算内なら内容そのまま（none）。undefined 値だけ落とす（Admin SDK は undefined を拒否する）', () => {
-        const review = reviewOf([candidate('p0', { paragraphStartLine: 3, confidence: undefined })]);
-        const fitted = fitReviewToDocumentBudget(review, 10_000);
-        expect(fitted.adjustment).toBe('none');
-        expect(fitted.review).toEqual(reviewOf([candidate('p0', { paragraphStartLine: 3 })]));
-        expect(fitted.review?.candidates[0]).not.toHaveProperty('confidence');
-        expect(JSON.stringify(fitted.review)).toBe(JSON.stringify(review));
-    });
+describe('reviewFitsDocument', () => {
+    const limit = FIRESTORE_MAX_DOCUMENT_BYTES - DOCUMENT_OVERHEAD_HEADROOM_BYTES;
 
-    it('🔴 アンカー込みで 128 KiB を超えるなら抽出側の規則で末尾候補を落とし partial にする（総件数とアンカーは保つ）', () => {
-        // 抽出側の予算（アンカー無し）ちょうど 128 KiB に合わせ、アンカーを足すと超える形を作る
-        const base = Array.from({ length: 100 }, (_, i) => candidate(`p${i}`, { excerpt: 'あ'.repeat(100), startSec: i, endSec: i + 1 }));
-        const padding = REVIEW_MAX_JSON_BYTES - jsonBytes(reviewOf(base));
-        expect(padding).toBeGreaterThan(0);
-        const padded = reviewOf(base.map((c, i) => i === 0 ? { ...c, excerpt: c.excerpt + 'x'.repeat(padding) } : c));
-        expect(jsonBytes(padded)).toBe(REVIEW_MAX_JSON_BYTES);
-        const anchored = withParagraphAnchors(padded, new Map(base.map((c, i) => [c.phraseId, i * 2 + 1] as const)));
-        expect(jsonBytes(anchored)).toBeGreaterThan(REVIEW_MAX_JSON_BYTES);
-
-        const fitted = fitReviewToDocumentBudget(anchored, 10_000);
-        expect(fitted.adjustment).toBe('trimmed');
-        const saved = fitted.review!;
-        expect(saved.availability).toBe('partial');
-        expect(saved.candidates.length).toBeLessThan(100);
-        expect(saved.candidates.length).toBeGreaterThan(0);
-        expect(saved.summary.savedCandidates).toBe(saved.candidates.length);
-        expect(saved.summary.candidateTotal).toBe(100);
-        // 先頭からの並びを保ち、残った候補のアンカーは残る
-        expect(saved.candidates.map((c) => c.phraseId)).toEqual(anchored.candidates.slice(0, saved.candidates.length).map((c) => c.phraseId));
-        expect(saved.candidates.every((c) => typeof c.paragraphStartLine === 'number')).toBe(true);
-        expect(jsonBytes(saved)).toBeLessThanOrEqual(REVIEW_MAX_JSON_BYTES);
-    });
-
-    it('unavailable はそのまま通す（summary(0) を complete に化けさせない）', () => {
-        const unavailable = buildUnavailableReview('synthetic-job', 'f'.repeat(64), 'internal_error');
-        expect(fitReviewToDocumentBudget(unavailable, 10_000)).toEqual({ review: unavailable, adjustment: 'none' });
-    });
-
-    it('本文＋候補＋見込みが Firestore 上限を超えるなら unavailable（storage_budget）。本文は切り詰めない', () => {
+    it('本文＋候補 JSON＋見込みが 1 MiB 以内なら収まる。1 バイト超えると収まらない', () => {
         const review = reviewOf([candidate('p0', { paragraphStartLine: 1 })]);
-        const limit = FIRESTORE_MAX_DOCUMENT_BYTES - DOCUMENT_OVERHEAD_HEADROOM_BYTES;
-        // ちょうど収まる
-        expect(fitReviewToDocumentBudget(review, limit - jsonBytes(review)).adjustment).toBe('none');
-        // 1 バイト超えると最小形へ
-        const fitted = fitReviewToDocumentBudget(review, limit - jsonBytes(review) + 1);
-        expect(fitted.adjustment).toBe('unavailable');
-        expect(fitted.review).toEqual(buildUnavailableReview('synthetic-job', 'f'.repeat(64), 'storage_budget', LOW_CONFIDENCE_THRESHOLD));
+        expect(reviewFitsDocument(review, limit - jsonBytes(review))).toBe(true);
+        expect(reviewFitsDocument(review, limit - jsonBytes(review) + 1)).toBe(false);
     });
 
-    it('最小形でも収まらなければ review 自体を省く（omitted）', () => {
-        const review = reviewOf([candidate('p0')]);
-        const fitted = fitReviewToDocumentBudget(review, FIRESTORE_MAX_DOCUMENT_BYTES - DOCUMENT_OVERHEAD_HEADROOM_BYTES);
-        expect(fitted).toEqual({ review: undefined, adjustment: 'omitted' });
+    it('候補を全部載せられない本文長でも unavailable の最小形なら収まる（最小形も無理なら false）', () => {
+        const full = reviewOf(Array.from({ length: 50 }, (_, i) => candidate(`p${i}`, { excerpt: 'あ'.repeat(100) })));
+        const minimal = buildUnavailableReview('synthetic-job', 'f'.repeat(64), 'storage_budget', LOW_CONFIDENCE_THRESHOLD);
+        const markdownBytes = limit - jsonBytes(minimal);
+        expect(reviewFitsDocument(full, markdownBytes)).toBe(false);
+        expect(reviewFitsDocument(minimal, markdownBytes)).toBe(true);
+        expect(reviewFitsDocument(minimal, markdownBytes + 1)).toBe(false);
+    });
+
+    it('候補の予算（200 件・128 KiB）はここでは判定しない（applyReviewBudget が単一の正）', () => {
+        const huge = reviewOf(Array.from({ length: 300 }, (_, i) => candidate(`p${i}`, { excerpt: 'い'.repeat(300) })));
+        expect(jsonBytes(huge)).toBeGreaterThan(REVIEW_MAX_JSON_BYTES);
+        expect(reviewFitsDocument(huge, 10_000)).toBe(true);
     });
 });

--- a/src/server/finalizeTranscription.test.ts
+++ b/src/server/finalizeTranscription.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createHash } from 'node:crypto';
+import remarkGfm from 'remark-gfm';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
 import type { TranscriptAnnotation } from '@/lib/transcribeApiContract';
 import {
     LOW_CONFIDENCE_THRESHOLD,
@@ -43,6 +46,58 @@ const parsedOf = (annotations: TranscriptAnnotation[], patch: Partial<ParsedBatc
     droppedAnnotations: [],
     ...patch,
 });
+
+/** 描画側（micromark）と同じ改行規則で行に分ける。CRLF・単独 CR・LF はいずれも 1 改行。 */
+const splitLines = (markdown: string): string[] => markdown.split(/\r\n?|\n/);
+
+interface RenderedBlock {
+    type: string;
+    startLine: number;
+    endLine: number;
+    /** 段落なら先頭の子要素の種類（時刻リンクなら 'link'） */
+    firstChildType?: string;
+    /** 先頭の子要素がリンクならその URL（`#t=<秒>`） */
+    firstChildUrl?: string;
+}
+
+/**
+ * 描画側（MarkdownDocument: react-markdown + remark-gfm）と同じ構文解析（unified + remark-parse + remark-gfm）で
+ * ブロックの種類と開始行を得る。アンカーが「描画上の段落」と一致することの検算に使う。
+ */
+const renderedBlocksOf = (markdown: string): RenderedBlock[] => {
+    const root = unified().use(remarkParse).use(remarkGfm).parse(markdown);
+    return root.children.map((node) => {
+        const first = node.type === 'paragraph' ? node.children[0] : undefined;
+        return {
+            type: node.type,
+            startLine: node.position?.start.line ?? -1,
+            endLine: node.position?.end.line ?? -1,
+            firstChildType: first?.type,
+            firstChildUrl: first?.type === 'link' ? first.url : undefined,
+        };
+    });
+};
+
+/**
+ * 対応の付いた句ごとに、その行から始まる描画上の段落が存在し、先頭が元の句の開始秒の時刻リンクであることを確かめる。
+ * 描画側の構文解析に対する検算（文字列上の行番号だけでなく、実際にその行が段落として描かれること）。
+ */
+const expectAnchorsToMatchRenderedParagraphs = (parsed: ParsedBatch): void => {
+    const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+    const blocks = renderedBlocksOf(markdown);
+    for (const [phraseIndex, line] of phraseLineByIndex) {
+        const annotation = parsed.annotations.find((a) => a.phraseIndex === phraseIndex);
+        expect(annotation, `phraseIndex ${phraseIndex} の句`).toBeDefined();
+        const block = blocks.find((b) => b.startLine === line);
+        expect(block, `${line} 行目から始まるブロック（phraseIndex ${phraseIndex}）`).toMatchObject({
+            type: 'paragraph',
+            firstChildType: 'link',
+        });
+        // 段落の先頭の時刻リンクは、その段落の開始秒（= 段落先頭の句の開始秒）。句は段落内のどこかにあるので開始秒以下
+        const seconds = Number(/^#t=(\d+)$/.exec(block?.firstChildUrl ?? '')?.[1]);
+        expect(seconds).toBeLessThanOrEqual(Math.floor(annotation?.startSec ?? Number.NEGATIVE_INFINITY));
+    }
+};
 
 const twoSpeakers = (): ParsedBatch => parsedOf([
     phrase(0, 'こんにちは。', 0.5, 2, 'spk:1'),
@@ -167,6 +222,142 @@ describe('buildTranscriptWithAnchors', () => {
         expect(markdown).toBe(buildTranscriptMarkdownFromBatch(parsed));
         expect(phraseLineByIndex.size).toBe(0);
         expect(warnMock).toHaveBeenCalledWith('段落アンカーの算出に失敗（本文は保存・アンカー無し）', { reason: '合成の内部エラー' });
+    });
+});
+
+/** 話者を交互にして、句ごとに 1 段落になる合成入力 */
+const alternating = (texts: string[]): ParsedBatch =>
+    parsedOf(texts.map((text, i) => phrase(i, text, i, i + 1, `spk:${(i % 2) + 1}`)));
+
+describe('buildTranscriptWithAnchors: 行の数え方と Markdown 構文（アンカーの堅牢性）', () => {
+    it('対応の付いた句は、描画側と同じ構文解析でもその行から始まる段落になる（話者交替のプレーンな段落）', () => {
+        expectAnchorsToMatchRenderedParagraphs(twoSpeakers());
+        const many = Array.from({ length: 120 }, (_, i) => phrase(i, `句${i}。`, i, i + 1, `spk:${i % 3}`));
+        expectAnchorsToMatchRenderedParagraphs(parsedOf(many, { speakers: 3 }));
+    });
+
+    it('🔴 CRLF を含む本文: 行は CRLF を 1 改行として数え、その句には付けず、後続の段落は正しい行', () => {
+        const parsed = alternating(['一段落目。', '一行目\r\n二行目', '三段落目。']);
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+        expect(markdown).toBe(buildTranscriptMarkdownFromBatch(parsed));
+        const lines = splitLines(markdown);
+        expect(lines).toHaveLength(6);
+        expect(lines[2]).toBe('[00:01](#t=1) **spk:2** 一行目');
+        expect(lines[3]).toBe('二行目');
+        expect(lines[4]).toBe('');
+        expect(lines[5]).toBe('[00:02](#t=2) **spk:1** 三段落目。');
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [2, 6]]);
+        expectAnchorsToMatchRenderedParagraphs(parsed);
+    });
+
+    it('🔴 単独 CR を含む本文: Markdown は CR も改行として扱うので、LF だけを数えた行番号（5）ではなく 6 行目に対応する', () => {
+        const parsed = alternating(['一段落目。', '一行目\r二行目', '三段落目。']);
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+        expect(splitLines(markdown)[5]).toBe('[00:02](#t=2) **spk:1** 三段落目。');
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [2, 6]]);
+        // 描画側の構文解析でも 3 段落目は 6 行目から始まる（5 行目からではない）
+        expect(renderedBlocksOf(markdown).map((b) => [b.type, b.startLine])).toEqual([
+            ['paragraph', 1], ['paragraph', 3], ['paragraph', 6],
+        ]);
+        expectAnchorsToMatchRenderedParagraphs(parsed);
+    });
+
+    it('🔴 本文末尾の CR は区切りの LF と合流して 1 つの CRLF になる（後続の行番号を 1 多く数えない）', () => {
+        const parsed = alternating(['一段落目。', '末尾がCR\r', '三段落目。']);
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+        expect(markdown).toBe('[00:00](#t=0) **spk:1** 一段落目。\n\n[00:01](#t=1) **spk:2** 末尾がCR\r\n\n[00:02](#t=2) **spk:1** 三段落目。');
+        const lines = splitLines(markdown);
+        expect(lines).toHaveLength(5);
+        expect(lines[4]).toBe('[00:02](#t=2) **spk:1** 三段落目。');
+        // CR を含む句は付けない（保守的）。後続は 6 行目ではなく 5 行目
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [2, 5]]);
+        expect(renderedBlocksOf(markdown).map((b) => [b.type, b.startLine])).toEqual([
+            ['paragraph', 1], ['paragraph', 3], ['paragraph', 5],
+        ]);
+        expectAnchorsToMatchRenderedParagraphs(parsed);
+    });
+
+    it('🔴 Markdown の目印になり得る本文（フェンス・先頭の # > - 数字. | ・<）の句には付けず、後続の段落は正しい行', () => {
+        const parsed = alternating([
+            'プレーン。',
+            '```',
+            '# 見出しに見える',
+            '> 引用に見える',
+            '- 箇条書きに見える',
+            '1. 番号付きに見える',
+            '| 表に見える |',
+            'a<b',
+            '最後もプレーン。',
+        ]);
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+        expect(markdown).toBe(buildTranscriptMarkdownFromBatch(parsed));
+        const lines = splitLines(markdown);
+        expect(lines).toHaveLength(17);
+        expect(lines[16]).toBe('[00:08](#t=8) **spk:1** 最後もプレーン。');
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [8, 17]]);
+        // 時刻リンクで始まる 1 行の段落は描画上は全て段落（省略は保守的な判定）。後続の行番号は汚れない
+        expect(renderedBlocksOf(markdown).map((b) => b.type)).toEqual(Array(9).fill('paragraph'));
+        expectAnchorsToMatchRenderedParagraphs(parsed);
+    });
+
+    it('目印にならない書き方（小数点・語中のハイフン・文中の # や *）はプレーンな段落として付ける', () => {
+        const parsed = alternating(['3.5パーセント', 'Wi-Fi の設定', 'ハッシュ #1 番', '-5度から 2*3 まで']);
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1], [1, 3], [2, 5], [3, 7]]);
+        expect(renderedBlocksOf(markdown).map((b) => b.type)).toEqual(Array(4).fill('paragraph'));
+        expectAnchorsToMatchRenderedParagraphs(parsed);
+    });
+
+    it('🔴 改行を含む段落の続きの行がコードフェンスを開き得るなら、以降の段落は全て付けない（描画上は段落でない）', () => {
+        const parsed = alternating(['一段落目。', '説明\n```', '三段落目。', '四段落目。']);
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+        expect(markdown).toBe(buildTranscriptMarkdownFromBatch(parsed));
+        // 文字列上は 3 段落目が 6 行目にあるが、閉じていないフェンスが文末まで飲み込むので描画上は段落でない
+        expect(splitLines(markdown)[5]).toBe('[00:02](#t=2) **spk:1** 三段落目。');
+        expect(renderedBlocksOf(markdown).map((b) => [b.type, b.startLine, b.endLine])).toEqual([
+            ['paragraph', 1, 1], ['paragraph', 3, 3], ['code', 4, 8],
+        ]);
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1]]);
+    });
+
+    it('🔴 改行を含む段落の続きの行が HTML ブロック（<script / <!--）を開き得る場合も、以降の段落は全て付けない', () => {
+        for (const opener of ['<script>', '<!-- コメント', '  <pre>']) {
+            const parsed = alternating(['一段落目。', `説明\n${opener}`, '三段落目。']);
+            const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+            expect(renderedBlocksOf(markdown).map((b) => b.type), opener).toEqual(['paragraph', 'paragraph', 'html']);
+            expect([...phraseLineByIndex.entries()], opener).toEqual([[0, 1]]);
+        }
+    });
+
+    it('続きの行が `<` で始まれば HTML ブロックの種類を見ずに保守的に以降を付けない（<div> は空行で終わるが同じ扱い）', () => {
+        const parsed = alternating(['一段落目。', '説明\n<div>', '三段落目。']);
+        const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+        expect(renderedBlocksOf(markdown).map((b) => [b.type, b.startLine])).toEqual([
+            ['paragraph', 1], ['paragraph', 3], ['html', 4], ['paragraph', 6],
+        ]);
+        expect([...phraseLineByIndex.entries()]).toEqual([[0, 1]]);
+    });
+
+    it('改行を含む段落でも、続きの行の構文が空行で終わる（引用・箇条書き・見出し・区切り線）なら後続の段落は正しい行', () => {
+        for (const continuation of ['> 引用', '- 項目', '# 見出し', '---']) {
+            const parsed = alternating(['一段落目。', `説明\n${continuation}`, '三段落目。']);
+            const { markdown, phraseLineByIndex } = buildTranscriptWithAnchors(parsed);
+            expect(splitLines(markdown)[5], continuation).toBe('[00:02](#t=2) **spk:1** 三段落目。');
+            expect([...phraseLineByIndex.entries()], continuation).toEqual([[0, 1], [2, 6]]);
+            expectAnchorsToMatchRenderedParagraphs(parsed);
+        }
+    });
+
+    it('同一話者に畳まれた段落のどれかの句に CR や目印があれば、その段落全体の句に付けない（後続は正しい行）', () => {
+        const { phraseLineByIndex } = buildTranscriptWithAnchors(parsedOf([
+            phrase(0, '先頭。', 0, 1, 'spk:1'),
+            phrase(1, '途中に\rCR。', 1, 2, 'spk:1'),
+            phrase(2, '次の話者。', 2, 3, 'spk:2'),
+            phrase(3, '```', 3, 4, 'spk:1'),
+            phrase(4, '同じ段落の続き。', 4, 5, 'spk:1'),
+            phrase(5, '最後の話者。', 5, 6, 'spk:2'),
+        ]));
+        expect([...phraseLineByIndex.entries()]).toEqual([[2, 4], [5, 8]]);
     });
 });
 

--- a/src/server/finalizeTranscription.ts
+++ b/src/server/finalizeTranscription.ts
@@ -7,6 +7,8 @@
  * 🔴 バッチは単一エンジン（Azure 標準モデル）なので、フォールバック注記は付かない。
  * 🔴 要確認候補（設計 B2/B4）: 句 → 段落開始行の対応は**生成時に決定的に**作る。本文の文字列検索・最寄り時刻・
  *    `#t=` の先頭一致で推測しない。対応が確定しない句はアンカー無し（undefined）にする。
+ *    行番号は描画側（react-markdown / micromark）と同じ規則で数え（CRLF・単独 CR・LF はいずれも 1 改行）、
+ *    アンカーは Markdown 上で必ず 1 つの段落ブロックになる「プレーンな 1 行の段落」にだけ付ける。
  */
 import { createHash } from 'node:crypto';
 import {
@@ -50,7 +52,9 @@ export interface TranscriptWithAnchors {
     markdown: string;
     /**
      * 句 index（`TranscriptAnnotation.phraseIndex`）→ その句が属する段落の開始行（生成 Markdown の 1 始まり）。
-     * 対応が確定しない句（本文が改行を含む段落・順序や描画形が期待と一致しない段落）は入らない。
+     * 行は描画側と同じく CRLF・単独 CR・LF をいずれも 1 改行として数える。
+     * 対応が確定しない句は入らない: 本文が改行や Markdown 構文になり得る書き方を含む段落、
+     * 改行を含む段落の続きの行がフェンス・HTML ブロックを開き得るときのそれ以降の全段落、描画形が期待と一致しない段落以降。
      */
     phraseLineByIndex: Map<number, number>;
 }
@@ -58,10 +62,46 @@ export interface TranscriptWithAnchors {
 /** `toTranscriptMarkdown` の既定と同じ: 同じ話者なら間隔に関係なく段落を分けない。 */
 const PARAGRAPH_BREAK_GAP_SEC = Number.POSITIVE_INFINITY;
 
-const countNewlines = (text: string): number => {
-    let count = 0;
-    for (let i = text.indexOf('\n'); i !== -1; i = text.indexOf('\n', i + 1)) count += 1;
-    return count;
+/** `toTranscriptMarkdown` のブロック区切り（空行 1 行） */
+const BLOCK_SEPARATOR = '\n\n';
+
+/**
+ * 描画側（react-markdown → micromark）と同じ改行規則。CommonMark は CRLF・単独 CR・LF をいずれも 1 つの行末として扱うので、
+ * 行番号もこの規則で数える（LF だけを数えると、本文に CR を含む句以降の行番号が描画とずれる）。
+ */
+const LINE_ENDING = /\r\n?|\n/;
+
+/** `text` に含まれる行末の数（= 行数 − 1）。 */
+const countLineEndings = (text: string): number => text.split(LINE_ENDING).length - 1;
+
+/** コードフェンス。開いたまま閉じないと、空行を越えて文末まで後続ブロックを飲み込む。 */
+const FENCE_RUN = /```|~~~/;
+
+/**
+ * 本文の先頭が行頭に出たとき Markdown のブロック構造に化け得る書き方: 見出し（#）・引用（>）・表（|）・箇条書き（- * + と
+ * 「数字.」「数字)」の後ろに空白か行末）・区切り線（--- *** ___）。時刻リンクで始まる 1 行の段落では実際には行頭に出ないが、
+ * B2 は保守的に倒し、迷う書き方には付けない。
+ */
+const BLOCK_MARKER_AT_BODY_START = /^[ \t]*(?:#|>|\||[-*+](?:[ \t]|$)|\d{1,9}[.)](?:[ \t]|$)|-{3,}|\*{3,}|_{3,})/;
+
+/**
+ * 「プレーンな段落」= 1 つの段落ブロックになることが確定しているブロック。
+ * 改行を含まず（続きの行が行頭に出ない）、フェンス・`<`（HTML）を含まず、本文の先頭がブロックの目印にならない。
+ * `block` は保存 Markdown 上のブロック全文（時刻リンク＋話者ラベル＋空白＋本文）、`bodyStart` は本文の開始位置。
+ */
+const isPlainBlock = (block: string, bodyStart: number): boolean =>
+    !/[\r\n<]/.test(block) && !FENCE_RUN.test(block) && !BLOCK_MARKER_AT_BODY_START.test(block.slice(bodyStart));
+
+/**
+ * 改行を含むブロックの続きの行は行頭に出る。そこでコードフェンス（``` / ~~~）や HTML ブロック（`<` 始まり: script / pre /
+ * style / textarea / コメント等）が開くと、閉じるまで空行を越えて後続のブロックまで飲み込む（閉じなければ文末まで）。
+ * その後の段落は行番号が文字列上は正しくても描画上は段落でないので、対応を確定できない。
+ * 引用・箇条書き・見出し・表は空行で必ず終わるので後続には波及しない。判定は保守的（フェンス片はブロック内のどこにあっても真）。
+ */
+const mayLeakIntoFollowingBlocks = (block: string): boolean => {
+    const [, ...continuationLines] = block.split(LINE_ENDING);
+    if (continuationLines.length === 0) return false;
+    return FENCE_RUN.test(block) || continuationLines.some((row) => /^[ \t]*</.test(row));
 };
 
 interface ParagraphRef {
@@ -69,14 +109,13 @@ interface ParagraphRef {
     speaker: string | null;
     /** この段落に畳まれた `parsed.annotations` の添字 */
     annotationIndices: number[];
-    /** 段落本文に含まれる改行数。0 でないと段落と行の対応が確定しない */
-    newlines: number;
 }
 
 /**
  * 句 → 段落開始行。`toTranscriptMarkdown` の段落化規則（話者が変わったときだけ段落を分ける・段落は空行 1 行で区切る）を
- * 同じ入力に適用して行番号を算出し、各段落の描画形（時刻リンク＋話者ラベル）が実際の行と一致することを確認する。
- * 一致しない段落以降は対応を確定できないので付けない。
+ * 同じ入力に適用して段落列を得て、保存 Markdown を先頭から 1 文字ずつ照合しながら各段落ブロックの開始位置を確定し、
+ * 開始行はその位置までの実際の行末の数から求める（算出値の推測ではなく、実際の文字列に対する検算）。
+ * 照合が崩れた段落以降は対応を確定できないので付けない。
  */
 function paragraphLinesByPhraseIndex(
     parsed: ParsedBatch,
@@ -115,37 +154,54 @@ function paragraphLinesByPhraseIndex(
             segment.startSec - lastEndSec <= PARAGRAPH_BREAK_GAP_SEC;
         if (current !== null && continues) {
             current.annotationIndices.push(kept[k]);
-            current.newlines += countNewlines(segment.text);
             lastEndSec = Math.max(lastEndSec, segment.endSec);
             continue;
         }
-        current = {
-            startSec: segment.startSec,
-            speaker: segment.speaker,
-            annotationIndices: [kept[k]],
-            newlines: countNewlines(segment.text),
-        };
+        current = { startSec: segment.startSec, speaker: segment.speaker, annotationIndices: [kept[k]] };
         paragraphs.push(current);
         lastEndSec = segment.endSec;
     }
 
-    // 3) 行番号: 段落 k の開始行 = 1 + Σ(前の段落の行数 + 空行 1)。段落の行数 = 1 + 本文中の改行数。
-    //    各段落の先頭（時刻リンク＋話者ラベル＋空白）が実際の行と一致することを確認する（推測ではなく算出値の検算）。
-    const markdownLines = markdown.split('\n');
+    // 3) 保存 Markdown を先頭から照合する。ブロック = 時刻リンク＋話者ラベル＋空白＋句の連結（英数字の境目にだけ空白 1 個が
+    //    入り得る）。ブロック間は空行 1 行、末尾のブロックは文末まで。開始行 = 1 + その位置より前にある行末の数
+    //    （区切りも含めて実際の文字列で数えるので、本文末尾の CR が区切りの LF と CRLF に合流する場合も描画と一致する）。
+    let offset = 0;
     let line = 1;
-    for (const paragraph of paragraphs) {
+    for (let k = 0; k < paragraphs.length; k += 1) {
+        const paragraph = paragraphs[k];
         const label = paragraph.speaker ? ` **${paragraph.speaker}**` : '';
         const prefix = `${formatTimestampLink(paragraph.startSec)}${label} `;
-        const actual = markdownLines[line - 1];
-        if (actual === undefined || !actual.startsWith(prefix)) break;
-        // 本文が改行を含む段落は Markdown 上で複数行・複数ブロックになり得るので、その句にはアンカーを付けない
-        if (paragraph.newlines === 0) {
+        if (!markdown.startsWith(prefix, offset)) break;
+        let cursor = offset + prefix.length;
+        let matched = true;
+        for (const annotationIndex of paragraph.annotationIndices) {
+            const { text } = chunk.annotations[annotationIndex];
+            if (markdown.startsWith(text, cursor)) {
+                cursor += text.length;
+            } else if (markdown[cursor] === ' ' && markdown.startsWith(text, cursor + 1)) {
+                cursor += 1 + text.length;
+            } else {
+                matched = false;
+                break;
+            }
+        }
+        if (!matched) break;
+        const separator = k === paragraphs.length - 1 ? '' : BLOCK_SEPARATOR;
+        if (separator === '' ? cursor !== markdown.length : !markdown.startsWith(separator, cursor)) break;
+
+        const block = markdown.slice(offset, cursor);
+        if (isPlainBlock(block, prefix.length)) {
             for (const annotationIndex of paragraph.annotationIndices) {
                 const phraseIndex = parsed.annotations[annotationIndex]?.phraseIndex;
                 if (typeof phraseIndex === 'number') lines.set(phraseIndex, line);
             }
+        } else if (mayLeakIntoFollowingBlocks(block)) {
+            // 後続の段落は描画上の段落であることを保証できない（B2: 対応が確定しない句にはアンカーを付けない）
+            break;
         }
-        line += paragraph.newlines + 1 + 1;
+        const next = cursor + separator.length;
+        line += countLineEndings(markdown.slice(offset, next));
+        offset = next;
     }
     return lines;
 }

--- a/src/server/finalizeTranscription.ts
+++ b/src/server/finalizeTranscription.ts
@@ -1,33 +1,211 @@
 /**
- * バッチ結果 → 既存の文書と同じ Markdown。
+ * バッチ結果 → 既存の文書と同じ Markdown（＋要確認候補の段落アンカー・本文ハッシュ・保存予算）。
  *
  * 🔴 既存の結合・整形（mergeTranscriptChunks / toTranscriptMarkdown）を**そのまま再利用**する。
  *    バッチは 1 ファイル = 1 結果なのでチャンクは 1 本。出力の見た目（段落・時刻リンク・話者ラベル）は
  *    同期チャンク方式のときと変わらない（時刻シーク再生・PDF・編集の回帰の錠がそのまま効く）。
  * 🔴 バッチは単一エンジン（Azure 標準モデル）なので、フォールバック注記は付かない。
+ * 🔴 要確認候補（設計 B2/B4）: 句 → 段落開始行の対応は**生成時に決定的に**作る。本文の文字列検索・最寄り時刻・
+ *    `#t=` の先頭一致で推測しない。対応が確定しない句はアンカー無し（undefined）にする。
  */
-import { mergeTranscriptChunks, toTranscriptMarkdown, type MergeChunk } from '@/lib/transcriptMerge';
+import { createHash } from 'node:crypto';
+import {
+    formatTimestampLink,
+    mergeTranscriptChunks,
+    midpointSec,
+    toAbsoluteSec,
+    toTranscriptMarkdown,
+    type MergeChunk,
+    type MergedSegment,
+} from '@/lib/transcriptMerge';
+import type { TranscriptReview } from '@/lib/transcriptReviewContract';
+import { createLogger } from '@/lib/logger';
 import type { ParsedBatch } from './azureBatchTranscribe';
+import { measureReviewJsonBytes } from './reviewCandidates';
+
+const logger = createLogger('server/finalizeTranscription');
+
+/** バッチ結果 1 本を結合器の入力（チャンク 1 本）にする。チャンク開始が 0 なので、区間内オフセット = 元音声の絶対秒。 */
+const toMergeChunk = (parsed: ParsedBatch): MergeChunk => ({
+    index: 0,
+    startSec: 0,
+    prefixSec: 0,
+    endSec: parsed.audioSec,
+    failed: false,
+    // 句単位の注釈。
+    annotations: parsed.annotations.map((a) => ({
+        text: a.text ?? '',
+        startOffsetSec: a.startSec ?? 0,
+        endOffsetSec: a.endSec ?? a.startSec ?? 0,
+        speaker: a.speaker ?? null,
+    })),
+});
 
 /** バッチ結果 1 本を、文書へ保存できる Markdown にする。 */
 export function buildTranscriptMarkdownFromBatch(parsed: ParsedBatch): string {
-    const chunk: MergeChunk = {
-        index: 0,
-        startSec: 0,
-        prefixSec: 0,
-        endSec: parsed.audioSec,
-        failed: false,
-        // 句単位の注釈。チャンク開始が 0 なので、区間内オフセット = 元音声の絶対秒。
-        annotations: parsed.annotations.map((a) => ({
-            text: a.text ?? '',
-            startOffsetSec: a.startSec ?? 0,
-            endOffsetSec: a.endSec ?? a.startSec ?? 0,
-            speaker: a.speaker ?? null,
-        })),
-    };
-    const merged = mergeTranscriptChunks([chunk]);
-    return toTranscriptMarkdown(merged);
+    return toTranscriptMarkdown(mergeTranscriptChunks([toMergeChunk(parsed)]));
 }
+
+export interface TranscriptWithAnchors {
+    markdown: string;
+    /**
+     * 句 index（`TranscriptAnnotation.phraseIndex`）→ その句が属する段落の開始行（生成 Markdown の 1 始まり）。
+     * 対応が確定しない句（本文が改行を含む段落・順序や描画形が期待と一致しない段落）は入らない。
+     */
+    phraseLineByIndex: Map<number, number>;
+}
+
+/** `toTranscriptMarkdown` の既定と同じ: 同じ話者なら間隔に関係なく段落を分けない。 */
+const PARAGRAPH_BREAK_GAP_SEC = Number.POSITIVE_INFINITY;
+
+const countNewlines = (text: string): number => {
+    let count = 0;
+    for (let i = text.indexOf('\n'); i !== -1; i = text.indexOf('\n', i + 1)) count += 1;
+    return count;
+};
+
+interface ParagraphRef {
+    startSec: number;
+    speaker: string | null;
+    /** この段落に畳まれた `parsed.annotations` の添字 */
+    annotationIndices: number[];
+    /** 段落本文に含まれる改行数。0 でないと段落と行の対応が確定しない */
+    newlines: number;
+}
+
+/**
+ * 句 → 段落開始行。`toTranscriptMarkdown` の段落化規則（話者が変わったときだけ段落を分ける・段落は空行 1 行で区切る）を
+ * 同じ入力に適用して行番号を算出し、各段落の描画形（時刻リンク＋話者ラベル）が実際の行と一致することを確認する。
+ * 一致しない段落以降は対応を確定できないので付けない。
+ */
+function paragraphLinesByPhraseIndex(
+    parsed: ParsedBatch,
+    chunk: MergeChunk,
+    segments: readonly MergedSegment[],
+    gapCount: number,
+    markdown: string,
+): Map<number, number> {
+    const lines = new Map<number, number>();
+    // 単一の非失敗チャンクでは欠落注記は出ない。出ていれば段落の並びが読めないので付けない。
+    if (gapCount !== 0) return lines;
+
+    // 1) 結合で残る注釈を、mergeTranscriptChunks と同じ規則（中点がチャンク開始より前なら捨てる）で特定する
+    const kept: number[] = [];
+    chunk.annotations.forEach((annotation, i) => {
+        const startSec = toAbsoluteSec(annotation.startOffsetSec, chunk);
+        const endSec = toAbsoluteSec(annotation.endOffsetSec, chunk);
+        if (midpointSec(startSec, endSec) < chunk.startSec) return;
+        kept.push(i);
+    });
+    if (kept.length !== segments.length) return lines;
+
+    // 2) 段落へ畳む（toTranscriptMarkdown の既定と同じ規則）。各段が元の注釈と一致することも確認する
+    const paragraphs: ParagraphRef[] = [];
+    let current: ParagraphRef | null = null;
+    let lastEndSec = 0;
+    for (let k = 0; k < segments.length; k += 1) {
+        const segment = segments[k];
+        const annotation = chunk.annotations[kept[k]];
+        if (segment.text !== annotation.text || segment.startSec !== toAbsoluteSec(annotation.startOffsetSec, chunk)) {
+            return lines;
+        }
+        const continues =
+            current !== null &&
+            current.speaker === segment.speaker &&
+            segment.startSec - lastEndSec <= PARAGRAPH_BREAK_GAP_SEC;
+        if (current !== null && continues) {
+            current.annotationIndices.push(kept[k]);
+            current.newlines += countNewlines(segment.text);
+            lastEndSec = Math.max(lastEndSec, segment.endSec);
+            continue;
+        }
+        current = {
+            startSec: segment.startSec,
+            speaker: segment.speaker,
+            annotationIndices: [kept[k]],
+            newlines: countNewlines(segment.text),
+        };
+        paragraphs.push(current);
+        lastEndSec = segment.endSec;
+    }
+
+    // 3) 行番号: 段落 k の開始行 = 1 + Σ(前の段落の行数 + 空行 1)。段落の行数 = 1 + 本文中の改行数。
+    //    各段落の先頭（時刻リンク＋話者ラベル＋空白）が実際の行と一致することを確認する（推測ではなく算出値の検算）。
+    const markdownLines = markdown.split('\n');
+    let line = 1;
+    for (const paragraph of paragraphs) {
+        const label = paragraph.speaker ? ` **${paragraph.speaker}**` : '';
+        const prefix = `${formatTimestampLink(paragraph.startSec)}${label} `;
+        const actual = markdownLines[line - 1];
+        if (actual === undefined || !actual.startsWith(prefix)) break;
+        // 本文が改行を含む段落は Markdown 上で複数行・複数ブロックになり得るので、その句にはアンカーを付けない
+        if (paragraph.newlines === 0) {
+            for (const annotationIndex of paragraph.annotationIndices) {
+                const phraseIndex = parsed.annotations[annotationIndex]?.phraseIndex;
+                if (typeof phraseIndex === 'number') lines.set(phraseIndex, line);
+            }
+        }
+        line += paragraph.newlines + 1 + 1;
+    }
+    return lines;
+}
+
+/**
+ * バッチ結果 1 本を Markdown にし、同時に「句 index → 段落開始行」の対応を作る（設計 B2）。
+ * Markdown は `buildTranscriptMarkdownFromBatch` と同一。アンカーの算出に失敗しても本文は返す（設計 B4: 候補のために本文を失敗させない）。
+ */
+export function buildTranscriptWithAnchors(parsed: ParsedBatch): TranscriptWithAnchors {
+    const chunk = toMergeChunk(parsed);
+    const merged = mergeTranscriptChunks([chunk]);
+    const markdown = toTranscriptMarkdown(merged);
+    let phraseLineByIndex: Map<number, number>;
+    try {
+        phraseLineByIndex = paragraphLinesByPhraseIndex(parsed, chunk, merged.segments, merged.gaps.length, markdown);
+    } catch (error) {
+        logger.warn('段落アンカーの算出に失敗（本文は保存・アンカー無し）', {
+            reason: error instanceof Error ? error.message : String(error),
+        });
+        phraseLineByIndex = new Map();
+    }
+    return { markdown, phraseLineByIndex };
+}
+
+/**
+ * 保存する Markdown の UTF-8 バイト列の SHA-256（hex）。
+ * UI は表示本文を同じ規則でハッシュし、一致する間だけ本文の段落バッジ・移動を有効にする（設計 B2）。
+ */
+export const sourceTextHashOf = (markdown: string): string =>
+    createHash('sha256').update(markdown, 'utf8').digest('hex');
+
+/** 候補に段落開始行を補う。対応の無い候補には付けない（推測しない）。候補の順序・件数は変えない。 */
+export function withParagraphAnchors(
+    review: TranscriptReview,
+    lineByPhraseId: ReadonlyMap<string, number>,
+): TranscriptReview {
+    return {
+        ...review,
+        candidates: review.candidates.map((candidate) => {
+            const line = lineByPhraseId.get(candidate.phraseId);
+            return line === undefined ? candidate : { ...candidate, paragraphStartLine: line };
+        }),
+    };
+}
+
+/** Firestore の 1 文書上限（バイト）。本文＋候補＋他フィールドの合計がこれを超えると終端 commit 自体が失敗する。 */
+export const FIRESTORE_MAX_DOCUMENT_BYTES = 1024 * 1024;
+/**
+ * title / fileName / 音声参照 / 時刻 / フィールド名などのぶんの見込み。JSON バイト数は Firestore の実サイズと一致しないので
+ * 余裕を取る（候補を省く側に倒す。本文は本機能では切り詰めない）。
+ */
+export const DOCUMENT_OVERHEAD_HEADROOM_BYTES = 64 * 1024;
+
+/**
+ * 本文＋候補＋見込みが Firestore の 1 文書上限に収まるか（設計 B2: JSON サイズだけで保存可否を判定しない。文書全体で見る）。
+ * 🔴 候補件数・128 KiB の予算そのものは抽出側の applyReviewBudget が単一の正。ここはその後の文書全体の見積りだけを担う。
+ *    収まらないときの扱い（unavailable の最小形 → それでも超えるなら review を省く）は呼び出し側（status route）。
+ */
+export const reviewFitsDocument = (review: TranscriptReview, markdownBytes: number): boolean =>
+    markdownBytes + measureReviewJsonBytes(review) + DOCUMENT_OVERHEAD_HEADROOM_BYTES <= FIRESTORE_MAX_DOCUMENT_BYTES;
 
 /**
  * 完成した文書に載せる「使用モデル」表示。バッチは Azure 標準モデル。

--- a/src/server/reviewCandidates.test.ts
+++ b/src/server/reviewCandidates.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, expect } from 'vitest';
+import {
+    applyReviewBudget,
+    buildReviewCandidates,
+    buildReviewCandidatesSafe,
+    buildUnavailableReview,
+    measureReviewJsonBytes,
+    phraseIdFor,
+    KNOWN_RECOGNITION_STATUSES,
+    type ReviewPhraseInput,
+} from './reviewCandidates';
+import {
+    LOW_CONFIDENCE_THRESHOLD,
+    REVIEW_EXCERPT_MAX_CHARS,
+    REVIEW_MAX_CANDIDATES,
+    REVIEW_MAX_JSON_BYTES,
+    TRANSCRIPT_REVIEW_VERSION,
+} from '@/lib/transcriptReviewContract';
+
+/**
+ * 🔴 fixture は合成（架空）のみ。実顧客の発話・ジョブ ID・ハッシュは置かない。
+ * 既定の句は「Success・confidence 0.9・時刻あり・話者あり」で、候補にならない健全な句。
+ */
+const JOB = 'job-synthetic-0001';
+const HASH = 'f'.repeat(64);
+
+const phrase = (index: number, overrides: Partial<ReviewPhraseInput> = {}): ReviewPhraseInput => ({
+    index,
+    text: `合成の発話 ${index} です。`,
+    confidence: 0.9,
+    recognitionStatus: 'Success',
+    speaker: 'spk:1',
+    startSec: index * 2,
+    endSec: index * 2 + 1.5,
+    ...overrides,
+});
+
+const build = (phrases: ReviewPhraseInput[], options?: Parameters<typeof buildReviewCandidates>[3]) =>
+    buildReviewCandidates(phrases, JOB, HASH, options);
+
+describe('buildReviewCandidates: 閾値境界', () => {
+    it.each([
+        [0, true],
+        [0.5, true],
+        [0.749, true],
+        [0.7499999, true],
+        [0.75, false],
+        [0.76, false],
+        [1, false],
+    ])('confidence=%s → 低信頼候補=%s（0.75 ちょうどは含めない）', (confidence, expected) => {
+        const review = build([phrase(0, { confidence })]);
+        expect(review.availability).toBe('complete');
+        expect(review.summary.lowConfidence).toBe(expected ? 1 : 0);
+        expect(review.summary.candidateTotal).toBe(expected ? 1 : 0);
+        expect(review.summary.unknownConfidence).toBe(0);
+        if (expected) {
+            expect(review.candidates[0]).toMatchObject({ phraseId: 'p0', reasons: ['low_confidence'], confidence });
+        } else {
+            expect(review.candidates).toEqual([]);
+        }
+    });
+
+    it('閾値オプションを使い、使った閾値を記録する', () => {
+        const review = build([phrase(0, { confidence: 0.85 })], { threshold: 0.9 });
+        expect(review.threshold).toBe(0.9);
+        expect(review.summary.lowConfidence).toBe(1);
+        const byDefault = build([phrase(0, { confidence: 0.85 })]);
+        expect(byDefault.threshold).toBe(LOW_CONFIDENCE_THRESHOLD);
+        expect(byDefault.summary.lowConfidence).toBe(0);
+    });
+
+    it.each([1.5, -0.1, Number.NaN, Number.POSITIVE_INFINITY])('不正な閾値 %s は RangeError', (threshold) => {
+        expect(() => build([phrase(0)], { threshold })).toThrow(RangeError);
+    });
+});
+
+describe('buildReviewCandidates: confidence 不明', () => {
+    it.each([
+        ['欠損', undefined],
+        ['NaN', Number.NaN],
+        ['Infinity', Number.POSITIVE_INFINITY],
+        ['負', -0.1],
+        ['1 超', 1.5],
+        ['文字列', '0.5' as unknown as number],
+    ])('%s は不明として数え、候補にも 0 の低信頼にもしない', (_label, confidence) => {
+        const review = build([phrase(0, { confidence })]);
+        expect(review.summary.unknownConfidence).toBe(1);
+        expect(review.summary.lowConfidence).toBe(0);
+        expect(review.summary.candidateTotal).toBe(0);
+        expect(review.candidates).toEqual([]);
+        expect(review.availability).toBe('complete');
+    });
+
+    it('confidence も recognitionStatus も無い句は候補にせず、両方の不明に数える', () => {
+        const review = build([phrase(0, { confidence: undefined, recognitionStatus: undefined })]);
+        expect(review.summary).toMatchObject({
+            totalPhrases: 1,
+            unknownConfidence: 1,
+            unknownRecognitionStatus: 1,
+            candidateTotal: 0,
+            lowConfidence: 0,
+            recognitionFlagged: 0,
+        });
+        expect(review.candidates).toEqual([]);
+    });
+});
+
+describe('buildReviewCandidates: 認識結果要確認', () => {
+    const nonSuccess = [...KNOWN_RECOGNITION_STATUSES].filter((s) => s !== 'Success');
+
+    it('既知の非 Success は全て把握している', () => {
+        expect(nonSuccess).toEqual(['Failure', 'NoMatch', 'InitialSilenceTimeout', 'BabbleTimeout', 'Error']);
+    });
+
+    it.each(nonSuccess)('recognitionStatus=%s → recognition_status 候補（status を保持）', (recognitionStatus) => {
+        const review = build([phrase(0, { recognitionStatus, text: '' })]);
+        expect(review.summary.recognitionFlagged).toBe(1);
+        expect(review.summary.lowConfidence).toBe(0);
+        expect(review.summary.unknownRecognitionStatus).toBe(0);
+        expect(review.candidates).toHaveLength(1);
+        expect(review.candidates[0]).toMatchObject({ reasons: ['recognition_status'], recognitionStatus });
+    });
+
+    it('非 Success の句は confidence が低くても理由は recognition_status だけ（低信頼に数えない）', () => {
+        const review = build([phrase(0, { recognitionStatus: 'NoMatch', confidence: 0.1 })]);
+        expect(review.candidates[0].reasons).toEqual(['recognition_status']);
+        expect(review.summary.lowConfidence).toBe(0);
+        expect(review.summary.recognitionFlagged).toBe(1);
+        expect(review.summary.candidateTotal).toBe(1);
+    });
+
+    it.each([['空文字', ''], ['空白のみ', ' \n\t ']])('Success だが text が%s → empty_text（excerpt は空・truncated=false）', (_label, text) => {
+        const review = build([phrase(0, { text })]);
+        expect(review.candidates).toHaveLength(1);
+        expect(review.candidates[0]).toMatchObject({
+            reasons: ['empty_text'],
+            excerpt: '',
+            excerptTruncated: false,
+            recognitionStatus: 'Success',
+        });
+        expect(review.summary.recognitionFlagged).toBe(1);
+        expect(review.summary.lowConfidence).toBe(0);
+    });
+
+    it('未知の recognitionStatus でも confidence が閾値未満なら low_confidence + unknown_confidence の候補', () => {
+        const review = build([phrase(0, { recognitionStatus: 'SomethingNew', confidence: 0.5 })]);
+        expect(review.candidates).toHaveLength(1);
+        expect(review.candidates[0]).toMatchObject({
+            reasons: ['low_confidence', 'unknown_confidence'],
+            recognitionStatus: 'SomethingNew',
+            confidence: 0.5,
+        });
+        expect(review.summary).toMatchObject({
+            lowConfidence: 1,
+            recognitionFlagged: 0,
+            unknownRecognitionStatus: 1,
+            candidateTotal: 1,
+        });
+    });
+
+    it('recognitionStatus 欠落でも confidence が閾値未満なら候補（status キーは置かない）', () => {
+        const review = build([phrase(0, { recognitionStatus: undefined, confidence: 0.2 })]);
+        expect(review.candidates[0].reasons).toEqual(['low_confidence', 'unknown_confidence']);
+        expect(review.candidates[0]).not.toHaveProperty('recognitionStatus');
+        expect(review.summary.unknownRecognitionStatus).toBe(1);
+    });
+
+    it('未知の recognitionStatus で confidence が高い句は候補にしない（不明に数えるだけ）', () => {
+        const review = build([phrase(0, { recognitionStatus: 'SomethingNew', confidence: 0.95 })]);
+        expect(review.candidates).toEqual([]);
+        expect(review.summary.unknownRecognitionStatus).toBe(1);
+        expect(review.summary.candidateTotal).toBe(0);
+    });
+
+    it('未知の recognitionStatus・text 空・confidence 無しは判定材料が無いので候補にしない', () => {
+        const review = build([phrase(0, { recognitionStatus: 'SomethingNew', text: '', confidence: undefined })]);
+        expect(review.candidates).toEqual([]);
+        expect(review.summary).toMatchObject({ unknownRecognitionStatus: 1, unknownConfidence: 1, candidateTotal: 0 });
+    });
+
+    it('recognitionStatus の前後空白は無視して既知値に合わせる', () => {
+        const review = build([phrase(0, { recognitionStatus: ' NoMatch ' })]);
+        expect(review.candidates[0]).toMatchObject({ reasons: ['recognition_status'], recognitionStatus: 'NoMatch' });
+    });
+});
+
+describe('buildReviewCandidates: 複数理由と ID の和集合', () => {
+    it('Success・text 空・confidence 低 → 候補 1 件に理由 2 つ', () => {
+        const review = build([phrase(0, { text: '', confidence: 0.3 })]);
+        expect(review.candidates).toHaveLength(1);
+        expect(review.candidates[0].reasons).toEqual(['low_confidence', 'empty_text']);
+        expect(review.summary).toMatchObject({
+            totalPhrases: 1,
+            lowConfidence: 1,
+            recognitionFlagged: 1,
+            candidateTotal: 1,
+            savedCandidates: 1,
+        });
+    });
+
+    it('候補総数はカテゴリの和ではなく ID の和集合', () => {
+        const review = build([
+            phrase(0, { confidence: 0.4 }),                 // 低信頼のみ
+            phrase(1, { recognitionStatus: 'NoMatch' }),     // 認識結果のみ
+            phrase(2, { text: '', confidence: 0.2 }),        // 両方
+            phrase(3),                                       // 健全
+        ]);
+        expect(review.summary).toMatchObject({
+            totalPhrases: 4,
+            lowConfidence: 2,
+            recognitionFlagged: 2,
+            candidateTotal: 3,
+            savedCandidates: 3,
+        });
+        expect(review.candidates.map((c) => c.phraseId)).toEqual(['p0', 'p1', 'p2']);
+    });
+
+    it('同じ index が二重に渡っても候補は 1 件（ID の和集合・保存数も 1）', () => {
+        const review = build([phrase(5, { confidence: 0.1 }), phrase(5, { confidence: 0.2 })]);
+        expect(review.summary.candidateTotal).toBe(1);
+        expect(review.summary.savedCandidates).toBe(1);
+        expect(review.candidates).toHaveLength(1);
+        expect(review.candidates[0].confidence).toBe(0.1);
+        expect(review.availability).toBe('complete');
+    });
+});
+
+describe('buildReviewCandidates: 時刻', () => {
+    it('有限かつ 0 <= start <= end の時刻だけ候補に持たせる', () => {
+        const review = build([phrase(0, { confidence: 0.1, startSec: 12.5, endSec: 15 })]);
+        expect(review.candidates[0]).toMatchObject({ startSec: 12.5, endSec: 15 });
+        expect(review.summary.noTimeCandidates).toBe(0);
+    });
+
+    it('開始と終了が同じ（長さ 0）でも時刻として有効', () => {
+        const review = build([phrase(0, { confidence: 0.1, startSec: 3, endSec: 3 })]);
+        expect(review.candidates[0]).toMatchObject({ startSec: 3, endSec: 3 });
+    });
+
+    it.each([
+        ['end 欠損', { startSec: 1, endSec: undefined }],
+        ['start 欠損', { startSec: undefined, endSec: 1 }],
+        ['両方欠損', { startSec: undefined, endSec: undefined }],
+        ['start > end', { startSec: 5, endSec: 4 }],
+        ['負の start', { startSec: -1, endSec: 4 }],
+        ['NaN', { startSec: Number.NaN, endSec: 4 }],
+        ['Infinity', { startSec: 1, endSec: Number.POSITIVE_INFINITY }],
+    ])('%s の時刻は持たせず（0 にしない）、時刻不明候補に数える', (_label, time) => {
+        const review = build([phrase(0, { confidence: 0.1, ...time })]);
+        expect(review.candidates).toHaveLength(1);
+        expect(review.candidates[0]).not.toHaveProperty('startSec');
+        expect(review.candidates[0]).not.toHaveProperty('endSec');
+        expect(review.summary.noTimeCandidates).toBe(1);
+        expect(review.summary.candidateTotal).toBe(1);
+    });
+
+    it('audioSec が分かるとき、開始がそれを超える時刻は読めない扱い（0 や不正な audioSec は無視）', () => {
+        const over = build([phrase(0, { confidence: 0.1, startSec: 500, endSec: 501 })], { audioSec: 100 });
+        expect(over.candidates[0]).not.toHaveProperty('startSec');
+        expect(over.summary.noTimeCandidates).toBe(1);
+
+        const within = build([phrase(0, { confidence: 0.1, startSec: 99, endSec: 101 })], { audioSec: 100 });
+        expect(within.candidates[0]).toMatchObject({ startSec: 99, endSec: 101 });
+
+        for (const audioSec of [0, -5, Number.NaN]) {
+            const ignored = build([phrase(0, { confidence: 0.1, startSec: 500, endSec: 501 })], { audioSec });
+            expect(ignored.candidates[0]).toMatchObject({ startSec: 500, endSec: 501 });
+        }
+    });
+
+    it('時刻あり候補を時刻昇順（同時刻は index 順）、その後に時刻なしを index 順で並べる', () => {
+        const review = build([
+            phrase(7, { confidence: 0.1, startSec: undefined, endSec: undefined }),
+            phrase(3, { confidence: 0.1, startSec: 10, endSec: 11 }),
+            phrase(9, { confidence: 0.1, startSec: 4, endSec: 5 }),
+            phrase(2, { confidence: 0.1, startSec: undefined, endSec: undefined }),
+            phrase(8, { confidence: 0.1, startSec: 4, endSec: 6 }),
+            phrase(1, { confidence: 0.1, startSec: 4, endSec: 4.5 }),
+        ]);
+        expect(review.candidates.map((c) => c.phraseId)).toEqual(['p1', 'p8', 'p9', 'p3', 'p2', 'p7']);
+        expect(review.summary.noTimeCandidates).toBe(2);
+    });
+});
+
+describe('buildReviewCandidates: excerpt', () => {
+    it('上限ちょうどは切らない・1 文字超えたら上限まで切って truncated=true', () => {
+        const exact = 'あ'.repeat(REVIEW_EXCERPT_MAX_CHARS);
+        const over = 'い'.repeat(REVIEW_EXCERPT_MAX_CHARS + 1);
+        const review = build([phrase(0, { confidence: 0.1, text: exact }), phrase(1, { confidence: 0.1, text: over })]);
+        expect(review.candidates[0]).toMatchObject({ excerpt: exact, excerptTruncated: false });
+        expect(review.candidates[1].excerptTruncated).toBe(true);
+        expect(Array.from(review.candidates[1].excerpt)).toHaveLength(REVIEW_EXCERPT_MAX_CHARS);
+        expect(review.candidates[1].excerpt).toBe('い'.repeat(REVIEW_EXCERPT_MAX_CHARS));
+    });
+
+    it('サロゲートペアは 1 文字として数え、途中で割らない', () => {
+        const emoji = '😀';
+        const exact = emoji.repeat(REVIEW_EXCERPT_MAX_CHARS);
+        const over = emoji.repeat(REVIEW_EXCERPT_MAX_CHARS + 1);
+        const review = build([phrase(0, { confidence: 0.1, text: exact }), phrase(1, { confidence: 0.1, text: over })]);
+        expect(review.candidates[0]).toMatchObject({ excerpt: exact, excerptTruncated: false });
+        expect(review.candidates[1]).toMatchObject({ excerpt: exact, excerptTruncated: true });
+    });
+
+    it('前後の空白は抜粋から落とす', () => {
+        const review = build([phrase(0, { confidence: 0.1, text: '  合成の発話です。  ' })]);
+        expect(review.candidates[0].excerpt).toBe('合成の発話です。');
+    });
+});
+
+describe('buildReviewCandidates: 候補の形', () => {
+    it('取れなかった任意項目はキー自体を置かない（Firestore の undefined 拒否対策）・paragraphStartLine は付けない', () => {
+        const review = build([
+            phrase(4, {
+                confidence: 0.1,
+                recognitionStatus: undefined,
+                speaker: undefined,
+                startSec: undefined,
+                endSec: undefined,
+            }),
+        ]);
+        expect(review.candidates[0]).toStrictEqual({
+            phraseId: 'p4',
+            reasons: ['low_confidence', 'unknown_confidence'],
+            excerpt: '合成の発話 4 です。',
+            excerptTruncated: false,
+            confidence: 0.1,
+        });
+        expect(Object.keys(review.candidates[0])).not.toContain('paragraphStartLine');
+        expect(JSON.stringify(review)).not.toContain('paragraphStartLine');
+    });
+
+    it('取れた任意項目は全て持つ・speaker null は置かない', () => {
+        const full = build([phrase(2, { confidence: 0.4, speaker: 'spk:3', startSec: 1, endSec: 2 })]);
+        expect(full.candidates[0]).toStrictEqual({
+            phraseId: 'p2',
+            reasons: ['low_confidence'],
+            excerpt: '合成の発話 2 です。',
+            excerptTruncated: false,
+            confidence: 0.4,
+            recognitionStatus: 'Success',
+            speaker: 'spk:3',
+            startSec: 1,
+            endSec: 2,
+        });
+        const noSpeaker = build([phrase(2, { confidence: 0.4, speaker: null })]);
+        expect(noSpeaker.candidates[0]).not.toHaveProperty('speaker');
+    });
+
+    it('phraseId は index から決定的（同じ入力なら同じ出力・index は連番でなくてよい）', () => {
+        const input = [phrase(12, { confidence: 0.1 }), phrase(40, { recognitionStatus: 'NoMatch' })];
+        const a = build(input);
+        const b = build(input.map((p) => ({ ...p })));
+        expect(a).toStrictEqual(b);
+        expect(a.candidates.map((c) => c.phraseId)).toEqual(['p12', 'p40']);
+        expect(phraseIdFor(0)).toBe('p0');
+    });
+
+    it.each([-1, 1.5, Number.NaN, undefined as unknown as number])('index=%s は契約違反として TypeError', (index) => {
+        expect(() => build([{ ...phrase(0, { confidence: 0.1 }), index }])).toThrow(TypeError);
+    });
+
+    it('version・threshold・sourceTextHash・sourceJobId を記録する', () => {
+        const review = build([phrase(0)]);
+        expect(review).toMatchObject({
+            version: TRANSCRIPT_REVIEW_VERSION,
+            threshold: LOW_CONFIDENCE_THRESHOLD,
+            sourceTextHash: HASH,
+            sourceJobId: JOB,
+        });
+        expect(review).not.toHaveProperty('unavailableReason');
+    });
+});
+
+describe('buildReviewCandidates: 保存予算', () => {
+    it('件数上限を超えたら先頭 REVIEW_MAX_CANDIDATES 件だけ保存し partial・総件数は全句の値を保つ', () => {
+        const total = REVIEW_MAX_CANDIDATES + 50;
+        const phrases = Array.from({ length: total }, (_, i) => phrase(i, { confidence: 0.1 }));
+        const review = build(phrases);
+        expect(review.availability).toBe('partial');
+        expect(review.candidates).toHaveLength(REVIEW_MAX_CANDIDATES);
+        expect(review.summary).toMatchObject({
+            totalPhrases: total,
+            lowConfidence: total,
+            candidateTotal: total,
+            savedCandidates: REVIEW_MAX_CANDIDATES,
+        });
+        // 時刻昇順の先頭 = index 0..199（fixture は index に比例した時刻）
+        expect(review.candidates[0].phraseId).toBe('p0');
+        expect(review.candidates[REVIEW_MAX_CANDIDATES - 1].phraseId).toBe(`p${REVIEW_MAX_CANDIDATES - 1}`);
+    });
+
+    it('JSON が REVIEW_MAX_JSON_BYTES を超えたら末尾から落として収める（partial・総件数は保つ）', () => {
+        // 300 文字 × 3 バイトの抜粋 ≒ 1 KB/件。150 件で 128 KiB を超える。
+        const total = 150;
+        const phrases = Array.from({ length: total }, (_, i) =>
+            phrase(i, { confidence: 0.1, text: '合'.repeat(REVIEW_EXCERPT_MAX_CHARS) }));
+        const review = build(phrases);
+        expect(review.availability).toBe('partial');
+        expect(measureReviewJsonBytes(review)).toBeLessThanOrEqual(REVIEW_MAX_JSON_BYTES);
+        expect(review.summary.savedCandidates).toBe(review.candidates.length);
+        expect(review.summary.savedCandidates).toBeLessThan(total);
+        expect(review.summary.savedCandidates).toBeGreaterThan(0);
+        expect(review.summary.candidateTotal).toBe(total);
+        // 1 件戻すと予算を超える（落とし過ぎていない）。戻す 1 件は実際に落とされた次の候補
+        // （fixture は index から決定的なので予算なしで同じ形を組める）。
+        const saved = review.summary.savedCandidates;
+        const dropped = build([phrases[saved]]).candidates[0];
+        expect(dropped.phraseId).toBe(`p${saved}`);
+        const oneMore: typeof review = {
+            ...review,
+            summary: { ...review.summary, savedCandidates: saved + 1 },
+            candidates: [...review.candidates, dropped],
+        };
+        expect(measureReviewJsonBytes(oneMore)).toBeGreaterThan(REVIEW_MAX_JSON_BYTES);
+        // 残すのは並び順の先頭
+        expect(review.candidates.map((c) => c.phraseId)).toEqual(
+            Array.from({ length: review.summary.savedCandidates }, (_, i) => `p${i}`));
+    });
+
+    it('上限内なら全件保存で complete', () => {
+        const phrases = Array.from({ length: 30 }, (_, i) => phrase(i, { confidence: 0.1 }));
+        const review = build(phrases);
+        expect(review.availability).toBe('complete');
+        expect(review.summary.savedCandidates).toBe(30);
+        expect(measureReviewJsonBytes(review)).toBeLessThanOrEqual(REVIEW_MAX_JSON_BYTES);
+    });
+});
+
+describe('applyReviewBudget（永続化レーンがアンカーを補った後の再適用）', () => {
+    const nearBudget = () =>
+        build(Array.from({ length: 150 }, (_, i) =>
+            phrase(i, { confidence: 0.1, text: '合'.repeat(REVIEW_EXCERPT_MAX_CHARS) })));
+
+    it('paragraphStartLine を足して予算を超えた review を末尾から落として収める（総件数は保つ）', () => {
+        const trimmed = nearBudget();
+        const anchored = {
+            ...trimmed,
+            candidates: trimmed.candidates.map((c, i) => ({ ...c, paragraphStartLine: 1000 + i * 2 })),
+        };
+        // 前提: アンカー分のバイト増で上限を超えている（超えていなければこのテストの素材が弱い）
+        expect(measureReviewJsonBytes(anchored)).toBeGreaterThan(REVIEW_MAX_JSON_BYTES);
+
+        const reapplied = applyReviewBudget(anchored);
+        expect(measureReviewJsonBytes(reapplied)).toBeLessThanOrEqual(REVIEW_MAX_JSON_BYTES);
+        expect(reapplied.availability).toBe('partial');
+        expect(reapplied.summary.savedCandidates).toBe(reapplied.candidates.length);
+        expect(reapplied.summary.savedCandidates).toBeLessThan(trimmed.summary.savedCandidates);
+        expect(reapplied.summary.candidateTotal).toBe(150);
+        // 残すのは並び順の先頭。アンカーは保持される
+        expect(reapplied.candidates.map((c) => c.phraseId)).toEqual(
+            anchored.candidates.slice(0, reapplied.candidates.length).map((c) => c.phraseId));
+        expect(reapplied.candidates.every((c) => typeof c.paragraphStartLine === 'number')).toBe(true);
+        // 入力は変更しない
+        expect(anchored.candidates).toHaveLength(trimmed.candidates.length);
+        expect(anchored.summary.savedCandidates).toBe(trimmed.summary.savedCandidates);
+    });
+
+    it('予算内の review には何もしない（冪等）', () => {
+        const review = build(Array.from({ length: 30 }, (_, i) => phrase(i, { confidence: 0.1 })));
+        expect(applyReviewBudget(review)).toStrictEqual(review);
+        const anchored = {
+            ...review,
+            candidates: review.candidates.map((c, i) => ({ ...c, paragraphStartLine: 1 + i * 2 })),
+        };
+        expect(applyReviewBudget(anchored)).toStrictEqual(anchored);
+    });
+
+    it('件数上限も再適用する', () => {
+        const review = build(Array.from({ length: 30 }, (_, i) => phrase(i, { confidence: 0.1 })));
+        const inflated = {
+            ...review,
+            summary: { ...review.summary, candidateTotal: REVIEW_MAX_CANDIDATES + 30 },
+            candidates: Array.from({ length: REVIEW_MAX_CANDIDATES + 30 }, (_, i) => ({
+                ...review.candidates[i % 30],
+                phraseId: `p${i}`,
+            })),
+        };
+        const reapplied = applyReviewBudget(inflated);
+        expect(reapplied.candidates).toHaveLength(REVIEW_MAX_CANDIDATES);
+        expect(reapplied.summary.savedCandidates).toBe(REVIEW_MAX_CANDIDATES);
+        expect(reapplied.availability).toBe('partial');
+    });
+
+    it('unavailable はそのまま返す（summary(0) から complete に化けさせない）', () => {
+        const review = buildUnavailableReview(JOB, HASH, 'storage_budget');
+        expect(applyReviewBudget(review)).toBe(review);
+        expect(applyReviewBudget(review).availability).toBe('unavailable');
+    });
+});
+
+describe('buildReviewCandidates: availability', () => {
+    it('句はあるが候補 0 件でも complete（素材はあった）', () => {
+        const review = build([phrase(0), phrase(1), phrase(2)]);
+        expect(review.availability).toBe('complete');
+        expect(review.candidates).toEqual([]);
+        expect(review.summary).toMatchObject({ totalPhrases: 3, candidateTotal: 0, savedCandidates: 0 });
+        expect(review).not.toHaveProperty('unavailableReason');
+    });
+
+    it('句が 0 件なら unavailable（reason no_phrases）・使った閾値を記録', () => {
+        const review = build([], { threshold: 0.8 });
+        expect(review.availability).toBe('unavailable');
+        expect(review.unavailableReason).toBe('no_phrases');
+        expect(review.threshold).toBe(0.8);
+        expect(review.candidates).toEqual([]);
+        expect(review.summary.totalPhrases).toBe(0);
+    });
+
+    it('配列でない入力（実行時の壊れた値）も unavailable no_phrases', () => {
+        const review = buildReviewCandidates(null as unknown as ReviewPhraseInput[], JOB, HASH);
+        expect(review.availability).toBe('unavailable');
+        expect(review.unavailableReason).toBe('no_phrases');
+    });
+});
+
+describe('buildUnavailableReview', () => {
+    it('最小形: version・threshold・hash・jobId・summary(0)・unavailable・reason・空 candidates', () => {
+        const review = buildUnavailableReview(JOB, HASH, 'storage_budget');
+        expect(review).toStrictEqual({
+            version: TRANSCRIPT_REVIEW_VERSION,
+            threshold: LOW_CONFIDENCE_THRESHOLD,
+            sourceTextHash: HASH,
+            sourceJobId: JOB,
+            summary: {
+                totalPhrases: 0,
+                lowConfidence: 0,
+                recognitionFlagged: 0,
+                candidateTotal: 0,
+                unknownConfidence: 0,
+                unknownRecognitionStatus: 0,
+                noTimeCandidates: 0,
+                savedCandidates: 0,
+            },
+            availability: 'unavailable',
+            unavailableReason: 'storage_budget',
+            candidates: [],
+        });
+        expect(measureReviewJsonBytes(review)).toBeLessThan(1024);
+    });
+
+    it('閾値を指定できる', () => {
+        expect(buildUnavailableReview(JOB, HASH, 'internal_error', 0.6).threshold).toBe(0.6);
+    });
+});
+
+describe('buildReviewCandidatesSafe', () => {
+    it('正常系は buildReviewCandidates と同じ結果', () => {
+        const input = [phrase(0, { confidence: 0.1 }), phrase(1)];
+        expect(buildReviewCandidatesSafe(input, JOB, HASH)).toStrictEqual(buildReviewCandidates(input, JOB, HASH));
+    });
+
+    it('内部で投げたら unavailable internal_error（本文完成を失敗させない）', () => {
+        const badIndex = buildReviewCandidatesSafe(
+            [{ ...phrase(0, { confidence: 0.1 }), index: undefined as unknown as number }], JOB, HASH);
+        expect(badIndex.availability).toBe('unavailable');
+        expect(badIndex.unavailableReason).toBe('internal_error');
+        expect(badIndex.candidates).toEqual([]);
+
+        const badThreshold = buildReviewCandidatesSafe([phrase(0)], JOB, HASH, { threshold: 2 });
+        expect(badThreshold.availability).toBe('unavailable');
+        expect(badThreshold.unavailableReason).toBe('internal_error');
+        expect(badThreshold.threshold).toBe(LOW_CONFIDENCE_THRESHOLD);
+    });
+});

--- a/src/server/reviewCandidates.ts
+++ b/src/server/reviewCandidates.ts
@@ -1,0 +1,323 @@
+/**
+ * 要確認候補（低信頼・認識結果要確認の句）の**抽出だけ**を行う純関数群（設計 §B2・2026-09-05）。
+ *
+ * 入力は永続化レーンが Azure バッチ結果（`recognizedPhrases`）から作った「解析済みの句情報」
+ * （`ReviewPhraseInput`）。ここでは Azure の生 JSON を再解析しない。出力は凍結契約 `TranscriptReview`。
+ *
+ * 🔴 「低信頼＝誤り」「候補ゼロ＝正確」ではない。高い confidence は正確さの保証ではなく、話者誤り・
+ *    発話抜けは検出できない。この関数は候補を挙げるだけで、正確さを判定しない（候補にしないだけ）。
+ * 🔴 confidence 欠損・範囲外・非数値・NaN は「不明」。高信頼にも 0 の低信頼にも置換しない。
+ * 🔴 読めない時刻を 0 秒にしない。時刻不明でも候補になり得る（再生・本文移動は後段 UI が無効化する）。
+ * 🔴 `paragraphStartLine` はここでは付けない（永続化レーンが Markdown 生成時に対応付けて補う）。
+ * 🔴 Firestore は `undefined` 値を拒否するので、取れなかった任意項目はキー自体を置かない。
+ * 🔴 候補を保存予算で減らしても summary の総件数は全句から算出した値を保ち、`savedCandidates` に実保存数。
+ * 🔴 永続化レーンは `paragraphStartLine` を補った後に `applyReviewBudget` を再適用する（アンカー分のバイト増）。
+ */
+import {
+    LOW_CONFIDENCE_THRESHOLD,
+    REVIEW_EXCERPT_MAX_CHARS,
+    REVIEW_MAX_CANDIDATES,
+    REVIEW_MAX_JSON_BYTES,
+    TRANSCRIPT_REVIEW_VERSION,
+    type ReviewCandidate,
+    type ReviewReason,
+    type ReviewSummary,
+    type TranscriptReview,
+} from '@/lib/transcriptReviewContract';
+
+/**
+ * 永続化レーンが `recognizedPhrases[]` の 1 句から作って渡す「解析済みの句情報」。
+ * 値の妥当性（有限か・範囲内か）はこちらで検査するので、呼び出し側は読めた値をそのまま置けばよい。
+ */
+export interface ReviewPhraseInput {
+    /** 元 `recognizedPhrases` の配列 index（`phraseId` の元）。🔴 非負整数以外は TypeError */
+    index: number;
+    /** `nBest[0].display`。空文字あり（取れなければ空文字） */
+    text: string;
+    /** `nBest[0].confidence`。有限の 0〜1 のみ有効。それ以外は「不明」 */
+    confidence?: number;
+    /** 句の `recognitionStatus`。ジョブ status と混同しない */
+    recognitionStatus?: string;
+    /** `"spk:N"`。話者分離が効いていなければ null/undefined */
+    speaker?: string | null;
+    /** 秒。読めた句だけ持つ（読めない時刻を 0 にしない） */
+    startSec?: number;
+    endSec?: number;
+}
+
+export interface BuildReviewCandidatesOptions {
+    /** 低信頼の閾値（既定 `LOW_CONFIDENCE_THRESHOLD`）。有限の 0〜1 以外は RangeError */
+    threshold?: number;
+    /**
+     * 分かっている結果音声長（秒）。有限の正数のときだけ有効で、開始がこれを超える時刻は「読めない」
+     * 扱いにする（不正時刻を再生に使わない・仕様 B2）。0 や未指定は「長さ不明」として無視する。
+     */
+    audioSec?: number;
+}
+
+/** `availability === 'unavailable'` の理由コード。UI の文言対応に使う（契約上は string）。 */
+export type ReviewUnavailableReason =
+    | 'no_phrases'       // 抽出材料（句）が 1 つも無い
+    | 'internal_error'   // 抽出中の内部エラー（候補配列を作れなかった）
+    | 'storage_budget';  // 永続化側の保存予算不足（完全形を文書に載せられない）
+
+/**
+ * Azure Speech の句 `recognitionStatus` の既知値。`Success` 以外の既知値は「認識結果要確認」。
+ * ここに無い文字列・欠落は「認識状態不明」として数え、それだけでは候補にしない。
+ */
+export const KNOWN_RECOGNITION_STATUSES: ReadonlySet<string> = new Set([
+    'Success',
+    'Failure',
+    'NoMatch',
+    'InitialSilenceTimeout',
+    'BabbleTimeout',
+    'Error',
+]);
+
+const SUCCESS_STATUS = 'Success';
+
+type StatusKind = 'success' | 'flagged' | 'unknown';
+
+interface ClassifiedStatus {
+    kind: StatusKind;
+    /** 文字列として読めたときだけ（欠落は undefined）。未知の文字列もそのまま保持する */
+    status?: string;
+}
+
+const classifyStatus = (raw: unknown): ClassifiedStatus => {
+    const status = typeof raw === 'string' ? raw.trim() : '';
+    if (status === '') return { kind: 'unknown' };
+    if (status === SUCCESS_STATUS) return { kind: 'success', status };
+    if (KNOWN_RECOGNITION_STATUSES.has(status)) return { kind: 'flagged', status };
+    return { kind: 'unknown', status };
+};
+
+/** 有限の 0〜1 だけを有効な confidence とする。非数値・NaN・範囲外は undefined（不明）。 */
+const toValidConfidence = (raw: unknown): number | undefined =>
+    typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : undefined;
+
+/** 有限かつ 0 <= start <= end（さらに音声長が分かれば start <= audioSec）のときだけ時刻を返す。 */
+const toValidTime = (
+    start: unknown,
+    end: unknown,
+    audioSec: number | undefined,
+): { startSec: number; endSec: number } | undefined => {
+    if (typeof start !== 'number' || typeof end !== 'number') return undefined;
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return undefined;
+    if (start < 0 || start > end) return undefined;
+    if (audioSec !== undefined && start > audioSec) return undefined;
+    return { startSec: start, endSec: end };
+};
+
+const resolveThreshold = (threshold: number | undefined): number => {
+    if (threshold === undefined) return LOW_CONFIDENCE_THRESHOLD;
+    if (typeof threshold !== 'number' || !Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+        throw new RangeError('threshold は有限の 0〜1 で指定してください');
+    }
+    return threshold;
+};
+
+const resolveAudioSec = (audioSec: number | undefined): number | undefined =>
+    typeof audioSec === 'number' && Number.isFinite(audioSec) && audioSec > 0 ? audioSec : undefined;
+
+/** 抜粋は文字（コードポイント）単位で切る。サロゲートペアを途中で割らない。 */
+const buildExcerpt = (text: string): { excerpt: string; excerptTruncated: boolean } => {
+    const chars = Array.from(text);
+    if (chars.length <= REVIEW_EXCERPT_MAX_CHARS) return { excerpt: text, excerptTruncated: false };
+    return { excerpt: chars.slice(0, REVIEW_EXCERPT_MAX_CHARS).join(''), excerptTruncated: true };
+};
+
+/** 句 index から決定的に採番する（同一結果の再取り込みで同じ ID）。 */
+export const phraseIdFor = (index: number): string => {
+    if (!Number.isInteger(index) || index < 0) {
+        throw new TypeError('ReviewPhraseInput.index は非負整数（recognizedPhrases の配列 index）で渡してください');
+    }
+    return `p${index}`;
+};
+
+const emptySummary = (): ReviewSummary => ({
+    totalPhrases: 0,
+    lowConfidence: 0,
+    recognitionFlagged: 0,
+    candidateTotal: 0,
+    unknownConfidence: 0,
+    unknownRecognitionStatus: 0,
+    noTimeCandidates: 0,
+    savedCandidates: 0,
+});
+
+/** 保存予算の判定に使う UTF-8 JSON サイズ（バイト）。永続化側の見積りにも使える。 */
+export function measureReviewJsonBytes(review: TranscriptReview): number {
+    const json = JSON.stringify(review);
+    return typeof Buffer !== 'undefined'
+        ? Buffer.byteLength(json, 'utf8')
+        : new TextEncoder().encode(json).byteLength;
+}
+
+/**
+ * 素材が無い／候補配列を作れないときの最小形。summary は契約上必須なので 0 で埋めるが、
+ * `availability === 'unavailable'` のときの summary は「算出値」ではない（UI は summary を出さない）。
+ */
+export function buildUnavailableReview(
+    sourceJobId: string,
+    sourceTextHash: string,
+    reason: string,
+    threshold: number = LOW_CONFIDENCE_THRESHOLD,
+): TranscriptReview {
+    return {
+        version: TRANSCRIPT_REVIEW_VERSION,
+        threshold,
+        sourceTextHash,
+        sourceJobId,
+        summary: emptySummary(),
+        availability: 'unavailable',
+        unavailableReason: reason,
+        candidates: [],
+    };
+}
+
+interface OrderedCandidate {
+    candidate: ReviewCandidate;
+    index: number;
+    /** 時刻のある候補だけ持つ */
+    startSec?: number;
+}
+
+/**
+ * 句配列から要確認候補と集計を作る。副作用なし・決定的（同じ入力なら同じ出力）。
+ *
+ * 判定規則（仕様 B2）:
+ * - `Success` かつ有効 confidence < 閾値 → `low_confidence`（ちょうどは含めない）
+ * - 既知の非 `Success` の recognitionStatus → `recognition_status`（confidence は見ない）
+ * - `Success` だが表示テキストが空 → `empty_text`
+ * - recognitionStatus 欠落／未知でも有効 confidence < 閾値 → `low_confidence` + `unknown_confidence`
+ *   （契約の補助理由。「認識状態不明」の印であって confidence が無いという意味ではない）
+ * - 有効 confidence が無く、recognitionStatus にも判定材料が無い句は候補にしない（不明として集計のみ）
+ * - 1 句に複数理由でも候補は 1 件。候補総数は ID の和集合
+ *
+ * 保存予算: 時刻あり候補を時刻昇順（同時刻は index 順）、その後に時刻なしを index 順で並べ、
+ * `REVIEW_MAX_CANDIDATES` 件かつ JSON `REVIEW_MAX_JSON_BYTES` バイト以内に収まるまで末尾を落とす。
+ * 落としたら `partial`、全件なら `complete`。句が 0 件なら `unavailable`（reason `no_phrases`）。
+ *
+ * @throws RangeError 閾値が有限の 0〜1 でない
+ * @throws TypeError  index が非負整数でない（呼び出し側の契約違反）
+ */
+export function buildReviewCandidates(
+    phrases: readonly ReviewPhraseInput[],
+    sourceJobId: string,
+    sourceTextHash: string,
+    options: BuildReviewCandidatesOptions = {},
+): TranscriptReview {
+    const threshold = resolveThreshold(options.threshold);
+    if (!Array.isArray(phrases) || phrases.length === 0) {
+        return buildUnavailableReview(sourceJobId, sourceTextHash, 'no_phrases', threshold);
+    }
+    const audioSec = resolveAudioSec(options.audioSec);
+
+    const summary = emptySummary();
+    const ids = new Set<string>();
+    const timed: OrderedCandidate[] = [];
+    const untimed: OrderedCandidate[] = [];
+
+    for (const phrase of phrases) {
+        summary.totalPhrases += 1;
+        const confidence = toValidConfidence(phrase.confidence);
+        if (confidence === undefined) summary.unknownConfidence += 1;
+        const status = classifyStatus(phrase.recognitionStatus);
+        if (status.kind === 'unknown') summary.unknownRecognitionStatus += 1;
+        const text = typeof phrase.text === 'string' ? phrase.text.trim() : '';
+
+        // 理由は契約の宣言順で並べる（決定的な出力）
+        const reasons: ReviewReason[] = [];
+        const isLowConfidence = status.kind !== 'flagged' && confidence !== undefined && confidence < threshold;
+        if (isLowConfidence) reasons.push('low_confidence');
+        if (status.kind === 'flagged') reasons.push('recognition_status');
+        if (status.kind === 'success' && text === '') reasons.push('empty_text');
+        if (isLowConfidence && status.kind === 'unknown') reasons.push('unknown_confidence');
+        if (reasons.length === 0) continue;
+
+        if (isLowConfidence) summary.lowConfidence += 1;
+        if (status.kind === 'flagged' || reasons.includes('empty_text')) summary.recognitionFlagged += 1;
+
+        const phraseId = phraseIdFor(phrase.index);
+        if (ids.has(phraseId)) continue; // 同じ index が二重に渡っても候補は 1 件（ID の和集合）
+        ids.add(phraseId);
+
+        const candidate: ReviewCandidate = { phraseId, reasons, ...buildExcerpt(text) };
+        if (confidence !== undefined) candidate.confidence = confidence;
+        if (status.status !== undefined) candidate.recognitionStatus = status.status;
+        if (typeof phrase.speaker === 'string' && phrase.speaker !== '') candidate.speaker = phrase.speaker;
+
+        const time = toValidTime(phrase.startSec, phrase.endSec, audioSec);
+        if (time) {
+            candidate.startSec = time.startSec;
+            candidate.endSec = time.endSec;
+            timed.push({ candidate, index: phrase.index, startSec: time.startSec });
+        } else {
+            summary.noTimeCandidates += 1;
+            untimed.push({ candidate, index: phrase.index });
+        }
+    }
+    summary.candidateTotal = ids.size;
+
+    timed.sort((a, b) => (a.startSec as number) - (b.startSec as number) || a.index - b.index);
+    untimed.sort((a, b) => a.index - b.index);
+    const ordered = [...timed, ...untimed].map((entry) => entry.candidate);
+
+    return applyReviewBudget({
+        version: TRANSCRIPT_REVIEW_VERSION,
+        threshold,
+        sourceTextHash,
+        sourceJobId,
+        summary,
+        availability: 'complete',
+        candidates: ordered,
+    });
+}
+
+/**
+ * 保存予算を（再）適用する純関数。候補を `REVIEW_MAX_CANDIDATES` 件に切り、JSON（UTF-8）が
+ * `REVIEW_MAX_JSON_BYTES` に収まるまで末尾（並び順の後方）から落とし、`savedCandidates` と
+ * `availability`（全件なら complete・省略したら partial）を整える。summary の総件数は変えない。
+ *
+ * 🔴 `buildReviewCandidates` の内部でも使うが、永続化レーンが `paragraphStartLine` を補った**後**にも
+ *    必ず呼ぶこと。アンカーは 1 件あたり数十バイト増えるので、抽出時に上限ぎりぎりだった候補は最終形で
+ *    超え得る。`savedCandidates`/`availability` を反映した最終形そのものを毎回測る（過小評価を残さない）。
+ * `availability === 'unavailable'` はそのまま返す（summary(0) から complete に化けさせない）。
+ */
+export function applyReviewBudget(review: TranscriptReview): TranscriptReview {
+    if (review.availability === 'unavailable') return review;
+    const result: TranscriptReview = {
+        ...review,
+        summary: { ...review.summary },
+        candidates: review.candidates.slice(0, REVIEW_MAX_CANDIDATES),
+    };
+    const settle = (): void => {
+        result.summary.savedCandidates = result.candidates.length;
+        result.availability =
+            result.summary.savedCandidates === result.summary.candidateTotal ? 'complete' : 'partial';
+    };
+    settle();
+    while (result.candidates.length > 0 && measureReviewJsonBytes(result) > REVIEW_MAX_JSON_BYTES) {
+        result.candidates = result.candidates.slice(0, -1);
+        settle();
+    }
+    return result;
+}
+
+/**
+ * 本文完成を候補表示のために失敗させないための入口。`buildReviewCandidates` が投げたら
+ * `unavailable`（reason `internal_error`）を返す。永続化レーンはこちらを呼べばよい。
+ */
+export function buildReviewCandidatesSafe(
+    phrases: readonly ReviewPhraseInput[],
+    sourceJobId: string,
+    sourceTextHash: string,
+    options: BuildReviewCandidatesOptions = {},
+): TranscriptReview {
+    try {
+        return buildReviewCandidates(phrases, sourceJobId, sourceTextHash, options);
+    } catch {
+        return buildUnavailableReview(sourceJobId, sourceTextHash, 'internal_error');
+    }
+}

--- a/src/server/transcriptionJob.test.ts
+++ b/src/server/transcriptionJob.test.ts
@@ -43,6 +43,7 @@ vi.mock('./firebaseAdmin', () => ({
 
 import { claimJobForFinalize, commitTerminalOutcome, FINALIZE_LEASE_MS, getTranscriptionJob, getTranscriptionJobByDocId, recordAzureObservation, updateTranscriptionJob, type TerminalOutcome } from './transcriptionJob';
 import type { AzureBatchStatus } from '@/lib/azureBatchContract';
+import type { TranscriptReview } from '@/lib/transcriptReviewContract';
 
 const NOW_MS = 1_800_000_000_000;
 const JOB_ID = 'synthetic-job';
@@ -80,6 +81,23 @@ const successOutcome: TerminalOutcome = {
     speakers: 2,
 };
 const failureOutcome: TerminalOutcome = { kind: 'failed', reason: '合成の失敗理由' };
+/** 合成の要確認候補（設計 B2）。本文と同じトランザクションで文書にだけ保存される */
+const syntheticReview: TranscriptReview = {
+    version: 1,
+    threshold: 0.75,
+    sourceTextHash: 'a'.repeat(64),
+    sourceJobId: JOB_ID,
+    summary: {
+        totalPhrases: 3, lowConfidence: 1, recognitionFlagged: 0, candidateTotal: 1,
+        unknownConfidence: 0, unknownRecognitionStatus: 0, noTimeCandidates: 0, savedCandidates: 1,
+    },
+    availability: 'complete',
+    candidates: [{
+        phraseId: 'p1', reasons: ['low_confidence'], excerpt: '合成の低信頼句', excerptTruncated: false,
+        confidence: 0.4, recognitionStatus: 'Success', speaker: 'spk:1', startSec: 1, endSec: 2, paragraphStartLine: 1,
+    }],
+};
+const reviewOutcome: TerminalOutcome = { ...successOutcome, review: syntheticReview };
 const terminalParams = (outcome: TerminalOutcome) => ({ jobId: JOB_ID, docId: DOC_ID, expectedOwnerId: OWNER_ID, outcome });
 
 beforeEach(() => {
@@ -366,6 +384,52 @@ describe('commitTerminalOutcome', () => {
         });
         expect(doubles.jobs.get(JOB_PATH)).toMatchObject({ status: 'succeeded', speakers: 2, docId: DOC_ID });
         expect(doubles.update).not.toHaveBeenCalled();
+    });
+
+    it('review 無しの成功は transcriptReview キー自体を書かない（旧文書と同じ形）', async () => {
+        await expect(commitTerminalOutcome(terminalParams(successOutcome))).resolves.toBe('committed');
+        expect(doubles.set.mock.calls[0][1]).not.toHaveProperty('transcriptReview');
+        expect(doubles.jobs.get(DOC_PATH)).not.toHaveProperty('transcriptReview');
+    });
+
+    it('🔴 review 付きの成功は本文・status と同じ set で transcriptReview を保存し、job には複製しない', async () => {
+        await expect(commitTerminalOutcome(terminalParams(reviewOutcome))).resolves.toBe('committed');
+        expect(doubles.runTransaction).toHaveBeenCalledTimes(1);
+        expect(doubles.set).toHaveBeenCalledTimes(2);
+        expect(doubles.set).toHaveBeenNthCalledWith(1, { id: DOC_PATH }, {
+            transcription: successOutcome.transcription,
+            generatedByModel: successOutcome.generatedByModel,
+            transcriptReview: syntheticReview,
+            status: 'completed',
+            processingProgress: 'SERVER_DELETE',
+            updatedAt: 'SERVER_TS',
+        }, { merge: true });
+        expect(doubles.set).toHaveBeenNthCalledWith(2, { id: JOB_PATH }, {
+            status: 'succeeded', speakers: 2, updatedAt: 'SERVER_TS',
+        }, { merge: true });
+        expect(doubles.jobs.get(DOC_PATH)).toMatchObject({ status: 'completed', transcriptReview: syntheticReview });
+        expect(doubles.jobs.get(JOB_PATH)).not.toHaveProperty('transcriptReview');
+    });
+
+    it('review 付きでも本文の書き込みが失敗したら候補も残らず、リース切れ後に再確定できる', async () => {
+        const error = new Error('synthetic transaction failure');
+        doubles.set.mockImplementationOnce(() => { throw error; });
+        await expect(commitTerminalOutcome(terminalParams(reviewOutcome))).rejects.toBe(error);
+        expect(doubles.jobs.get(DOC_PATH)).not.toHaveProperty('transcriptReview');
+        expect(doubles.jobs.get(DOC_PATH)?.status).toBe('processing');
+        expect(doubles.jobs.get(JOB_PATH)?.status).toBe('finalizing');
+
+        vi.mocked(Date.now).mockReturnValue(NOW_MS + FINALIZE_LEASE_MS + 1);
+        await expect(claimJobForFinalize(JOB_ID)).resolves.toMatchObject({ status: 'finalizing' });
+        await expect(commitTerminalOutcome(terminalParams(reviewOutcome))).resolves.toBe('committed');
+        expect(doubles.jobs.get(DOC_PATH)).toMatchObject({ status: 'completed', transcriptReview: syntheticReview });
+    });
+
+    it.each(['completed', 'failed'])('%s の文書へ review 付きで再確定しても候補を書かない（完成後の編集を上書きしない）', async status => {
+        doubles.jobs.set(DOC_PATH, makeDocument({ status, transcription: '利用者の合成編集' }));
+        await expect(commitTerminalOutcome(terminalParams(reviewOutcome))).resolves.toBe('committed');
+        expect(doubles.jobs.get(DOC_PATH)).toEqual(makeDocument({ status, transcription: '利用者の合成編集' }));
+        expect(doubles.set).toHaveBeenCalledTimes(1);
     });
 
     it('失敗でも文書を消さず理由本文を残し、ジョブも同じトランザクションで失敗にする', async () => {

--- a/src/server/transcriptionJob.test.ts
+++ b/src/server/transcriptionJob.test.ts
@@ -411,6 +411,29 @@ describe('commitTerminalOutcome', () => {
         expect(doubles.jobs.get(JOB_PATH)).not.toHaveProperty('transcriptReview');
     });
 
+    it('🔴 文書全体が 1MiB を超えるときは要確認データを省いて本文だけ保存する（B4・実 title を含めて判定）', async () => {
+        // 極端に長い title があると、本文＋review で Firestore の 1MiB を超え得る。route の事前チェックは title を
+        // 見ないので、終端トランザクション内で実フィールドを含めて最終判定し、review を落として本文だけ保存する。
+        doubles.jobs.set(DOC_PATH, makeDocument({ title: 'a'.repeat(1_040_000) }));
+        await expect(commitTerminalOutcome(terminalParams(reviewOutcome))).resolves.toBe('committed');
+        const docWrite = doubles.set.mock.calls.find((call) => call[0].id === DOC_PATH)?.[1] as Record<string, unknown>;
+        expect(docWrite).toMatchObject({ transcription: successOutcome.transcription, status: 'completed' });
+        expect(docWrite).not.toHaveProperty('transcriptReview');
+        expect(doubles.warn).toHaveBeenCalledWith(
+            '文書全体が保存上限に近いため要確認データを省いて本文だけ保存',
+            expect.objectContaining({ docId: DOC_ID }),
+        );
+        // 本文は保存できたので job は成功で終端化する
+        expect(doubles.jobs.get(JOB_PATH)?.status).toBe('succeeded');
+    });
+
+    it('文書全体が上限内なら要確認データはそのまま保存する（実 title を含めても収まる）', async () => {
+        doubles.jobs.set(DOC_PATH, makeDocument({ title: '通常のファイル名.mp4' }));
+        await expect(commitTerminalOutcome(terminalParams(reviewOutcome))).resolves.toBe('committed');
+        const docWrite = doubles.set.mock.calls.find((call) => call[0].id === DOC_PATH)?.[1] as Record<string, unknown>;
+        expect(docWrite).toHaveProperty('transcriptReview', syntheticReview);
+    });
+
     it('review 付きでも本文の書き込みが失敗したら候補も残らず、リース切れ後に再確定できる', async () => {
         const error = new Error('synthetic transaction failure');
         doubles.set.mockImplementationOnce(() => { throw error; });

--- a/src/server/transcriptionJob.ts
+++ b/src/server/transcriptionJob.ts
@@ -20,6 +20,17 @@ const logger = createLogger('server/transcriptionJob');
 export const TRANSCRIPTION_JOBS_COLLECTION = 'transcriptionJobs';
 
 /**
+ * Firestore の 1 文書上限（1 MiB）と、その手前で確保する余白。
+ * 🔴 要確認データ(transcriptReview)を載せた**文書全体**がこの上限を超えないかは、既存フィールド（title 等）の
+ *    実サイズを含めて確定判定しなければならない。route 側の reviewFitsDocument は本文＋review＋一定の余白しか見ないため、
+ *    極端に長い title があると見落とす。ここ（終端トランザクション）は tx で読んだ実フィールドで最終判定し、
+ *    超えるなら review を落として**本文だけは必ず保存する**（設計 B4 の本文優先）。
+ *    余白は Firestore の実サイズ計算（フィールド名・型オーバーヘッド）と JSON 概算の差を吸収するためのもの。
+ */
+const FIRESTORE_DOC_LIMIT_BYTES = 1024 * 1024;
+const DOC_WRITE_MARGIN_BYTES = 32 * 1024;
+
+/**
  * `finalizing` は確定処理中の一時状態（内部用）。
  * 🔴 並行に status が 2 回叩かれても確定を 1 回にするための CAS ロック（設計 §3.7・冪等性）。
  *    利用者向けの公開ステータスは running / succeeded / failed の 3 値だけ（finalizing は running 相当に見せる）。
@@ -210,11 +221,29 @@ export async function commitTerminalOutcome(params: {
         } else if (doc.jobId !== undefined && doc.jobId !== jobId) {
             logger.warn('ジョブが異なる文書の終端更新をスキップ', { docId });
         } else {
+            // 🔴 文書全体（既存フィールド＋本文＋review）が 1MiB を超えないか、実フィールドで最終判定する。
+            //    超えるなら review を落として本文だけ保存する（B4: 本文は必ず完成させる）。
+            let reviewToWrite = outcome.kind === 'succeeded' ? outcome.review : undefined;
+            if (reviewToWrite !== undefined && outcome.kind === 'succeeded') {
+                const projected = {
+                    ...doc,
+                    transcription: outcome.transcription,
+                    generatedByModel: outcome.generatedByModel,
+                    status: 'completed',
+                    transcriptReview: reviewToWrite,
+                };
+                delete (projected as Record<string, unknown>).processingProgress;
+                const projectedBytes = Buffer.byteLength(JSON.stringify(projected), 'utf8');
+                if (projectedBytes > FIRESTORE_DOC_LIMIT_BYTES - DOC_WRITE_MARGIN_BYTES) {
+                    logger.warn('文書全体が保存上限に近いため要確認データを省いて本文だけ保存', { docId, projectedBytes });
+                    reviewToWrite = undefined;
+                }
+            }
             tx.set(docRef, outcome.kind === 'succeeded' ? {
                 transcription: outcome.transcription,
                 generatedByModel: outcome.generatedByModel,
                 // 書く先は processing 文書だけ（上の分岐）。processing 文書は候補を持たないので merge で旧候補と混ざらない。
-                ...(outcome.review !== undefined && { transcriptReview: outcome.review }),
+                ...(reviewToWrite !== undefined && { transcriptReview: reviewToWrite }),
                 status: 'completed' satisfies TranscriptionDocStatus,
                 processingProgress: FieldValue.delete(),
                 updatedAt,

--- a/src/server/transcriptionJob.ts
+++ b/src/server/transcriptionJob.ts
@@ -13,6 +13,7 @@ import { getAdminFirestore } from './firebaseAdmin';
 import { TRANSCRIPTIONS_COLLECTION, type TranscriptionDocStatus } from './transcriptionDocument';
 import { createLogger } from '@/lib/logger';
 import type { AzureBatchStatus } from '@/lib/azureBatchContract';
+import type { TranscriptReview } from '@/lib/transcriptReviewContract';
 
 const logger = createLogger('server/transcriptionJob');
 
@@ -63,7 +64,17 @@ export interface CreateTranscriptionJobInput {
 }
 
 export type TerminalOutcome =
-    | { kind: 'succeeded'; transcription: string; generatedByModel: string; speakers: number }
+    | {
+        kind: 'succeeded';
+        transcription: string;
+        generatedByModel: string;
+        speakers: number;
+        /**
+         * 要確認候補（設計 B2/B4）。本文・status・job 終端と**同じトランザクション**で文書へ保存する（job には複製しない）。
+         * 省略時はフィールドを書かない（旧文書と同じ形）。再確定のたびに呼び出し側が決定的に作り直す（後から append しない）。
+         */
+        review?: TranscriptReview;
+    }
     | { kind: 'failed'; reason: string };
 
 const db = (): Firestore => getAdminFirestore();
@@ -202,6 +213,8 @@ export async function commitTerminalOutcome(params: {
             tx.set(docRef, outcome.kind === 'succeeded' ? {
                 transcription: outcome.transcription,
                 generatedByModel: outcome.generatedByModel,
+                // 書く先は processing 文書だけ（上の分岐）。processing 文書は候補を持たないので merge で旧候補と混ざらない。
+                ...(outcome.review !== undefined && { transcriptReview: outcome.review }),
                 status: 'completed' satisfies TranscriptionDocStatus,
                 processingProgress: FieldValue.delete(),
                 updatedAt,


### PR DESCRIPTION
## 概要

全文文字起こしに**要確認箇所（低信頼句）のデータ層**を追加します（PR2・仕様 §B2/B4）。バッチは部分再実行ができないため「再試行」ではなく、Azure の句ごとの信頼度から**要確認箇所を可視化する素材**を生成し、完成文書に保存します。UI は PR3。

## エージェントチーム（Fable 5.1 のみ）
- **継ぎ目（lead 先行固定）**: `TranscriptReview` などの型と閾値・上限定数。
- **レーンA（抽出・純関数）**: `buildReviewCandidates` ほか。信頼度・認識状態から候補・summary・保存予算。
- **レーンB（配線・保存）**: 解析器に信頼度を持たせ、段落行アンカーを作り、確定処理で文書と原子保存。
- lead が継ぎ目固定・裁定（ID命名・予算方針の統一）・統合・全検証を担当。

## 主な内容
- **抽出**: 低信頼(Success かつ conf<0.75)・非Success・空text を理由分け。conf 欠損/範囲外/NaN は不明として 0 埋めしない。候補は 200 件かつ JSON 128KiB 以内（時刻順に末尾を落として partial）。
- **保存**: 解析器が句ごとに confidence/recognitionStatus/phraseIndex を載せる。段落行アンカーは描画側と同じ改行規則で数え、**プレーンな1行段落だけ**に付ける（Markdown 構文の波及を遮断）。`commitTerminalOutcome` が本文・status・job と**同一トランザクションで原子保存**。
- **本文優先(B4)**: review 生成・アンカー・予算のどこで失敗しても、本文が読めるなら文書は completed。文書全体が 1MiB を超えるときは review を省いて本文だけ保存（終端トランザクション内で実 title 込みで判定）。

## レビュー（Codex GPT-6 Astra・ultra）
段階的に本物の指摘を是正し、最終 **NO BLOCKING FINDINGS**:
- 段落アンカーの堅牢性（CR/CRLF の行計数・Markdown 構文の後続波及）を修正。
- 文書全体の保存上限を、固定余白ではなく終端トランザクション内の実フィールドで判定するよう修正。
- 錠の実効性を旧実装複製で確認（新テストが旧実装で赤）。

全体テスト **1,889 passed / 0 failed**。tsc・lint 緑。

## 含めないもの（後続）
PR3 要確認UI・PR4 推定残り時間。restore/copy での review 引き継ぎ（仕様 C2・PR3 で条件付き）。アップロード上限緩和（別件）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
