### PR TITLE
fix(プロンプト): 組み込み「全文文字起こし」がログインユーザーで使えない本番エラーを修正

### DIFF
--- a/src/lib/promptPermissions.test.ts
+++ b/src/lib/promptPermissions.test.ts
@@ -1,0 +1,141 @@
+/**
+ * プロンプト利用権限チェックの錠。
+ *
+ * 🔴 本番事故（2026-09-05）: ログインユーザーが組み込みの「全文文字起こし」プロンプトで
+ * 生成すると「他のユーザーが所有しています」と弾かれた。組み込みプロンプトは
+ * ownerType 'guest' / ownerId 'BUILTIN' なので、ログインユーザー（ownerType 'user' を
+ * 要求）では所有権チェックを通れなかった。
+ *
+ * ここが崩れると、①組み込みプロンプトがログインユーザーで使えなくなる（本番事故の再発）、
+ * あるいは逆に②他人の所有プロンプトを使えてしまう（権限の穴）ことになる。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    hasPromptPermission,
+    validateMultiplePrompts,
+    validatePromptPermission,
+} from './promptPermissions';
+import { TRANSCRIPT_PROMPT } from './transcriptPrompt';
+import { getCurrentUserId, getOwnerType } from './auth';
+import type { Prompt } from './prompts';
+
+// getCurrentUserId / getOwnerType は呼び出し時に評価されるので、テストごとに差し替える
+vi.mock('./auth', () => ({
+    getCurrentUserId: vi.fn(),
+    getOwnerType: vi.fn(),
+}));
+
+const asLoggedIn = (uid: string) => {
+    vi.mocked(getOwnerType).mockReturnValue('user');
+    vi.mocked(getCurrentUserId).mockReturnValue(uid);
+};
+
+const asGuest = () => {
+    vi.mocked(getOwnerType).mockReturnValue('guest');
+    vi.mocked(getCurrentUserId).mockReturnValue('GUEST');
+};
+
+const userPrompt = (over: Partial<Prompt> = {}): Prompt => ({
+    id: 'p-user-1',
+    name: '議事録',
+    content: '…',
+    model: 'gemini-3.8-flash',
+    isDefault: false,
+    ownerType: 'user',
+    ownerId: 'u1',
+    createdBy: 'u1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+});
+
+const guestPrompt = (over: Partial<Prompt> = {}): Prompt =>
+    userPrompt({ id: 'p-guest-1', ownerType: 'guest', ownerId: 'GUEST', createdBy: 'GUEST', ...over });
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('組み込み「全文文字起こし」プロンプトは所有権チェックの対象外', () => {
+    it('🔴 ログインユーザーでも利用できる（本番事故の再発防止）', () => {
+        asLoggedIn('u1');
+        expect(hasPromptPermission(TRANSCRIPT_PROMPT)).toBe(true);
+        expect(() => validatePromptPermission(TRANSCRIPT_PROMPT)).not.toThrow();
+    });
+
+    it('別のログインユーザーでも利用できる（所有者に縛られない）', () => {
+        asLoggedIn('someone-else');
+        expect(hasPromptPermission(TRANSCRIPT_PROMPT)).toBe(true);
+        expect(() => validatePromptPermission(TRANSCRIPT_PROMPT)).not.toThrow();
+    });
+
+    it('ゲストでも利用できる（従来どおり）', () => {
+        asGuest();
+        expect(hasPromptPermission(TRANSCRIPT_PROMPT)).toBe(true);
+        expect(() => validatePromptPermission(TRANSCRIPT_PROMPT)).not.toThrow();
+    });
+
+    it('判定は ID であって ownerType/ownerId ではない', () => {
+        // 組み込みは ownerType 'guest'/ownerId 'BUILTIN' のまま。ID で素通ししている。
+        asLoggedIn('u1');
+        expect(TRANSCRIPT_PROMPT.ownerType).toBe('guest');
+        expect(TRANSCRIPT_PROMPT.ownerId).toBe('BUILTIN');
+        expect(hasPromptPermission(TRANSCRIPT_PROMPT)).toBe(true);
+    });
+});
+
+describe('通常のユーザー所有プロンプト — 所有者だけが使える（正しいガードは維持）', () => {
+    it('所有者本人は true', () => {
+        asLoggedIn('u1');
+        expect(hasPromptPermission(userPrompt({ ownerId: 'u1' }))).toBe(true);
+    });
+
+    it('🔴 他人が所有するプロンプトは false（権限の穴を開けない）', () => {
+        asLoggedIn('u1');
+        expect(hasPromptPermission(userPrompt({ ownerId: 'someone-else' }))).toBe(false);
+    });
+
+    it('他人所有プロンプトは validatePromptPermission が「他のユーザーが所有」で投げる', () => {
+        asLoggedIn('u1');
+        expect(() => validatePromptPermission(userPrompt({ ownerId: 'someone-else' }))).toThrow(
+            /他のユーザーが所有/
+        );
+    });
+
+    it('ゲストはユーザー所有プロンプトを使えない（従来どおり）', () => {
+        asGuest();
+        expect(hasPromptPermission(userPrompt({ ownerId: 'u1' }))).toBe(false);
+        expect(() => validatePromptPermission(userPrompt({ ownerId: 'u1' }))).toThrow(
+            /ログインユーザー専用/
+        );
+    });
+});
+
+describe('ゲスト共有プロンプト — 既存挙動を維持', () => {
+    it('ゲストは利用できる', () => {
+        asGuest();
+        expect(hasPromptPermission(guestPrompt())).toBe(true);
+    });
+
+    it('ログインユーザーは（組み込みでない）ゲスト共有プロンプトは使えない（従来どおり）', () => {
+        asLoggedIn('u1');
+        expect(hasPromptPermission(guestPrompt())).toBe(false);
+    });
+});
+
+describe('validateMultiplePrompts — まとめてチェック', () => {
+    it('組み込み＋自分のプロンプトの混在はすべて valid（ログインユーザー）', () => {
+        asLoggedIn('u1');
+        const result = validateMultiplePrompts([TRANSCRIPT_PROMPT, userPrompt({ ownerId: 'u1' })]);
+        expect(result.valid).toBe(true);
+        expect(result.invalidPrompts).toHaveLength(0);
+    });
+
+    it('他人所有プロンプトだけが invalid として返る（組み込みは通す）', () => {
+        asLoggedIn('u1');
+        const foreign = userPrompt({ id: 'p-foreign', ownerId: 'someone-else' });
+        const result = validateMultiplePrompts([TRANSCRIPT_PROMPT, foreign]);
+        expect(result.valid).toBe(false);
+        expect(result.invalidPrompts.map(p => p.id)).toEqual(['p-foreign']);
+    });
+});

--- a/src/lib/promptPermissions.ts
+++ b/src/lib/promptPermissions.ts
@@ -4,6 +4,7 @@
 
 import { Prompt } from './prompts';
 import { getCurrentUserId, getOwnerType } from './auth';
+import { isTranscriptPrompt } from './transcriptPrompt';
 
 /**
  * プロンプトの利用権限があるかチェック
@@ -11,6 +12,15 @@ import { getCurrentUserId, getOwnerType } from './auth';
  * @returns 権限がある場合true、ない場合false
  */
 export function hasPromptPermission(prompt: Prompt): boolean {
+    // 組み込みの「全文文字起こし」プロンプトは所有権チェックの対象外。
+    // 実体は ownerType 'guest' / ownerId 'BUILTIN'（src/lib/transcriptPrompt.ts）で
+    // Firestore には保存されず、全利用者に一覧の先頭で共通提供される。所有権で判定すると
+    // ログインユーザー（ownerType 'user' を要求）が常に弾かれてしまう。
+    // 判定は名前ではなく予約 ID（TRANSCRIPT_PROMPT_ID）で行う（isTranscriptPrompt）。
+    if (isTranscriptPrompt(prompt)) {
+        return true;
+    }
+
     const currentUserId = getCurrentUserId();
     const currentOwnerType = getOwnerType();
 


### PR DESCRIPTION
## 本番エラーの修正

ログインユーザーが組み込みプロンプト「全文文字起こし」で文書生成すると次のエラーで失敗していました:
> プロンプト「全文文字起こし」を利用する権限がありません。このプロンプトは他のユーザーが所有しています。

## 原因
組み込みの文字起こしプロンプトは `ownerType: 'guest'` / `ownerId: 'BUILTIN'`（Firestore に保存せず全利用者へ一覧先頭で共通提供）。しかし `hasPromptPermission` はログインユーザーに対し `ownerType === 'user' && ownerId === 自分` のみ許可するため、組み込み（guest）は**ログインユーザーでは常に false**になり弾かれていました。ゲストは 'guest' 一致で通るため、アカウントをログイン状態に切り替えたときに顕在化しました。

## 修正
`hasPromptPermission` の先頭で、組み込み文字起こしプロンプト（予約 ID `TRANSCRIPT_PROMPT_ID` / `isTranscriptPrompt`）を所有権チェックの対象外にして許可します。名前ではなく ID で判定。`validateMultiplePrompts` も同関数経由で同時に是正されます。

## 「一通り確認」
本文完成までの経路（保存 `saveTranscription`・`/api/transcribe/submit`・その他の `ownerType` 比較）を追い、いずれも「利用者本人の identity」または「文書/ゲスト既定プロンプトの編集UI」向けで、組み込み生成フローを塞ぐ他の誤ガードは無いことを確認。セキュリティのための所有権ガード（他人のファイル/文書）は無改変です。

## テスト
- 組み込みプロンプトはゲスト/ログイン/別ユーザーいずれでも利用可、通常プロンプトは所有者限定を維持。
- 旧実装（ガード無効化）で錠5件が RED になることを確認（テストが実バグを捕まえる）。
- tsc・eslint 緑、全体テスト緑。

Opus 5 実装・lead 検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
