### PR TITLE
feat: 要確認箇所UI（PR3）＋不具合連絡先の常時表示

### DIFF
--- a/src/components/AppHeader.serviceContactNotice.test.tsx
+++ b/src/components/AppHeader.serviceContactNotice.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SERVICE_CONTACT_NOTICE } from './ServiceContactNotice';
+
+/**
+ * サービスの不具合の連絡先案内は、どの認証状態でも常に見える。
+ * 「文言が HTML に含まれる」だけを錠にすると、閉じたモバイルメニュー(inert)の中や
+ * sr-only の中に落ちても緑になる。隠す仕組みの外に 1 回だけ出ることを DOM で見る。
+ */
+
+const state = vi.hoisted(() => ({
+    user: { uid: 'u1', email: 'a@example.com', displayName: '利用者A', providerData: [{ providerId: 'password' }] } as
+        | { uid: string; email: string; displayName: string; providerData: { providerId: string }[] }
+        | null,
+    authLoading: false,
+    isAdmin: false,
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+    useAuth: () => ({ user: state.user, loading: state.authLoading }),
+}));
+vi.mock('@/hooks/useAdmin', async () => {
+    const { adminAccessResult } = await import('@/testUtils/hookResults');
+    return { useAdmin: () => adminAccessResult(state.isAdmin ? 'allowed' : 'denied') };
+});
+vi.mock('@/hooks/useSystemNotifications', async () => {
+    const { systemNotificationsResult } = await import('@/testUtils/hookResults');
+    return { useSystemNotifications: () => systemNotificationsResult() };
+});
+vi.mock('next/navigation', () => ({
+    usePathname: () => '/home',
+    useSearchParams: () => new URLSearchParams(''),
+}));
+vi.mock('@/lib/auth', () => ({ signOutNow: vi.fn() }));
+// 実物の AccountDeletionFlow は @/lib/firebase を読み込み、API キー未設定で落ちる。
+vi.mock('./AccountDeletionFlow', () => ({
+    useAccountDeletionFlow: () => ({ beginAccountDeletion: vi.fn(), accountDeletionDialog: null }),
+}));
+vi.mock('@/lib/relationships', () => ({ subscribeToPendingSubordinateRelationships: vi.fn(() => vi.fn()) }));
+vi.mock('@/lib/logger', () => ({ createLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }) }));
+vi.mock('./AuthModal', () => ({ default: () => null }));
+vi.mock('./PasswordChangeModal', () => ({ default: () => null }));
+vi.mock('./DisplayNameModal', () => ({ default: () => null }));
+
+const { AppHeader } = await import('./AppHeader');
+
+function parse(html: string): DocumentFragment {
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    return template.content;
+}
+
+const renderHeader = () => parse(renderToStaticMarkup(<AppHeader />));
+
+/** 文言をそのまま本文に持つ最内側の要素。祖先も同じ本文になるので、同じ本文の子を持つ要素は除く。 */
+function noticeElements(root: ParentNode): HTMLElement[] {
+    const holds = (element: Element) => element.textContent?.trim() === SERVICE_CONTACT_NOTICE;
+    return Array.from(root.querySelectorAll<HTMLElement>('*'))
+        .filter(element => holds(element) && !Array.from(element.children).some(holds));
+}
+
+/** 視覚か支援技術のどちらかから隠すユーティリティ。幅限定(lg:hidden 等)も「常時」を破る。 */
+const HIDING_UTILITIES = new Set(['hidden', 'invisible', 'sr-only', 'collapse']);
+const bareUtility = (token: string) => token.split(':').at(-1) ?? token;
+
+/** 隠す仕組み（属性かクラス）を要素自身か祖先に持てば、その要素を返す。 */
+function hidingAncestor(element: Element): Element | null {
+    for (let current: Element | null = element; current; current = current.parentElement) {
+        if (current.hasAttribute('inert') || current.hasAttribute('hidden') || current.getAttribute('aria-hidden') === 'true') {
+            return current;
+        }
+        const classes = (current.getAttribute('class') ?? '').split(/\s+/).map(bareUtility);
+        if (classes.some(cls => HIDING_UTILITIES.has(cls))) return current;
+    }
+    return null;
+}
+
+/** 折り返しや溢れを切り捨てるユーティリティ。狭い画面で文の後半が消える。 */
+const TRUNCATION = /(?:^|\s|:)(?:truncate|line-clamp-\S+|text-ellipsis|whitespace-nowrap)(?=\s|$)/;
+
+const AUTH_STATES: { name: string; setup: () => void }[] = [
+    { name: 'ログイン済み', setup: () => { } },
+    { name: '未ログイン', setup: () => { state.user = null; } },
+    { name: '認証確認中', setup: () => { state.authLoading = true; } },
+    { name: '管理者', setup: () => { state.isAdmin = true; } },
+];
+
+describe('サービス不具合の連絡先案内は常時見える', () => {
+    beforeEach(() => {
+        state.user = { uid: 'u1', email: 'a@example.com', displayName: '利用者A', providerData: [{ providerId: 'password' }] };
+        state.authLoading = false;
+        state.isAdmin = false;
+    });
+
+    it.each(AUTH_STATES)('$name: 案内文が隠されずに 1 回だけ、sticky なヘッダーの中に出る', ({ setup }) => {
+        setup();
+        const found = noticeElements(renderHeader());
+        expect(found, '案内文が描画されていない、または複数回出ている').toHaveLength(1);
+
+        const notice = found[0];
+        const hidden = hidingAncestor(notice);
+        expect(hidden, `隠す仕組みの中にある: ${hidden?.outerHTML.slice(0, 160)}`).toBeNull();
+        expect(notice.className, '切り捨てると狭い画面で文の後半が消える').not.toMatch(TRUNCATION);
+
+        // スクロール後も見え続けるのは、sticky なヘッダーの中にあるから。
+        const header = notice.closest('header');
+        expect(header, 'ヘッダーの外にある').not.toBeNull();
+        expect(header?.classList.contains('sticky')).toBe(true);
+    });
+
+    it('読み上げ順ではメインナビゲーションの後に来る（本題の前に割り込まない）', () => {
+        const root = renderHeader();
+        const nav = root.querySelector('nav[aria-label="メインナビゲーション"]');
+        const [notice] = noticeElements(root);
+        expect(nav).not.toBeNull();
+        expect(nav!.compareDocumentPosition(notice) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    });
+});
+
+describe('陰性統制: 隠す仕組みの検出器が実際に反応する', () => {
+    const firstParagraph = (html: string) => parse(html).querySelector('p')!;
+
+    it.each([
+        ['inert の祖先', '<div inert><p>x</p></div>'],
+        ['aria-hidden の祖先', '<div aria-hidden="true"><p>x</p></div>'],
+        ['hidden 属性', '<p hidden>x</p>'],
+        ['幅限定の hidden クラス', '<div class="shrink-0 lg:hidden"><p>x</p></div>'],
+        ['sr-only', '<p class="sr-only">x</p>'],
+    ])('%s を捕まえる', (_name, html) => {
+        expect(hidingAncestor(firstParagraph(html))).not.toBeNull();
+    });
+
+    it('overflow-hidden や focus-visible:not-sr-only には反応しない', () => {
+        const html = '<div class="overflow-hidden focus-visible:not-sr-only"><p class="text-xs">x</p></div>';
+        expect(hidingAncestor(firstParagraph(html))).toBeNull();
+    });
+
+    it('切り捨て検出器は truncate に反応し、寸法クラスには反応しない', () => {
+        expect(TRUNCATION.test('text-xs truncate text-muted')).toBe(true);
+        expect(TRUNCATION.test('sm:whitespace-nowrap')).toBe(true);
+        expect(TRUNCATION.test('text-xs text-center px-4')).toBe(false);
+    });
+});

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -13,6 +13,7 @@ import AuthModal from './AuthModal';
 import PasswordChangeModal from './PasswordChangeModal';
 import DisplayNameModal from './DisplayNameModal';
 import { useAccountDeletionFlow } from './AccountDeletionFlow';
+import { ServiceContactNotice } from './ServiceContactNotice';
 import { subscribeToPendingSubordinateRelationships } from '@/lib/relationships';
 import { useSystemNotifications } from '@/hooks/useSystemNotifications';
 import { Button } from '@/components/ui/Button';
@@ -471,11 +472,14 @@ export const AppHeader: React.FC = () => {
                                 )}
                             </IconButton>
 
+                            {/* 高さの上限は「画面 − ヘッダー」。ヘッダーは連絡先バーの分だけ 5rem より高く、
+                                バーが折り返すと更に伸びるので、定数ではなく包含ブロック(sticky な header)の
+                                高さ = 100% を引く。絶対配置の子では % が包含ブロックの高さに解決する。 */}
                             <div
                                 id="app-header-mobile-menu"
                                 aria-hidden={!showMobileMenu}
                                 inert={!showMobileMenu}
-                                className={`absolute inset-x-0 top-full z-50 max-h-[calc(100dvh-5rem)] overflow-y-auto overscroll-contain border-y border-border bg-surface shadow-elevation-overlay transition-all duration-150 ease-out motion-reduce:transition-none ${showMobileMenu
+                                className={`absolute inset-x-0 top-full z-50 max-h-[calc(100dvh-100%)] overflow-y-auto overscroll-contain border-y border-border bg-surface shadow-elevation-overlay transition-all duration-150 ease-out motion-reduce:transition-none ${showMobileMenu
                                     ? 'visible translate-y-0 opacity-100'
                                     : 'invisible pointer-events-none -translate-y-1 opacity-0'
                                     }`}
@@ -650,6 +654,10 @@ export const AppHeader: React.FC = () => {
                     </div>
                 </div>
             </div>
+
+            {/* サービス不具合の連絡先。スクロールしても見えるよう sticky なヘッダーの中に置き、
+                読み上げ順ではナビとアカウント操作の後・本文の前に 1 回だけ現れる。 */}
+            <ServiceContactNotice />
 
             <AuthModal
                 isOpen={showAuthModal}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -17,7 +17,10 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
         >
             メインコンテンツへ移動
         </a>
-        <Suspense fallback={<div className="h-20" />}>
+        {/* サスペンス中のプレースホルダ高さは、実ヘッダー（ナビ行＋不具合連絡先バー、デスクトップ約 109px）に
+            近づけて hydration 時のレイアウトシフトを抑える。応答形（375px 未満は連絡先が 2 行）で厳密一致は
+            できないので近似。ヘッダー高を固定値で持たない設計にするのが本筋（別途）。 */}
+        <Suspense fallback={<div className="h-28" />}>
             <AppHeader />
         </Suspense>
         <main

--- a/src/components/DocumentDetailPanel.test.tsx
+++ b/src/components/DocumentDetailPanel.test.tsx
@@ -18,6 +18,9 @@ import {
 } from './DocumentDetailPanel';
 import type { DocumentStatusWatchSnapshot } from '@/hooks/batchTranscriptionClient';
 import { PdfDocumentHeader } from './PdfDocumentHeader';
+import { TranscriptReviewPanel } from './TranscriptReviewPanel';
+import { TranscriptAwareMarkdown } from './TranscriptDocumentView';
+import type { TranscriptReview } from '@/lib/transcriptReviewContract';
 
 const { createPortal, documentPrintPortal, printPdf } = vi.hoisted(() => ({
     createPortal: vi.fn((children: React.ReactNode) => children),
@@ -1772,6 +1775,142 @@ describe('DocumentDetailPanel', () => {
                 .toBe('画面が非表示のため自動確認を止めています。表示に戻ると確認を再開します。');
             expect(describeProcessingFreshness(null, null))
                 .toBe('状態を確認できません。「状態を確認」をお試しください。');
+        });
+    });
+
+    describe('要確認箇所パネル（仕様 B3）', () => {
+        /** 合成の要確認データ（架空の会話） */
+        const syntheticReview: TranscriptReview = {
+            version: 1,
+            threshold: 0.75,
+            sourceTextHash: '0'.repeat(64),
+            sourceJobId: 'job-synthetic',
+            summary: {
+                totalPhrases: 1, lowConfidence: 1, recognitionFlagged: 0, candidateTotal: 1,
+                unknownConfidence: 0, unknownRecognitionStatus: 0, noTimeCandidates: 0, savedCandidates: 1,
+            },
+            availability: 'complete',
+            candidates: [{
+                phraseId: 'p-0', reasons: ['low_confidence'], excerpt: 'いえ、こちらこそ', excerptTruncated: false,
+                confidence: 0.5, startSec: 12.2, endSec: 14, paragraphStartLine: 1,
+            }],
+        };
+        const transcriptText = '[00:12](#t=12) **お客様** いえ、こちらこそ。';
+        const reviewDocument: Transcription = {
+            ...document,
+            id: 'review-1',
+            text: transcriptText,
+            transcriptReview: syntheticReview,
+        };
+
+        type AnyElement = React.ReactElement<Record<string, unknown> & { children?: React.ReactNode }>;
+        const findElement = (
+            node: React.ReactNode,
+            predicate: (element: AnyElement) => boolean,
+        ): AnyElement | null => {
+            if (Array.isArray(node)) {
+                for (const child of node) {
+                    const found = findElement(child, predicate);
+                    if (found) return found;
+                }
+                return null;
+            }
+            if (!React.isValidElement<Record<string, unknown> & { children?: React.ReactNode }>(node)) return null;
+            if (predicate(node)) return node;
+            return findElement(node.props.children, predicate);
+        };
+        const findReviewPanel = (node: React.ReactNode): React.ReactElement<React.ComponentProps<typeof TranscriptReviewPanel>> | null =>
+            findElement(node, element => element.type === TranscriptReviewPanel) as
+                React.ReactElement<React.ComponentProps<typeof TranscriptReviewPanel>> | null;
+        const findTextarea = (node: React.ReactNode): AnyElement | null =>
+            findElement(node, element => element.type === 'textarea');
+
+        it('🔴 review を持つ完成文書では、表示モードで本文の上（pdf-preview の外）にパネルを置き、本文照合の材料を渡す', () => {
+            mockPanelState();
+            const tree = DocumentDetailPanel({ document: reviewDocument, onDocumentUpdate: async () => undefined });
+
+            const panel = findReviewPanel(tree);
+            expect(panel).not.toBeNull();
+            expect(panel?.props.documentId).toBe('review-1');
+            expect(panel?.props.review).toBe(syntheticReview);
+            expect(panel?.props.bodyText).toBe(transcriptText);
+            expect(panel?.props.bodyState).toBe('view');
+            expect(panel?.props.canEdit).toBe(true);
+            expect(typeof panel?.props.onEditBody).toBe('function');
+
+            // PDF 本文領域（印刷・コピーの対象）の中には置かない
+            const preview = findPdfPreview(tree);
+            expect(preview).not.toBeNull();
+            expect(findReviewPanel(preview)).toBeNull();
+
+            // 本文の描画側にも文書 ID と review を渡す（段落バッジはハッシュ一致時だけ描かれる）
+            const markdown = findElement(tree, element => element.type === TranscriptAwareMarkdown);
+            expect(markdown?.props.documentId).toBe('review-1');
+            expect(markdown?.props.review).toBe(syntheticReview);
+        });
+
+        it('編集モードでは bodyState=editing でパネルを残し、textarea と並べる', () => {
+            mockPanelState({ isViewMode: false });
+            const tree = DocumentDetailPanel({ document: reviewDocument, onDocumentUpdate: async () => undefined });
+
+            const panel = findReviewPanel(tree);
+            expect(panel?.props.bodyState).toBe('editing');
+            expect(findTextarea(tree)).not.toBeNull();
+            expect(findPdfPreview(tree)).toBeNull();
+        });
+
+        it('閲覧専用（onDocumentUpdate 無し）では canEdit=false・onEditBody 無し（確認・再生だけ）', () => {
+            mockPanelState();
+            const tree = DocumentDetailPanel({ document: reviewDocument });
+            const panel = findReviewPanel(tree);
+            expect(panel).not.toBeNull();
+            expect(panel?.props.canEdit).toBe(false);
+            expect(panel?.props.onEditBody).toBeUndefined();
+        });
+
+        it('保存中は canEdit=false', () => {
+            mockPanelState({ saving: true });
+            const tree = DocumentDetailPanel({ document: reviewDocument, onDocumentUpdate: async () => undefined });
+            expect(findReviewPanel(tree)?.props.canEdit).toBe(false);
+        });
+
+        it('パネルの「本文を編集」は既存の全文編集へ移る（新しいエディタは作らない）', () => {
+            const setIsViewMode = vi.fn();
+            const setSaveError = vi.fn();
+            mockPanelState({ setIsViewMode, setSaveError });
+            const tree = DocumentDetailPanel({ document: reviewDocument, onDocumentUpdate: async () => undefined });
+
+            findReviewPanel(tree)?.props.onEditBody?.();
+            expect(setSaveError).toHaveBeenCalledWith(null);
+            expect(setIsViewMode).toHaveBeenCalledWith(false);
+        });
+
+        it('review の無い文字起こし文書（時刻リンクあり）にもパネルを置く（「信頼度情報がありません」を出す側）', () => {
+            mockPanelState();
+            const tree = DocumentDetailPanel({ document: { ...document, id: 'legacy-1', text: transcriptText } });
+            const panel = findReviewPanel(tree);
+            expect(panel).not.toBeNull();
+            expect(panel?.props.review).toBeUndefined();
+        });
+
+        it('🔴 時刻リンクの無い通常の文書にはパネルを置かない（既存文書の描画木を変えない）', () => {
+            mockPanelState();
+            const tree = DocumentDetailPanel({ document, onDocumentUpdate: async () => undefined });
+            expect(findReviewPanel(tree)).toBeNull();
+            // 編集モードの textarea も従来どおり直下に置く
+            mockPanelState({ isViewMode: false });
+            const editing = DocumentDetailPanel({ document, onDocumentUpdate: async () => undefined });
+            expect(findReviewPanel(editing)).toBeNull();
+            expect(findTextarea(editing)).not.toBeNull();
+        });
+
+        it('processing 文書にはパネルを置かない（仮本文は文字起こし結果ではない）', () => {
+            mockPanelState();
+            const tree = DocumentDetailPanel({
+                document: { ...reviewDocument, id: 'processing-2', status: 'processing' },
+                onDocumentUpdate: async () => undefined,
+            });
+            expect(findReviewPanel(tree)).toBeNull();
         });
     });
 });

--- a/src/components/DocumentDetailPanel.transcript.test.tsx
+++ b/src/components/DocumentDetailPanel.transcript.test.tsx
@@ -161,3 +161,94 @@ describe('🔴 回帰: TranscriptAwareMarkdown は通常の文書を素通しす
         expect(through).not.toBe(plain);
     });
 });
+
+// ---------------------------------------------------------------------------
+// 仕様 B3（要確認箇所）で足した判定と描画の錠
+// ---------------------------------------------------------------------------
+
+import {
+    reviewAnchorsByLine,
+    shouldShowTranscriptReviewPanel,
+} from '@/lib/transcriptDocument';
+import type { TranscriptReview } from '@/lib/transcriptReviewContract';
+
+/** 合成の要確認データ。本文 1 行目・3 行目に段落アンカーを持つ */
+const SYNTHETIC_REVIEW: TranscriptReview = {
+    version: 1,
+    threshold: 0.75,
+    sourceTextHash: '0'.repeat(64),
+    sourceJobId: 'job-synthetic',
+    summary: {
+        totalPhrases: 2, lowConfidence: 2, recognitionFlagged: 0, candidateTotal: 2,
+        unknownConfidence: 0, unknownRecognitionStatus: 0, noTimeCandidates: 0, savedCandidates: 2,
+    },
+    availability: 'complete',
+    candidates: [
+        { phraseId: 'p-0', reasons: ['low_confidence'], excerpt: '本日はお忙しい中', excerptTruncated: false, confidence: 0.5, startSec: 0.2, endSec: 3, paragraphStartLine: 1 },
+        { phraseId: 'p-1', reasons: ['low_confidence'], excerpt: 'いえ、こちらこそ', excerptTruncated: false, confidence: 0.6, startSec: 12.4, endSec: 14, paragraphStartLine: 3 },
+    ],
+};
+
+describe('音声 UI の有効化: 本文の時刻リンクが無くても review の有効時刻で有効化する（仕様 B3）', () => {
+    it('🔴 音声を持つ通常の議事録は、review が無ければ引き続き対象外', () => {
+        expect(shouldEnableTranscriptUi({ text: ORDINARY_DOCUMENT, audioStoragePath: 'audio/user-1/a.mp3' })).toBe(false);
+    });
+
+    it('編集で時刻リンクが全て消えた本文でも、review に有効時刻の候補があれば対象', () => {
+        expect(shouldEnableTranscriptUi({ text: ORDINARY_DOCUMENT, transcriptReview: SYNTHETIC_REVIEW })).toBe(true);
+    });
+
+    it('review があっても有効時刻の候補が無ければ対象外（audioStoragePath だけで有効化しない）', () => {
+        const noTime: TranscriptReview = {
+            ...SYNTHETIC_REVIEW,
+            candidates: [{ phraseId: 'p-0', reasons: ['recognition_status'], excerpt: '', excerptTruncated: false }],
+        };
+        expect(shouldEnableTranscriptUi({ text: ORDINARY_DOCUMENT, audioStoragePath: 'audio/user-1/a.mp3', transcriptReview: noTime })).toBe(false);
+    });
+});
+
+describe('要確認パネルを置く文書', () => {
+    it('🔴 時刻リンクの無い通常の議事録には置かない（見た目を変えない）', () => {
+        expect(shouldShowTranscriptReviewPanel({ text: ORDINARY_DOCUMENT, audioStoragePath: 'audio/user-1/a.mp3' })).toBe(false);
+    });
+
+    it('review を持つ文書・review の無い文字起こし文書には置く。処理中には置かない', () => {
+        expect(shouldShowTranscriptReviewPanel({ text: ORDINARY_DOCUMENT, transcriptReview: SYNTHETIC_REVIEW })).toBe(true);
+        expect(shouldShowTranscriptReviewPanel({ text: TRANSCRIPT_DOCUMENT })).toBe(true);
+        expect(shouldShowTranscriptReviewPanel({ text: TRANSCRIPT_DOCUMENT, status: 'processing', transcriptReview: SYNTHETIC_REVIEW })).toBe(false);
+    });
+});
+
+describe('🔴 回帰: 段落バッジは本文ハッシュの照合が済むまで描かない', () => {
+    it('review を渡しても照合前（SSR）は review 無しの描画と完全一致する', () => {
+        const without = renderToStaticMarkup(<TranscriptAwareMarkdown markdown={TRANSCRIPT_DOCUMENT} />);
+        const withReview = renderToStaticMarkup(
+            <TranscriptAwareMarkdown markdown={TRANSCRIPT_DOCUMENT} documentId="doc-1" review={SYNTHETIC_REVIEW} />,
+        );
+        expect(withReview).toBe(without);
+        expect(withReview).not.toContain('要確認');
+    });
+
+    it('通常の議事録に review を付けても、本文の描画は既定と完全一致する（アンカー行が無い）', () => {
+        const plain = renderToStaticMarkup(<MarkdownDocument markdown={ORDINARY_DOCUMENT} />);
+        const through = renderToStaticMarkup(
+            <TranscriptAwareMarkdown markdown={ORDINARY_DOCUMENT} documentId="doc-1" review={SYNTHETIC_REVIEW} />,
+        );
+        expect(through).toBe(plain);
+    });
+
+    it('アンカーを明示的に渡したときだけ、該当段落に選択不可・印刷非表示のバッジが付く', () => {
+        const components = createTranscriptMarkdownComponents({
+            markdown: TRANSCRIPT_DOCUMENT,
+            reviewAnchors: { documentId: 'doc-1', anchorsByLine: reviewAnchorsByLine(SYNTHETIC_REVIEW.candidates) },
+        });
+        const html = renderToStaticMarkup(<MarkdownDocument markdown={TRANSCRIPT_DOCUMENT} components={components} />);
+        expect(html).toContain('data-review-line="1"');
+        expect(html).toContain('data-review-line="3"');
+        expect(html).toContain('要確認 1 箇所');
+        expect(html).toContain('select-none');
+        expect(html).toContain('print:hidden');
+        // PDF 用の描画（MarkdownDocument 単体）には出ない
+        expect(renderToStaticMarkup(<MarkdownDocument markdown={TRANSCRIPT_DOCUMENT} />)).not.toContain('要確認');
+    });
+});

--- a/src/components/DocumentDetailPanel.tsx
+++ b/src/components/DocumentDetailPanel.tsx
@@ -39,6 +39,8 @@ import { createLogger } from '@/lib/logger';
 import { MarkdownDocument } from '@/components/MarkdownDocument';
 import { TranscriptAudioBar, TranscriptAwareMarkdown } from '@/components/TranscriptDocumentView';
 import { renameSpeakerLabel } from '@/components/transcriptMarkdownComponents';
+import { TranscriptReviewPanel } from '@/components/TranscriptReviewPanel';
+import { shouldShowTranscriptReviewPanel } from '@/lib/transcriptDocument';
 import { DocumentPrintPortal } from '@/components/DocumentPrintPortal';
 import { PdfDocumentHeader } from './PdfDocumentHeader';
 import { useDocumentPrint } from '@/hooks/useDocumentPrint';
@@ -580,6 +582,27 @@ export function DocumentDetailPanelView({
         void printPdf();
     };
 
+    // 要確認箇所（仕様 B3）。完成した文字起こし文書だけに置く（時刻リンクの無い通常の議事録には出ない）。
+    // 🔴 パネルは独立コンポーネント（フックはそちらで走る）。ここでは要素を 1 つ置くだけ。
+    //    本文編集中（表示モードでない）は本文アンカーを無効化し、確定した本文（document.text）で照合する。
+    const reviewPanel = !isProcessingDocument && shouldShowTranscriptReviewPanel(document) ? (
+        <TranscriptReviewPanel
+            key={document.id ?? 'document'}
+            documentId={document.id ?? 'document'}
+            review={document.transcriptReview}
+            bodyText={document.text}
+            bodyState={isViewMode ? 'view' : 'editing'}
+            canEdit={isEditable && !saving}
+            onEditBody={isEditable
+                ? () => {
+                    setSaveError(null);
+                    setIsViewMode(false);
+                }
+                : undefined}
+            className={isViewMode ? 'mb-3' : 'max-h-[40%] shrink-0 overflow-y-auto'}
+        />
+    ) : null;
+
     const formatDate = (timestamp: Date | { toDate: () => Date } | undefined): string => {
         if (!timestamp) return '';
         const date = 'toDate' in timestamp ? timestamp.toDate() : timestamp;
@@ -769,21 +792,41 @@ export function DocumentDetailPanelView({
                         onCheck={onCheckProcessingStatus}
                     />
                 ) : isViewMode ? (
-                    <div
-                        className={`pdf-preview pdf-preview--reading pdf-theme-${pdfTheme} pdf-font-${resolvedPdfFont} shadow`}
-                    >
-                        <article className="pdf-document">
-                            {includeMetadata && (
-                                <PdfDocumentHeader document={document} />
-                            )}
-                            <TranscriptAwareMarkdown
-                                className="pdf-markdown"
-                                markdown={document.text}
-                                onRenameSpeaker={(from, to) => {
-                                    setEditedContent(current => renameSpeakerLabel(current, from, to));
-                                }}
+                    <>
+                        {/* 要確認箇所は PDF 本文領域（pdf-preview）の外。印刷・コピー・Markdown 保存に操作 UI や信頼度の色を混ぜない */}
+                        {reviewPanel}
+                        <div
+                            className={`pdf-preview pdf-preview--reading pdf-theme-${pdfTheme} pdf-font-${resolvedPdfFont} shadow`}
+                        >
+                            <article className="pdf-document">
+                                {includeMetadata && (
+                                    <PdfDocumentHeader document={document} />
+                                )}
+                                <TranscriptAwareMarkdown
+                                    className="pdf-markdown"
+                                    markdown={document.text}
+                                    documentId={document.id}
+                                    review={document.transcriptReview}
+                                    onRenameSpeaker={(from, to) => {
+                                        setEditedContent(current => renameSpeakerLabel(current, from, to));
+                                    }}
+                                />
+                            </article>
+                        </div>
+                    </>
+                ) : reviewPanel ? (
+                    // 編集中も候補の生成時抜粋を参照できるように残す（本文アンカーはパネル側で無効化される）
+                    <div className="flex h-full flex-col gap-3">
+                        {reviewPanel}
+                        <div className="min-h-0 flex-1">
+                            <textarea
+                                value={editedContent}
+                                onChange={(e) => setEditedContent(e.target.value)}
+                                className="w-full h-full min-h-0 px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent font-mono text-sm resize-none"
+                                placeholder="コンテンツを入力"
+                                disabled={saving}
                             />
-                        </article>
+                        </div>
                     </div>
                 ) : (
                     <div className="h-full">

--- a/src/components/ServiceContactNotice.tsx
+++ b/src/components/ServiceContactNotice.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+/**
+ * サービスの不具合や気づいた点の連絡先案内。
+ * 文言はこの定数 1 箇所にまとめる。担当者や連絡先（メール・URL）を変えるときはここだけを直す。
+ * 現在はメールアドレス・URL を渡されていないため、宛先は氏名だけで示す。
+ */
+export const SERVICE_CONTACT_NOTICE = 'サービスの不具合や気づいた点は東野までお知らせください。';
+
+/**
+ * ヘッダー行の直下に出す細い常時表示バー。
+ * - 操作を持たない案内なので、装飾ではなくテキストで伝える（role="note" は補助的な注記の意味）。
+ * - 文字色 text-muted(#374151) は bg-surface-subtle(#f1f5f9) 上で 9.4:1（AA の 4.5:1 を満たす）。
+ * - 文字はモバイルで text-xs、sm 以上で text-sm。行送りと余白の組で、1 行なら高さ 28px に揃う。
+ *   折り返しは隠さず伸ばす（truncate しない）。
+ */
+export const ServiceContactNotice: React.FC = () => (
+    <div className="border-t border-elevation-persistent-boundary bg-surface-subtle">
+        <p
+            role="note"
+            className="container mx-auto max-w-7xl px-4 py-1.5 text-center text-xs text-muted sm:py-1 sm:text-sm"
+        >
+            {SERVICE_CONTACT_NOTICE}
+        </p>
+    </div>
+);

--- a/src/components/TranscriptDocumentView.tsx
+++ b/src/components/TranscriptDocumentView.tsx
@@ -10,17 +10,32 @@
  * ここに切り出せば、パネルからは「要素を1つ置く」だけになり、フックは実描画のときにしか走らない。
  */
 import React, { useEffect, useMemo, useState } from 'react';
+import { RotateCw } from 'lucide-react';
 import { MarkdownDocument } from '@/components/MarkdownDocument';
-import { TranscriptPlayer } from '@/components/TranscriptPlayer';
+import { TranscriptPlayer, transcriptPlayback } from '@/components/TranscriptPlayer';
 import { createTranscriptMarkdownComponents } from '@/components/transcriptMarkdownComponents';
+import { useTranscriptTextHash } from '@/components/TranscriptReviewPanel';
 import { getAudioDownloadURL } from '@/lib/storage';
-import { shouldEnableTranscriptUi, type TranscriptCandidateDocument } from '@/lib/transcriptDocument';
+import {
+    hasTranscriptTimestampLinks,
+    reviewAnchorsByLine,
+    shouldEnableTranscriptUi,
+    type TranscriptCandidateDocument,
+} from '@/lib/transcriptDocument';
+import type { TranscriptReview } from '@/lib/transcriptReviewContract';
 
 export interface TranscriptAwareMarkdownProps {
     markdown: string;
     className?: string;
     /** 話者ラベルの改名。渡さなければラベルはただの強調のまま */
     onRenameSpeaker?: (from: string, to: string) => void;
+    /**
+     * 要確認候補の段落バッジ用（仕様 B3）。`documentId` と `review` が揃い、
+     * **表示本文の SHA-256 が `review.sourceTextHash` と一致するときだけ**段落にバッジを描く。
+     * 照合前・不一致（編集済み）・review 無しでは本文の描画は従来どおり。
+     */
+    documentId?: string;
+    review?: TranscriptReview | null;
 }
 
 /**
@@ -31,15 +46,28 @@ export function TranscriptAwareMarkdown({
     markdown,
     className,
     onRenameSpeaker,
+    documentId,
+    review,
 }: TranscriptAwareMarkdownProps): React.ReactElement {
+    const sourceHash = typeof review?.sourceTextHash === 'string' && review.sourceTextHash !== ''
+        ? review.sourceTextHash
+        : null;
+    const bodyHash = useTranscriptTextHash(markdown, sourceHash !== null && Boolean(documentId));
+    const anchorsEnabled = sourceHash !== null && bodyHash !== null && bodyHash === sourceHash && Boolean(documentId);
     const components = useMemo(
-        () => (shouldEnableTranscriptUi({ text: markdown })
-            ? createTranscriptMarkdownComponents({
+        () => {
+            // 上書きは本文に時刻リンクがあるときだけ（段落アンカーはハッシュ一致＝生成本文のときにしか立たないので、この条件に含まれる）。
+            // review の有無で本文の描画を変えない（音声 UI の有効化とは別の判定）。
+            if (!hasTranscriptTimestampLinks({ text: markdown })) return undefined;
+            return createTranscriptMarkdownComponents({
                 markdown,
                 ...(onRenameSpeaker && { onRename: onRenameSpeaker }),
-            })
-            : undefined),
-        [markdown, onRenameSpeaker],
+                ...(anchorsEnabled && documentId && review
+                    ? { reviewAnchors: { documentId, anchorsByLine: reviewAnchorsByLine(review.candidates) } }
+                    : {}),
+            });
+        },
+        [markdown, onRenameSpeaker, review, documentId, anchorsEnabled],
     );
     return <MarkdownDocument className={className} markdown={markdown} components={components} />;
 }
@@ -49,31 +77,117 @@ export interface TranscriptAudioBarProps {
 }
 
 /**
+ * 音声 URL の解決結果。「どのパス・何回目の試行に対する結果か」と一緒に持つ（文書切替・再試行直後の取り違え防止）。
+ * 結果が無い間（パス／試行が一致する結果が無い）は「読み込み中」と解釈する。
+ */
+type AudioResolution =
+    | { path: string; attempt: number; status: 'ready'; url: string }
+    | { path: string; attempt: number; status: 'url_failed' }
+    | { path: string; attempt: number; status: 'media_failed' };
+
+/** プレイヤーの帯と同じ位置・同じ大きさの状態表示（読み込み中／再生不可） */
+function AudioStatusStrip({ children }: { children: React.ReactNode }): React.ReactElement {
+    return (
+        <div
+            role="status"
+            data-testid="transcript-audio-status"
+            className="sticky bottom-0 z-10 flex flex-wrap items-center gap-2 border-t border-gray-200 bg-white/95 px-3 py-1.5 text-xs text-gray-600 backdrop-blur-sm print:hidden"
+        >
+            {children}
+        </div>
+    );
+}
+
+/**
  * 文書の下辺に貼り付く音声の帯。
  *
- * 🔴 出す条件は「音声があるか」ではなく **「本文に時刻リンクがあるか」**。
+ * 🔴 出す条件は「音声があるか」ではなく **「本文に時刻リンクがあるか」**（＋保存済み候補の有効時刻・仕様 B3）。
  * `audioStoragePath` は音声から生成した**すべての**文書に入っているため、
  * それを条件にすると既存の議事録文書にも帯が出て見た目が変わる (設計 §6.5-3)。
+ *
+ * 音声の状態は `transcriptPlayback.audio` に載せ、要確認カードの「音声を再生」の可否に使う（仕様 B3）:
+ * URL 取得中は loading、取得失敗・音声要素のロード失敗は unavailable（再試行は URL の再取得だけ。submit は呼ばない）。
  */
 export function TranscriptAudioBar({ document }: TranscriptAudioBarProps): React.ReactElement | null {
     const enabled = shouldEnableTranscriptUi(document);
     const storagePath = document?.audioStoragePath;
     // 🔴 解決した URL は「どのパスに対する URL か」と一緒に持つ。
     //    文書を切り替えた直後に、前の文書の音声が鳴るのを防ぐ (URL だけ持つと1描画ぶん古い値が残る)。
-    const [resolved, setResolved] = useState<{ path: string; url: string } | null>(null);
+    const [resolution, setResolution] = useState<AudioResolution | null>(null);
+    const [attempt, setAttempt] = useState(0);
 
     useEffect(() => {
-        if (!enabled || !storagePath) return;
+        if (!enabled) return;
+        if (!storagePath) {
+            // 文字起こしだが音声参照が無い: 再生はできない（本文の確認・編集はできる）
+            transcriptPlayback.setAudio('unavailable', 'no_audio');
+            return () => transcriptPlayback.setAudio('none');
+        }
         let cancelled = false;
+        transcriptPlayback.setAudio('loading');
         void getAudioDownloadURL(storagePath)
-            .then(url => { if (!cancelled) setResolved({ path: storagePath, url }); })
-            // 音声が取れなくても本文は読める。帯が出ないだけにする (例外で文書を落とさない)。
-            .catch(() => { if (!cancelled) setResolved(null); });
-        return () => { cancelled = true; };
-    }, [enabled, storagePath]);
+            .then(url => {
+                if (!cancelled) setResolution({ path: storagePath, attempt, status: 'ready', url });
+            })
+            // 音声が取れなくても本文は読める。帯を状態表示にするだけ（例外で文書を落とさない）
+            .catch(() => {
+                if (cancelled) return;
+                setResolution({ path: storagePath, attempt, status: 'url_failed' });
+                transcriptPlayback.setAudio('unavailable', 'url_failed');
+            });
+        return () => {
+            cancelled = true;
+            // 別文書・再試行へ移るとき、この解決の状態を残さない（次の effect が置き直す）
+            transcriptPlayback.setAudio('none');
+        };
+    }, [enabled, storagePath, attempt]);
+
+    // パスと試行が一致する結果だけを使う。切り替え・再試行の直後は null（＝読み込み中）になる。
+    const current = storagePath && resolution?.path === storagePath && resolution.attempt === attempt
+        ? resolution
+        : null;
+
+    // 音声要素のロード失敗でプレイヤーを外した後も「再生できない」を保つ（プレイヤーの離脱でストアが初期化されるため）
+    useEffect(() => {
+        if (!enabled || !current || current.status !== 'media_failed') return;
+        transcriptPlayback.setAudio('unavailable', 'media_failed');
+    }, [enabled, current]);
 
     if (!enabled) return null;
-    // パスが一致するときだけ使う。切り替え直後は null になり、帯は消える。
-    const audioUrl = storagePath && resolved?.path === storagePath ? resolved.url : null;
-    return <TranscriptPlayer audioUrl={audioUrl} />;
+    if (!storagePath) return null;
+
+    if (!current) {
+        return <AudioStatusStrip>音声を読み込んでいます…</AudioStatusStrip>;
+    }
+    if (current.status === 'ready') {
+        const { path: resolvedPath, attempt: resolvedAttempt } = current;
+        return (
+            <TranscriptPlayer
+                key={`${resolvedPath}#${resolvedAttempt}`}
+                audioUrl={current.url}
+                onMediaError={() => {
+                    setResolution(previous =>
+                        previous
+                            && previous.path === resolvedPath
+                            && previous.attempt === resolvedAttempt
+                            && previous.status === 'ready'
+                            ? { path: resolvedPath, attempt: resolvedAttempt, status: 'media_failed' }
+                            : previous);
+                }}
+            />
+        );
+    }
+    return (
+        <AudioStatusStrip>
+            <span>音声を再生できません。本文の確認・編集はできます。</span>
+            <button
+                type="button"
+                onClick={() => setAttempt(count => count + 1)}
+                className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-purple-700 hover:bg-purple-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500"
+            >
+                <RotateCw className="h-3.5 w-3.5" aria-hidden="true" />
+                <span>音声の取得を再試行</span>
+            </button>
+        </AudioStatusStrip>
+    );
 }

--- a/src/components/TranscriptDocumentView.tsx
+++ b/src/components/TranscriptDocumentView.tsx
@@ -61,6 +61,8 @@ export function TranscriptAwareMarkdown({
             if (!hasTranscriptTimestampLinks({ text: markdown })) return undefined;
             return createTranscriptMarkdownComponents({
                 markdown,
+                // 🔴 追従の一時停止を「この文書」に限定するため、review の有無に関わらず文書 ID を渡す
+                ...(documentId && { documentId }),
                 ...(onRenameSpeaker && { onRename: onRenameSpeaker }),
                 ...(anchorsEnabled && documentId && review
                     ? { reviewAnchors: { documentId, anchorsByLine: reviewAnchorsByLine(review.candidates) } }

--- a/src/components/TranscriptDocumentView.tsx
+++ b/src/components/TranscriptDocumentView.tsx
@@ -52,6 +52,14 @@ export function TranscriptAwareMarkdown({
     const sourceHash = typeof review?.sourceTextHash === 'string' && review.sourceTextHash !== ''
         ? review.sourceTextHash
         : null;
+    // 🔴 文書から離れる（表示 documentId が変わる・アンマウント）ときに、この文書で立てた候補ジャンプの
+    //    追従一時停止を破棄する。音声の無い文書ではプレイヤーが attach されず終了処理も走らないため、
+    //    docId 照合だけだと「A でジャンプ → 別文書 → A へ戻り A が音声を得る」で一時停止が残り追従が死ぬ。
+    //    文書離脱で明示的に解除することで、戻った文書は最初から追従が効く（プレイヤーの有無に依存しない）。
+    useEffect(() => {
+        if (!documentId) return undefined;
+        return () => transcriptPlayback.clearFollowPauseForDocument(documentId);
+    }, [documentId]);
     const bodyHash = useTranscriptTextHash(markdown, sourceHash !== null && Boolean(documentId));
     const anchorsEnabled = sourceHash !== null && bodyHash !== null && bodyHash === sourceHash && Boolean(documentId);
     const components = useMemo(

--- a/src/components/TranscriptPlayer.test.tsx
+++ b/src/components/TranscriptPlayer.test.tsx
@@ -349,3 +349,98 @@ describe('本文の読み取り（純関数）', () => {
         expect(parseClockDisplay('12')).toBeNull();
     });
 });
+
+describe('音声の可用性（仕様 B3）', () => {
+    it('プレイヤーが載ると loading、メタデータが読めたら ready、外れると none に戻る', async () => {
+        await render(<TranscriptPlayer audioUrl="https://example.test/a.m4a" />);
+        expect(transcriptPlayback.getSnapshot().audio).toBe('loading');
+        expect(transcriptPlayback.getSnapshot().ready).toBe(true);
+
+        await act(async () => {
+            container.querySelector('audio')!.dispatchEvent(new Event('loadedmetadata'));
+        });
+        expect(transcriptPlayback.getSnapshot().audio).toBe('ready');
+
+        await render(<TranscriptPlayer audioUrl={null} />);
+        expect(transcriptPlayback.getSnapshot().audio).toBe('none');
+        expect(transcriptPlayback.getSnapshot().ready).toBe(false);
+    });
+
+    it('preload を尊重しない環境（suspend）でも ready にして、押せば読み込みが始まる形にする', async () => {
+        await render(<TranscriptPlayer audioUrl="https://example.test/a.m4a" />);
+        await act(async () => {
+            container.querySelector('audio')!.dispatchEvent(new Event('suspend'));
+        });
+        expect(transcriptPlayback.getSnapshot().audio).toBe('ready');
+    });
+
+    it('音声要素のロード失敗は unavailable(media_failed)。その後の suspend で ready に戻さない', async () => {
+        const onMediaError = vi.fn();
+        await render(<TranscriptPlayer audioUrl="https://example.test/a.m4a" onMediaError={onMediaError} />);
+        await act(async () => {
+            container.querySelector('audio')!.dispatchEvent(new Event('error'));
+        });
+        expect(transcriptPlayback.getSnapshot().audio).toBe('unavailable');
+        expect(transcriptPlayback.getSnapshot().audioReason).toBe('media_failed');
+        expect(onMediaError).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            container.querySelector('audio')!.dispatchEvent(new Event('suspend'));
+        });
+        expect(transcriptPlayback.getSnapshot().audio).toBe('unavailable');
+    });
+
+    it('🔴 再生がブラウザに拒否されたら（NotAllowedError）再生中の見た目にせず、playbackBlocked を立てる', async () => {
+        const blocked = new Error('play() failed because the user didn\'t interact with the document first.');
+        blocked.name = 'NotAllowedError';
+        vi.mocked(HTMLMediaElement.prototype.play).mockImplementationOnce(async () => {
+            throw blocked;
+        });
+        await render(<TranscriptPlayer audioUrl="https://example.test/a.m4a" durationSec={60} />);
+        await click(container.querySelector('button[aria-label="再生"]'));
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(transcriptPlayback.getSnapshot().playing).toBe(false);
+        expect(transcriptPlayback.getSnapshot().playbackBlocked).toBe(true);
+        expect(container.querySelector('button[aria-label="再生"]')).not.toBeNull();
+
+        // 実際に再生が始まれば解ける
+        await act(async () => {
+            container.querySelector('audio')!.dispatchEvent(new Event('play'));
+        });
+        expect(transcriptPlayback.getSnapshot().playing).toBe(true);
+        expect(transcriptPlayback.getSnapshot().playbackBlocked).toBe(false);
+    });
+
+    it('pause() による中断（AbortError）は拒否として案内しない', async () => {
+        const aborted = new Error('The play() request was interrupted by a call to pause().');
+        aborted.name = 'AbortError';
+        vi.mocked(HTMLMediaElement.prototype.play).mockImplementationOnce(async () => {
+            throw aborted;
+        });
+        await render(<TranscriptPlayer audioUrl="https://example.test/a.m4a" durationSec={60} />);
+        await click(container.querySelector('button[aria-label="再生"]'));
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(transcriptPlayback.getSnapshot().playing).toBe(false);
+        expect(transcriptPlayback.getSnapshot().playbackBlocked).toBe(false);
+    });
+
+    it('時刻リンクからの seek も同じ経路（拒否されれば blocked）', async () => {
+        const blocked = new Error('blocked');
+        blocked.name = 'NotAllowedError';
+        vi.mocked(HTMLMediaElement.prototype.play).mockImplementationOnce(async () => {
+            throw blocked;
+        });
+        await render(transcriptView(TRANSCRIPT, { audioUrl: 'https://example.test/a.m4a' }));
+        await click(container.querySelector('a[data-timestamp-sec="12"]'));
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(transcriptPlayback.getSnapshot().currentSec).toBe(12);
+        expect(transcriptPlayback.getSnapshot().playing).toBe(false);
+        expect(transcriptPlayback.getSnapshot().playbackBlocked).toBe(true);
+    });
+});

--- a/src/components/TranscriptPlayer.test.tsx
+++ b/src/components/TranscriptPlayer.test.tsx
@@ -253,72 +253,74 @@ describe('再生中の行の追従', () => {
 });
 
 // 候補ジャンプ中の追従の一時停止（仕様 B3）。🔴 利用者の永続設定 follow は書き換えない過渡状態。
-// 本文側（段落）との組み合わせは transcriptMarkdownComponents.test.tsx。ここはストアの規則の錠。
-describe('候補ジャンプの追従一時停止（followPausedByJump）', () => {
+// 一時停止は「その文書 ID」に紐づく（followPauseDocId）。音声の無い文書では attach が起きず終了処理も
+// 走らないため、boolean ではなく docId で持つ。本文側（段落）との組み合わせ・文書切替での復帰は
+// transcriptMarkdownComponents.test.tsx。ここはストアの規則の錠。
+describe('候補ジャンプの追従一時停止（followPauseDocId）', () => {
     it('初期状態は一時停止なし・追従あり', () => {
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPauseDocId: null });
     });
 
-    it('pauseFollowForJump は一時停止だけを立て、follow を書き換えない（follow が OFF のときも触らない）', () => {
-        transcriptPlayback.pauseFollowForJump();
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: true });
+    it('pauseFollowForJump(docId) は一時停止をその文書 ID で立て、follow を書き換えない（follow が OFF のときも触らない）', () => {
+        transcriptPlayback.pauseFollowForJump('doc-1');
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPauseDocId: 'doc-1' });
 
         transcriptPlayback.setFollow(false);
-        transcriptPlayback.pauseFollowForJump();
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: false, followPausedByJump: true });
+        transcriptPlayback.pauseFollowForJump('doc-1');
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: false, followPauseDocId: 'doc-1' });
     });
 
     it('setFollow（追従トグル）は OFF でも ON でも一時停止を解く', () => {
-        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.pauseFollowForJump('doc-1');
         transcriptPlayback.setFollow(false);
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: false, followPausedByJump: false });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: false, followPauseDocId: null });
 
-        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.pauseFollowForJump('doc-1');
         transcriptPlayback.setFollow(true);
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPauseDocId: null });
     });
 
     it('seek（利用者が再生位置を動かした）は一時停止を解く。コントローラが居ないときは何も変えない', () => {
-        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.pauseFollowForJump('doc-1');
         transcriptPlayback.seek(30);
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ currentSec: 0, followPausedByJump: true });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ currentSec: 0, followPauseDocId: 'doc-1' });
 
         const seek = vi.fn();
         const detach = transcriptPlayback.attach({ seek });
         transcriptPlayback.seek(30);
         expect(seek).toHaveBeenCalledWith(30);
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ currentSec: 30, follow: true, followPausedByJump: false });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ currentSec: 30, follow: true, followPauseDocId: null });
         detach();
     });
 
     it('🔴 attach の終了（文書切替・プレイヤーの破棄）で一時停止は解け、follow は保持される（ON でも OFF でも）', () => {
         const detachA = transcriptPlayback.attach({ seek: vi.fn() });
-        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.pauseFollowForJump('doc-1');
         detachA();
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: false, follow: true, followPausedByJump: false });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: false, follow: true, followPauseDocId: null });
 
         transcriptPlayback.setFollow(false);
         const detachB = transcriptPlayback.attach({ seek: vi.fn() });
-        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.pauseFollowForJump('doc-1');
         detachB();
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: false, follow: false, followPausedByJump: false });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: false, follow: false, followPauseDocId: null });
     });
 
     it('reset で初期状態へ戻る', () => {
-        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.pauseFollowForJump('doc-1');
         transcriptPlayback.reset();
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPauseDocId: null });
     });
 
     it('🔴 プレイヤーの再マウント（文書切替＝key 変更）でも同じ: 一時停止は解け、follow は保持される', async () => {
         await render(<TranscriptPlayer key="docA" audioUrl="https://example.test/a.m4a" durationSec={60} />);
         await act(async () => {
-            transcriptPlayback.pauseFollowForJump();
+            transcriptPlayback.pauseFollowForJump('docA');
         });
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: true, follow: true, followPausedByJump: true });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: true, follow: true, followPauseDocId: 'docA' });
 
         await render(<TranscriptPlayer key="docB" audioUrl="https://example.test/b.m4a" durationSec={60} />);
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: true, follow: true, followPausedByJump: false });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: true, follow: true, followPauseDocId: null });
         // 追従トグルの見た目も押されたまま（永続設定は書き換えていない）
         expect(container.querySelector('button[aria-pressed]')?.getAttribute('aria-pressed')).toBe('true');
     });

--- a/src/components/TranscriptPlayer.test.tsx
+++ b/src/components/TranscriptPlayer.test.tsx
@@ -252,6 +252,78 @@ describe('再生中の行の追従', () => {
     });
 });
 
+// 候補ジャンプ中の追従の一時停止（仕様 B3）。🔴 利用者の永続設定 follow は書き換えない過渡状態。
+// 本文側（段落）との組み合わせは transcriptMarkdownComponents.test.tsx。ここはストアの規則の錠。
+describe('候補ジャンプの追従一時停止（followPausedByJump）', () => {
+    it('初期状態は一時停止なし・追従あり', () => {
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: false });
+    });
+
+    it('pauseFollowForJump は一時停止だけを立て、follow を書き換えない（follow が OFF のときも触らない）', () => {
+        transcriptPlayback.pauseFollowForJump();
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: true });
+
+        transcriptPlayback.setFollow(false);
+        transcriptPlayback.pauseFollowForJump();
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: false, followPausedByJump: true });
+    });
+
+    it('setFollow（追従トグル）は OFF でも ON でも一時停止を解く', () => {
+        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.setFollow(false);
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: false, followPausedByJump: false });
+
+        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.setFollow(true);
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: false });
+    });
+
+    it('seek（利用者が再生位置を動かした）は一時停止を解く。コントローラが居ないときは何も変えない', () => {
+        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.seek(30);
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ currentSec: 0, followPausedByJump: true });
+
+        const seek = vi.fn();
+        const detach = transcriptPlayback.attach({ seek });
+        transcriptPlayback.seek(30);
+        expect(seek).toHaveBeenCalledWith(30);
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ currentSec: 30, follow: true, followPausedByJump: false });
+        detach();
+    });
+
+    it('🔴 attach の終了（文書切替・プレイヤーの破棄）で一時停止は解け、follow は保持される（ON でも OFF でも）', () => {
+        const detachA = transcriptPlayback.attach({ seek: vi.fn() });
+        transcriptPlayback.pauseFollowForJump();
+        detachA();
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: false, follow: true, followPausedByJump: false });
+
+        transcriptPlayback.setFollow(false);
+        const detachB = transcriptPlayback.attach({ seek: vi.fn() });
+        transcriptPlayback.pauseFollowForJump();
+        detachB();
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: false, follow: false, followPausedByJump: false });
+    });
+
+    it('reset で初期状態へ戻る', () => {
+        transcriptPlayback.pauseFollowForJump();
+        transcriptPlayback.reset();
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: false });
+    });
+
+    it('🔴 プレイヤーの再マウント（文書切替＝key 変更）でも同じ: 一時停止は解け、follow は保持される', async () => {
+        await render(<TranscriptPlayer key="docA" audioUrl="https://example.test/a.m4a" durationSec={60} />);
+        await act(async () => {
+            transcriptPlayback.pauseFollowForJump();
+        });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: true, follow: true, followPausedByJump: true });
+
+        await render(<TranscriptPlayer key="docB" audioUrl="https://example.test/b.m4a" durationSec={60} />);
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ ready: true, follow: true, followPausedByJump: false });
+        // 追従トグルの見た目も押されたまま（永続設定は書き換えていない）
+        expect(container.querySelector('button[aria-pressed]')?.getAttribute('aria-pressed')).toBe('true');
+    });
+});
+
 describe('話者ラベルの改名', () => {
     it('その場で入力でき、変更箇所数が事前に出て、onRename が呼ばれる', async () => {
         const onRename = vi.fn();

--- a/src/components/TranscriptPlayer.test.tsx
+++ b/src/components/TranscriptPlayer.test.tsx
@@ -444,3 +444,67 @@ describe('音声の可用性（仕様 B3）', () => {
         expect(transcriptPlayback.getSnapshot().playbackBlocked).toBe(true);
     });
 });
+
+// Major1: 文書を切り替える（TranscriptDocumentView は key を変えて remount する）と、
+// 前の文書の play() の遅延結果が共有 transcriptPlayback を上書きしてはならない。
+describe('文書切替と再生状態（遅延結果の隔離・仕様 B3）', () => {
+    it('🔴 前の文書の play() が遅れて拒否されても、切替後の文書の再生を止めず・再生拒否も出さない', async () => {
+        // 文書 A の play() を保留にする（この 1 回だけ deferred を返す）
+        let rejectA: (reason: unknown) => void = () => {};
+        const pendingA = new Promise<void>((_, reject) => {
+            rejectA = reject;
+        });
+        vi.mocked(HTMLMediaElement.prototype.play).mockImplementationOnce(() => pendingA);
+
+        // A を再生（play() は保留のまま。楽観的に playing:true）
+        await render(<TranscriptPlayer key="docA" audioUrl="https://example.test/a.m4a" durationSec={60} />);
+        await click(container.querySelector('button[aria-label="再生"]'));
+        expect(transcriptPlayback.getSnapshot().playing).toBe(true);
+
+        // 文書 B へ切替（key 変更で remount → attach cleanup が状態を初期化）。B を再生
+        await render(<TranscriptPlayer key="docB" audioUrl="https://example.test/b.m4a" durationSec={60} />);
+        await click(container.querySelector('button[aria-label="再生"]'));
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(transcriptPlayback.getSnapshot().playing).toBe(true);
+        expect(transcriptPlayback.getSnapshot().playbackBlocked).toBe(false);
+
+        // A の play() が遅れて NotAllowedError で拒否される
+        const blocked = new Error('late rejection from document A');
+        blocked.name = 'NotAllowedError';
+        await act(async () => {
+            rejectA(blocked);
+            await Promise.resolve();
+        });
+
+        // B の状態は無傷（誤って停止せず、別文書に再生拒否案内も出ない）
+        expect(transcriptPlayback.getSnapshot().playing).toBe(true);
+        expect(transcriptPlayback.getSnapshot().playbackBlocked).toBe(false);
+    });
+
+    it('🔴 前の文書の play() が遅れて解決しても、切替後（停止中）の文書を再生中にしない', async () => {
+        let resolveA: () => void = () => {};
+        const pendingA = new Promise<void>(resolve => {
+            resolveA = resolve;
+        });
+        vi.mocked(HTMLMediaElement.prototype.play).mockImplementationOnce(() => pendingA);
+
+        await render(<TranscriptPlayer key="docA" audioUrl="https://example.test/a.m4a" durationSec={60} />);
+        await click(container.querySelector('button[aria-label="再生"]'));
+        expect(transcriptPlayback.getSnapshot().playing).toBe(true);
+
+        // B へ切替（remount で store 初期化 → playing:false）。B は停止のまま
+        await render(<TranscriptPlayer key="docB" audioUrl="https://example.test/b.m4a" durationSec={60} />);
+        expect(transcriptPlayback.getSnapshot().playing).toBe(false);
+
+        // A の play() が遅れて解決
+        await act(async () => {
+            resolveA();
+            await Promise.resolve();
+        });
+
+        // B は停止のまま（A の解決に引きずられて再生中に化けない）
+        expect(transcriptPlayback.getSnapshot().playing).toBe(false);
+    });
+});

--- a/src/components/TranscriptPlayer.tsx
+++ b/src/components/TranscriptPlayer.tsx
@@ -126,9 +126,18 @@ const createTranscriptPlaybackStore = () => {
         /**
          * 候補ジャンプ中の追従の一時停止を、その文書 ID で立てる（次の時刻更新でジャンプ先から引き戻さない）。
          * 🔴 `follow`（永続設定）は書き換えない。別文書の段落は自分の docId と照合するので自動的に無効になり、
-         *    音声の有無に依存しない。明示的な解除は setFollow / seek / reset。
+         *    音声の有無に依存しない。明示的な解除は setFollow / seek / clearFollowPauseForDocument（文書離脱）/ reset。
          */
         pauseFollowForJump: (documentId: string): void => patch({ followPauseDocId: documentId }),
+        /**
+         * 文書から離れる（本文の表示 documentId が変わる・アンマウント）ときに、その文書で立てた
+         * 候補ジャンプの一時停止を破棄する。🔴 プレイヤーの有無に依存しない解除経路（音声の無い文書では
+         * attach の終了処理が走らないため、docId 照合だけだと「A でジャンプ→別文書→A へ戻り A が音声を得る」で
+         * 一時停止が残り追従が死ぬ）。自分の文書の分だけ消す（別文書が既に立てた停止は壊さない）。
+         */
+        clearFollowPauseForDocument: (documentId: string): void => {
+            if (state.followPauseDocId === documentId) patch({ followPauseDocId: null });
+        },
         /** 音声の可用性を置く（URL の取得側とプレイヤーの両方から呼ぶ） */
         setAudio: (audio: TranscriptAudioStatus, reason: TranscriptAudioUnavailableReason | null = null): void =>
             patch({ audio, audioReason: audio === 'unavailable' ? reason : null }),

--- a/src/components/TranscriptPlayer.tsx
+++ b/src/components/TranscriptPlayer.tsx
@@ -14,7 +14,7 @@
  * - `audio`: 音声の可用性。`ready`（コントローラ接続）とは別に、URL の取得と音声要素のロード状態を持つ。
  *   要確認カードの「音声を再生」はこれが `'ready'` のときだけ押せる（押しても無反応なボタンを出さない）。
  * - `playbackBlocked`: ブラウザが再生を拒否した（自動再生ポリシー等）。再生済みの見た目にせず、案内を出す。
- * - `followPausedByJump`: 候補カードからの「本文の該当段落へ移動」で追従を一時的に止めている過渡状態。
+ * - `followPauseDocId`: 候補カードからの「本文の該当段落へ移動」で追従を一時停止している文書 ID（過渡状態）。
  *   🔴 利用者の永続設定 `follow` とは別物で、`follow` を書き換えない（文書切替・再マウントで自動的に解ける）。
  */
 
@@ -54,10 +54,13 @@ export interface TranscriptPlaybackSnapshot {
     /** 直前の再生要求をブラウザが拒否した（自動再生の拒否）。再生が始まると解ける */
     playbackBlocked: boolean;
     /**
-     * 候補ジャンプ（本文の該当段落へ移動）で追従を一時的に止めている。
-     * 🔴 `follow`（利用者の永続設定）は書き換えない過渡状態。追従トグル・シーク・文書切替（attach の終了）・reset で解ける。
+     * 候補ジャンプ（本文の該当段落へ移動）で追従を一時的に止めている「文書 ID」。null = 一時停止なし。
+     * 🔴 `follow`（利用者の永続設定）は書き換えない過渡状態。追従トグル・シーク・reset で解ける。
+     * 🔴 **文書 ID に紐付ける**のが要点。別文書を開けば（＝その文書の段落は自分の docId と照合して）自動的に
+     *    一時停止が外れる。音声の無い文書でジャンプした後に音声付き文書へ切り替えても、attach の終了処理に
+     *    依存せず追従が復帰する（音声が無いと attach が起きず終了処理も走らないため、boolean だと解けなかった）。
      */
-    followPausedByJump: boolean;
+    followPauseDocId: string | null;
 }
 
 /** 音声要素を持つ側（＝TranscriptPlayer）が登録する実操作 */
@@ -76,7 +79,7 @@ const INITIAL_SNAPSHOT: TranscriptPlaybackSnapshot = {
     audio: 'none',
     audioReason: null,
     playbackBlocked: false,
-    followPausedByJump: false,
+    followPauseDocId: null,
 };
 
 const createTranscriptPlaybackStore = () => {
@@ -115,16 +118,17 @@ const createTranscriptPlaybackStore = () => {
         seek: (sec: number): void => {
             if (!controller || !Number.isFinite(sec)) return;
             // 利用者が再生位置を動かした＝候補ジャンプの一時停止から追従へ復帰する
-            patch({ currentSec: Math.max(0, sec), followPausedByJump: false });
+            patch({ currentSec: Math.max(0, sec), followPauseDocId: null });
             controller.seek(Math.max(0, sec));
         },
         /** 追従の入切（利用者の永続設定）。トグル操作は候補ジャンプの一時停止を必ず解く */
-        setFollow: (follow: boolean): void => patch({ follow, followPausedByJump: false }),
+        setFollow: (follow: boolean): void => patch({ follow, followPauseDocId: null }),
         /**
-         * 候補ジャンプ中の追従の一時停止（次の時刻更新でジャンプ先から引き戻さない）。
-         * 🔴 `follow` は書き換えない。解除は setFollow / seek / attach の終了（文書切替・再マウント）/ reset。
+         * 候補ジャンプ中の追従の一時停止を、その文書 ID で立てる（次の時刻更新でジャンプ先から引き戻さない）。
+         * 🔴 `follow`（永続設定）は書き換えない。別文書の段落は自分の docId と照合するので自動的に無効になり、
+         *    音声の有無に依存しない。明示的な解除は setFollow / seek / reset。
          */
-        pauseFollowForJump: (): void => patch({ followPausedByJump: true }),
+        pauseFollowForJump: (documentId: string): void => patch({ followPauseDocId: documentId }),
         /** 音声の可用性を置く（URL の取得側とプレイヤーの両方から呼ぶ） */
         setAudio: (audio: TranscriptAudioStatus, reason: TranscriptAudioUnavailableReason | null = null): void =>
             patch({ audio, audioReason: audio === 'unavailable' ? reason : null }),
@@ -139,8 +143,9 @@ const createTranscriptPlaybackStore = () => {
             return () => {
                 if (controller !== next) return;
                 controller = null;
-                // 🔴 利用者の永続設定 `follow` だけを持ち越す。候補ジャンプの一時停止（followPausedByJump）は
-                //    INITIAL 由来で false に戻る＝文書切替・再マウントで自動的に解ける
+                // 🔴 利用者の永続設定 `follow` だけを持ち越す。候補ジャンプの一時停止（followPauseDocId）は
+                //    INITIAL 由来で null に戻る。ただし解除の主経路は docId 照合（音声が無い文書では attach 自体が
+                //    起きないため、ここに依存しない）。
                 state = { ...INITIAL_SNAPSHOT, follow: state.follow };
                 emit();
             };

--- a/src/components/TranscriptPlayer.tsx
+++ b/src/components/TranscriptPlayer.tsx
@@ -9,6 +9,11 @@
  * 本文（Markdown）側の時刻リンクとこの帯は別ファイルに分かれているため、両者はこのモジュールの
  * 小さなストアで繋ぐ。Provider を足すと lead 側の配線点が増えるので、
  * モジュール内シングルトン + useSyncExternalStore にした（同時に開く文書は常に 1 本）。
+ *
+ * 仕様 B3（要確認箇所）で足したもの:
+ * - `audio`: 音声の可用性。`ready`（コントローラ接続）とは別に、URL の取得と音声要素のロード状態を持つ。
+ *   要確認カードの「音声を再生」はこれが `'ready'` のときだけ押せる（押しても無反応なボタンを出さない）。
+ * - `playbackBlocked`: ブラウザが再生を拒否した（自動再生ポリシー等）。再生済みの見た目にせず、案内を出す。
  */
 
 import React, {
@@ -20,6 +25,16 @@ import React, {
 import { Crosshair, Pause, Play } from 'lucide-react';
 import { formatTimestamp } from '@/lib/transcriptMerge';
 
+/**
+ * 音声の可用性。
+ * - `none`: 文字起こし UI が載っていない（通常の文書・切替直後）
+ * - `loading`: URL の取得中、または音声要素がまだメタデータを読めていない
+ * - `ready`: 音声要素が読めた（再生・シークできる）
+ * - `unavailable`: 音声参照が無い／URL 取得失敗／音声要素のロード失敗（本文の確認・編集はできる）
+ */
+export type TranscriptAudioStatus = 'none' | 'loading' | 'ready' | 'unavailable';
+export type TranscriptAudioUnavailableReason = 'no_audio' | 'url_failed' | 'media_failed';
+
 export interface TranscriptPlaybackSnapshot {
     /** 現在の再生位置（秒） */
     currentSec: number;
@@ -28,8 +43,14 @@ export interface TranscriptPlaybackSnapshot {
     playing: boolean;
     /** 再生中の行へスクロール追従するか。利用者が止められる */
     follow: boolean;
-    /** 音声付きのプレイヤーが実際に載っているか。音声が無い文書ではずっと false */
+    /** 音声付きのプレイヤーが実際に載っているか（コントローラの接続）。音声ロード成功の保証ではない */
     ready: boolean;
+    /** 音声の可用性（URL 取得と音声要素のロード状態を含む） */
+    audio: TranscriptAudioStatus;
+    /** `audio === 'unavailable'` のときの理由。再試行の要否の判断に使う */
+    audioReason: TranscriptAudioUnavailableReason | null;
+    /** 直前の再生要求をブラウザが拒否した（自動再生の拒否）。再生が始まると解ける */
+    playbackBlocked: boolean;
 }
 
 /** 音声要素を持つ側（＝TranscriptPlayer）が登録する実操作 */
@@ -45,6 +66,9 @@ const INITIAL_SNAPSHOT: TranscriptPlaybackSnapshot = {
     playing: false,
     follow: true,
     ready: false,
+    audio: 'none',
+    audioReason: null,
+    playbackBlocked: false,
 };
 
 const createTranscriptPlaybackStore = () => {
@@ -86,6 +110,14 @@ const createTranscriptPlaybackStore = () => {
             controller.seek(Math.max(0, sec));
         },
         setFollow: (follow: boolean): void => patch({ follow }),
+        /** 音声の可用性を置く（URL の取得側とプレイヤーの両方から呼ぶ） */
+        setAudio: (audio: TranscriptAudioStatus, reason: TranscriptAudioUnavailableReason | null = null): void =>
+            patch({ audio, audioReason: audio === 'unavailable' ? reason : null }),
+        /** 音声要素が読めた。`loading` からだけ進める（ロード失敗の後に届く suspend 等で戻さない） */
+        markAudioReady: (): void => {
+            if (state.audio !== 'loading') return;
+            patch({ audio: 'ready', audioReason: null });
+        },
         attach: (next: TranscriptPlaybackController): (() => void) => {
             controller = next;
             patch({ ready: true });
@@ -115,8 +147,25 @@ export const useTranscriptPlayback = (): TranscriptPlaybackSnapshot =>
         transcriptPlayback.getSnapshot,
     );
 
+/**
+ * スクロールの寄せ方。動きを減らす設定（prefers-reduced-motion）ではアニメーションを止める。
+ * matchMedia の無い実行環境（jsdom・SSR）では従来どおり smooth。
+ */
+export const scrollBehaviorForMotion = (): ScrollBehavior => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return 'smooth';
+    try {
+        return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
+    } catch {
+        return 'smooth';
+    }
+};
+
 const safeDuration = (value: number | undefined): number =>
     typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+
+/** 自動再生ポリシーによる拒否だけを「案内対象」にする。pause() による中断（AbortError）等は含めない */
+const isNotAllowedError = (error: unknown): boolean =>
+    typeof error === 'object' && error !== null && (error as { name?: unknown }).name === 'NotAllowedError';
 
 export interface TranscriptPlayerProps {
     /** 再生する音声の URL。無い文書では未指定になり、この帯ごと消える */
@@ -124,6 +173,8 @@ export interface TranscriptPlayerProps {
     /** 総尺が分かっていれば渡す（metadata 読み込み前の表示に使う） */
     durationSec?: number;
     className?: string;
+    /** 音声要素のロード失敗（URL は取れたが再生できない）。呼び出し側が帯を状態表示へ差し替える */
+    onMediaError?: () => void;
 }
 
 /**
@@ -134,6 +185,7 @@ export function TranscriptPlayer({
     audioUrl,
     durationSec,
     className,
+    onMediaError,
 }: TranscriptPlayerProps): React.ReactElement | null {
     const audioRef = useRef<HTMLAudioElement | null>(null);
     const snapshot = useTranscriptPlayback();
@@ -144,11 +196,21 @@ export function TranscriptPlayer({
         if (!element) return;
         try {
             const started: unknown = element.play();
-            if (started && typeof (started as Promise<void>).catch === 'function') {
-                void (started as Promise<void>).catch(() => undefined);
+            if (started && typeof (started as Promise<void>).then === 'function') {
+                void (started as Promise<void>).then(
+                    () => transcriptPlayback.patch({ playing: true, playbackBlocked: false }),
+                    (error: unknown) => {
+                        // 🔴 拒否されたのに「再生中」の見た目にしない。自動再生の拒否だけを案内する
+                        transcriptPlayback.patch(
+                            isNotAllowedError(error)
+                                ? { playing: false, playbackBlocked: true }
+                                : { playing: false },
+                        );
+                    },
+                );
             }
         } catch {
-            // 自動再生の拒否や、音声要素を持たない実行環境。帯の状態表示だけ進める
+            // 音声要素を持たない実行環境。帯の状態表示だけ進める
         }
         transcriptPlayback.patch({ playing: true });
     }, []);
@@ -167,6 +229,9 @@ export function TranscriptPlayer({
     useEffect(() => {
         if (!hasAudio) return;
         transcriptPlayback.patch({ durationSec: safeDuration(durationSec) });
+        // 音声要素のロード状態。メタデータが読めていれば ready、まだなら loading（要素のイベントで進める）
+        const element = audioRef.current;
+        transcriptPlayback.setAudio(element && element.readyState >= 1 ? 'ready' : 'loading');
         return transcriptPlayback.attach({
             seek: (sec: number) => {
                 const element = audioRef.current;
@@ -191,6 +256,12 @@ export function TranscriptPlayer({
     };
     const onLoadedMetadata = (event: React.SyntheticEvent<HTMLAudioElement>): void => {
         transcriptPlayback.patch({ durationSec: safeDuration(event.currentTarget.duration) });
+        transcriptPlayback.markAudioReady();
+    };
+    const onMediaLoaded = (): void => transcriptPlayback.markAudioReady();
+    const onError = (): void => {
+        transcriptPlayback.setAudio('unavailable', 'media_failed');
+        onMediaError?.();
     };
 
     return (
@@ -210,7 +281,12 @@ export function TranscriptPlayer({
                 className="hidden"
                 onTimeUpdate={onTimeUpdate}
                 onLoadedMetadata={onLoadedMetadata}
-                onPlay={() => transcriptPlayback.patch({ playing: true })}
+                onLoadedData={onMediaLoaded}
+                onCanPlay={onMediaLoaded}
+                // preload を尊重しないブラウザは読み込みを中断（suspend）する。押せば読み込みが始まるので待たせない
+                onSuspend={onMediaLoaded}
+                onError={onError}
+                onPlay={() => transcriptPlayback.patch({ playing: true, playbackBlocked: false })}
                 onPause={() => transcriptPlayback.patch({ playing: false })}
                 onEnded={() => transcriptPlayback.patch({ playing: false })}
             />

--- a/src/components/TranscriptPlayer.tsx
+++ b/src/components/TranscriptPlayer.tsx
@@ -14,6 +14,8 @@
  * - `audio`: 音声の可用性。`ready`（コントローラ接続）とは別に、URL の取得と音声要素のロード状態を持つ。
  *   要確認カードの「音声を再生」はこれが `'ready'` のときだけ押せる（押しても無反応なボタンを出さない）。
  * - `playbackBlocked`: ブラウザが再生を拒否した（自動再生ポリシー等）。再生済みの見た目にせず、案内を出す。
+ * - `followPausedByJump`: 候補カードからの「本文の該当段落へ移動」で追従を一時的に止めている過渡状態。
+ *   🔴 利用者の永続設定 `follow` とは別物で、`follow` を書き換えない（文書切替・再マウントで自動的に解ける）。
  */
 
 import React, {
@@ -51,6 +53,11 @@ export interface TranscriptPlaybackSnapshot {
     audioReason: TranscriptAudioUnavailableReason | null;
     /** 直前の再生要求をブラウザが拒否した（自動再生の拒否）。再生が始まると解ける */
     playbackBlocked: boolean;
+    /**
+     * 候補ジャンプ（本文の該当段落へ移動）で追従を一時的に止めている。
+     * 🔴 `follow`（利用者の永続設定）は書き換えない過渡状態。追従トグル・シーク・文書切替（attach の終了）・reset で解ける。
+     */
+    followPausedByJump: boolean;
 }
 
 /** 音声要素を持つ側（＝TranscriptPlayer）が登録する実操作 */
@@ -69,6 +76,7 @@ const INITIAL_SNAPSHOT: TranscriptPlaybackSnapshot = {
     audio: 'none',
     audioReason: null,
     playbackBlocked: false,
+    followPausedByJump: false,
 };
 
 const createTranscriptPlaybackStore = () => {
@@ -106,10 +114,17 @@ const createTranscriptPlaybackStore = () => {
          */
         seek: (sec: number): void => {
             if (!controller || !Number.isFinite(sec)) return;
-            patch({ currentSec: Math.max(0, sec) });
+            // 利用者が再生位置を動かした＝候補ジャンプの一時停止から追従へ復帰する
+            patch({ currentSec: Math.max(0, sec), followPausedByJump: false });
             controller.seek(Math.max(0, sec));
         },
-        setFollow: (follow: boolean): void => patch({ follow }),
+        /** 追従の入切（利用者の永続設定）。トグル操作は候補ジャンプの一時停止を必ず解く */
+        setFollow: (follow: boolean): void => patch({ follow, followPausedByJump: false }),
+        /**
+         * 候補ジャンプ中の追従の一時停止（次の時刻更新でジャンプ先から引き戻さない）。
+         * 🔴 `follow` は書き換えない。解除は setFollow / seek / attach の終了（文書切替・再マウント）/ reset。
+         */
+        pauseFollowForJump: (): void => patch({ followPausedByJump: true }),
         /** 音声の可用性を置く（URL の取得側とプレイヤーの両方から呼ぶ） */
         setAudio: (audio: TranscriptAudioStatus, reason: TranscriptAudioUnavailableReason | null = null): void =>
             patch({ audio, audioReason: audio === 'unavailable' ? reason : null }),
@@ -124,6 +139,8 @@ const createTranscriptPlaybackStore = () => {
             return () => {
                 if (controller !== next) return;
                 controller = null;
+                // 🔴 利用者の永続設定 `follow` だけを持ち越す。候補ジャンプの一時停止（followPausedByJump）は
+                //    INITIAL 由来で false に戻る＝文書切替・再マウントで自動的に解ける
                 state = { ...INITIAL_SNAPSHOT, follow: state.follow };
                 emit();
             };

--- a/src/components/TranscriptPlayer.tsx
+++ b/src/components/TranscriptPlayer.tsx
@@ -188,19 +188,33 @@ export function TranscriptPlayer({
     onMediaError,
 }: TranscriptPlayerProps): React.ReactElement | null {
     const audioRef = useRef<HTMLAudioElement | null>(null);
+    // play() の世代。文書切替（要素の張り替え・remount）や後続の play() で追い越された
+    // 遅延結果を弾くために使う（Major1: 共有ストアへの誤った上書きを防ぐ）
+    const playGenerationRef = useRef(0);
     const snapshot = useTranscriptPlayback();
     const hasAudio = typeof audioUrl === 'string' && audioUrl.trim() !== '';
 
     const play = useCallback((): void => {
         const element = audioRef.current;
         if (!element) return;
+        // 🔴 この play() 呼び出しの世代と音声要素を捕捉する。文書を切り替える（＝プレイヤーが
+        //    remount されて要素が張り替わる）と、遅れて届く resolve/reject は共有ストアへ書かない。
+        //    そうしないと、前の文書の play() の遅延結果が別文書の再生状態を上書きしてしまう
+        //    （B の playing が誤って false になる／A の NotAllowedError が B に再生拒否案内を出す）。
+        const generation = (playGenerationRef.current += 1);
+        const isCurrent = (): boolean =>
+            audioRef.current === element && playGenerationRef.current === generation;
         try {
             const started: unknown = element.play();
             if (started && typeof (started as Promise<void>).then === 'function') {
                 void (started as Promise<void>).then(
-                    () => transcriptPlayback.patch({ playing: true, playbackBlocked: false }),
+                    () => {
+                        if (isCurrent()) transcriptPlayback.patch({ playing: true, playbackBlocked: false });
+                    },
                     (error: unknown) => {
-                        // 🔴 拒否されたのに「再生中」の見た目にしない。自動再生の拒否だけを案内する
+                        // 🔴 拒否されたのに「再生中」の見た目にしない。自動再生の拒否だけを案内する。
+                        //    ただし現役の要素／世代でなければ（切替後）何も書かない。
+                        if (!isCurrent()) return;
                         transcriptPlayback.patch(
                             isNotAllowedError(error)
                                 ? { playing: false, playbackBlocked: true }
@@ -212,7 +226,8 @@ export function TranscriptPlayer({
         } catch {
             // 音声要素を持たない実行環境。帯の状態表示だけ進める
         }
-        transcriptPlayback.patch({ playing: true });
+        // 楽観的な「再生中」表示も、現役の要素／世代のときだけ（切替直後の誤 true を防ぐ）
+        if (isCurrent()) transcriptPlayback.patch({ playing: true });
     }, []);
 
     const pause = useCallback((): void => {

--- a/src/components/TranscriptReviewPanel.test.tsx
+++ b/src/components/TranscriptReviewPanel.test.tsx
@@ -505,6 +505,34 @@ describe('本文との照合', () => {
         expect(moveButton('p-9')?.title).toContain('生成時に確定していません');
     });
 
+    // Major3: paragraphStartLine はあるが時刻が無効（startSec===null）な候補（PR2 で音声長超の句は
+    // 時刻が除去されつつアンカーは付与され得る）。B3「時刻不明は再生と本文移動を無効」。
+    it('🔴 段落アンカーはあるが時刻が無い候補: ハッシュ一致でも本文移動は無効（再生も無効）', async () => {
+        transcriptPlayback.setAudio('ready');
+        const anchoredNoTime: ReviewCandidate = {
+            phraseId: 'p-anchored-notime',
+            reasons: ['recognition_status'],
+            excerpt: '時刻は消えたが段落は分かる句',
+            excerptTruncated: false,
+            recognitionStatus: 'NoMatch',
+            speaker: '営業',
+            paragraphStartLine: 7,
+            // startSec なし（時刻情報のない候補）
+        };
+        await renderExpanded({ review: review({ candidates: [CANDIDATES[2], anchoredNoTime] }) });
+        await settleHash(TRANSCRIPT);
+
+        // 時刻あり＋アンカーあり＋ハッシュ一致（p-1）は従来どおり移動できる
+        expect(moveButton('p-1')?.disabled).toBe(false);
+
+        // アンカーはあるが時刻なし: 再生も本文移動も無効。理由を「時刻なし」と分けて表示する
+        expect(card('p-anchored-notime')?.querySelector('h4')?.textContent).toContain('時刻情報なし');
+        expect(playButton('p-anchored-notime')?.disabled).toBe(true);
+        const move = moveButton('p-anchored-notime');
+        expect(move?.disabled).toBe(true);
+        expect(move?.title).toContain('時刻情報がないため');
+    });
+
     it('sourceTextHash の無い壊れた review では移動を出さないが候補は読める', async () => {
         await renderExpanded({ review: review({ sourceTextHash: '' }) });
         await settleHash(TRANSCRIPT);
@@ -672,6 +700,56 @@ describe('本文の段落バッジとの往復', () => {
             card('p-1')!.focus();
         });
         expect(paragraph.getAttribute('data-review-target')).toBeNull();
+    });
+
+    // Major2: 再生追従中に候補へジャンプ → 次の時刻更新で追従がジャンプ先から引き戻す不具合。
+    // B3「候補移動と再生中段落の追従を区別」。ジャンプで追従を止め、利用者の明示再開で戻す。
+    it('🔴 再生追従中に候補へジャンプ→次の時刻更新で引き戻されない（追従を止め、明示再開で戻す）', async () => {
+        await render(
+            <div>
+                <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={createTranscriptMarkdownComponents({ markdown: TRANSCRIPT, reviewAnchors: anchors() })}
+                >
+                    {TRANSCRIPT}
+                </ReactMarkdown>
+                <TranscriptReviewPanel {...panelProps()} />
+                <TranscriptPlayer audioUrl="https://example.test/a.m4a" durationSec={3600} />
+            </div>,
+        );
+        await click(toggle());
+        await settleHash(TRANSCRIPT);
+
+        // 追従中: 30 秒 → 3 行目が現在行としてスクロール追従する
+        await act(async () => {
+            transcriptPlayback.patch({ currentSec: 30 });
+        });
+        expect(container.querySelector('[data-transcript-active="true"]')?.getAttribute('data-review-line')).toBe('3');
+
+        // 候補 p-1（1 行目）へ移動＝ジャンプ。ジャンプ先へ寄せ、フォーカスは維持し、以後の追従は止まる
+        scrollIntoView.mockClear();
+        await click(moveButton('p-1'));
+        const target = container.querySelector<HTMLElement>('p[data-review-line="1"]')!;
+        expect(target.getAttribute('data-review-target')).toBe('true');
+        expect(document.activeElement).toBe(target);
+        expect(scrollIntoView).toHaveBeenCalledTimes(1); // ジャンプの 1 回だけ
+
+        // 次の時刻更新（120 秒 → 7 行目が現在行）でも、ジャンプ先から引き戻されない
+        scrollIntoView.mockClear();
+        await act(async () => {
+            transcriptPlayback.patch({ currentSec: 120 });
+        });
+        expect(container.querySelector('[data-transcript-active="true"]')?.getAttribute('data-review-line')).toBe('7');
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        // 追従を明示的に再開すると、通常どおり追従スクロールに戻る
+        await click(container.querySelector('button[aria-pressed]'));
+        scrollIntoView.mockClear();
+        await act(async () => {
+            transcriptPlayback.patch({ currentSec: 30 });
+        });
+        expect(container.querySelector('[data-transcript-active="true"]')?.getAttribute('data-review-line')).toBe('3');
+        expect(scrollIntoView).toHaveBeenCalled();
     });
 
     it('別文書の移動要求には反応しない（文書 ID で照合）', async () => {

--- a/src/components/TranscriptReviewPanel.test.tsx
+++ b/src/components/TranscriptReviewPanel.test.tsx
@@ -628,7 +628,7 @@ describe('操作', () => {
 
         await render(<TranscriptReviewPanel key="other" {...panelProps({ documentId: 'doc-synthetic-2', review: undefined })} />);
         expect(transcriptReviewSelection.getSnapshot()).toEqual({
-            documentId: null, selectedPhraseId: null, revealRequest: null, paragraphRequest: null,
+            documentId: null, selectedPhraseId: null, revealRequest: null, paragraphRequest: null, consumedNonce: null,
         });
     });
 });
@@ -703,8 +703,10 @@ describe('本文の段落バッジとの往復', () => {
     });
 
     // Major2: 再生追従中に候補へジャンプ → 次の時刻更新で追従がジャンプ先から引き戻す不具合。
-    // B3「候補移動と再生中段落の追従を区別」。ジャンプで追従を止め、利用者の明示再開で戻す。
-    it('🔴 再生追従中に候補へジャンプ→次の時刻更新で引き戻されない（追従を止め、明示再開で戻す）', async () => {
+    // B3「候補移動と再生中段落の追従を区別」。ジャンプで追従を「一時停止」し（🔴 永続の follow は書き換えない。
+    // 書き換えると文書切替後も追従が戻らず、再開しても段落の再マウントで再び切られる）、利用者の明示操作（追従トグル・シーク）で戻す。
+    // 一時停止の解除・段落の再マウント・文書切替の錠は transcriptMarkdownComponents.test.tsx。
+    it('🔴 再生追従中に候補へジャンプ→次の時刻更新で引き戻されない（追従を一時停止・follow は書き換えない・「音声を再生」で戻る）', async () => {
         await render(
             <div>
                 <ReactMarkdown
@@ -719,6 +721,11 @@ describe('本文の段落バッジとの往復', () => {
         );
         await click(toggle());
         await settleHash(TRANSCRIPT);
+        // 音声要素がメタデータを読めた＝候補カードの「音声を再生」が押せる
+        await act(async () => {
+            container.querySelector('audio')!.dispatchEvent(new Event('loadedmetadata'));
+        });
+        expect(transcriptPlayback.getSnapshot().audio).toBe('ready');
 
         // 追従中: 30 秒 → 3 行目が現在行としてスクロール追従する
         await act(async () => {
@@ -726,13 +733,16 @@ describe('本文の段落バッジとの往復', () => {
         });
         expect(container.querySelector('[data-transcript-active="true"]')?.getAttribute('data-review-line')).toBe('3');
 
-        // 候補 p-1（1 行目）へ移動＝ジャンプ。ジャンプ先へ寄せ、フォーカスは維持し、以後の追従は止まる
+        // 候補 p-1（1 行目）へ移動＝ジャンプ。ジャンプ先へ寄せ、フォーカスは維持し、以後の追従は一時停止
         scrollIntoView.mockClear();
         await click(moveButton('p-1'));
         const target = container.querySelector<HTMLElement>('p[data-review-line="1"]')!;
         expect(target.getAttribute('data-review-target')).toBe('true');
         expect(document.activeElement).toBe(target);
         expect(scrollIntoView).toHaveBeenCalledTimes(1); // ジャンプの 1 回だけ
+        // 🔴 永続の follow は書き換えない（追従トグルは押されたまま）。一時停止だけが立つ
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: true });
+        expect(container.querySelector('button[aria-pressed]')?.getAttribute('aria-pressed')).toBe('true');
 
         // 次の時刻更新（120 秒 → 7 行目が現在行）でも、ジャンプ先から引き戻されない
         scrollIntoView.mockClear();
@@ -742,12 +752,10 @@ describe('本文の段落バッジとの往復', () => {
         expect(container.querySelector('[data-transcript-active="true"]')?.getAttribute('data-review-line')).toBe('7');
         expect(scrollIntoView).not.toHaveBeenCalled();
 
-        // 追従を明示的に再開すると、通常どおり追従スクロールに戻る
-        await click(container.querySelector('button[aria-pressed]'));
+        // 候補カードの「音声を再生」（＝シーク: 利用者が再生位置を動かした）で一時停止が解け、通常の追従に戻る
         scrollIntoView.mockClear();
-        await act(async () => {
-            transcriptPlayback.patch({ currentSec: 30 });
-        });
+        await click(playButton('p-3'));
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: false, currentSec: 30 });
         expect(container.querySelector('[data-transcript-active="true"]')?.getAttribute('data-review-line')).toBe('3');
         expect(scrollIntoView).toHaveBeenCalled();
     });

--- a/src/components/TranscriptReviewPanel.test.tsx
+++ b/src/components/TranscriptReviewPanel.test.tsx
@@ -16,6 +16,21 @@ const { getAudioDownloadURL } = vi.hoisted(() => ({
 }));
 vi.mock('@/lib/storage', () => ({ getAudioDownloadURL }));
 
+// 🔴 hashTranscriptText だけを差し替え可能な形にする（他は実物のまま）。
+//    「照合前はバッジ無し」を観測するテストは、crypto.subtle の解決が act の flush に入るか否かの
+//    時間依存でフレークになる。そのテストだけ、解決タイミングを手で制御できる deferred に差し替える。
+vi.mock('@/lib/transcriptDocument', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/lib/transcriptDocument')>();
+    return { ...actual, hashTranscriptText: vi.fn(actual.hashTranscriptText) };
+});
+
+/** テスト用の手動解決 Promise（モジュール直下・どの describe からも使える） */
+function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => { resolve = res; });
+    return { promise, resolve };
+}
+
 import type { ReviewCandidate, TranscriptReview } from '@/lib/transcriptReviewContract';
 import { hashTranscriptText, reviewAnchorsByLine } from '@/lib/transcriptDocument';
 import { TranscriptPlayer, transcriptPlayback } from './TranscriptPlayer';
@@ -780,21 +795,24 @@ describe('TranscriptAwareMarkdown の段落バッジ', () => {
         // このテストだけの本文（他のテストでハッシュがキャッシュ済みだと「照合前」を観測できない）
         const body = `${TRANSCRIPT}\n\n[04:00](#t=240) **営業** 照合テスト用の固有の段落。`;
         const matching = review({ sourceTextHash: sha256(body) });
+        // 🔴 「照合前」を決定的に観測するため、最初のハッシュ計算だけ手動解決の Promise に差し替える。
+        //    実 crypto.subtle は act の flush に入るか否かで解決タイミングが揺れ、「照合前はバッジ無し」がフレークになる。
+        const pending = makeDeferred<string>();
+        vi.mocked(hashTranscriptText).mockReturnValueOnce(pending.promise);
         await render(<TranscriptAwareMarkdown markdown={body} documentId={DOC_ID} review={matching} />);
-        // 照合前はバッジ無し
+        // 照合前はバッジ無し（ハッシュは保留中で決定的）
         expect(container.querySelector('[data-review-badge]')).toBeNull();
-        await settleHash(body);
+        await act(async () => { pending.resolve(sha256(body)); await pending.promise; });
         expect(container.querySelectorAll('[data-review-badge]')).toHaveLength(3);
 
+        // 編集後（不一致）は実装の実ハッシュで照合（mockOnce は消費済み＝以降は実物）
         const edited = body.replace('こちらこそ', 'こちらこそ、');
         await render(<TranscriptAwareMarkdown markdown={edited} documentId={DOC_ID} review={matching} />);
         await settleHash(edited);
         expect(container.querySelector('[data-review-badge]')).toBeNull();
         // 時刻リンク自体は引き続き動く
         expect(container.querySelector('a[data-timestamp-sec="12"]')).not.toBeNull();
-    // 🔴 2 回のレンダー＋2 回の非同期ハッシュ照合を含み、全体実行の並列負荷で既定 5000ms を超えることがある
-    //    （単体では緑）。判定内容は変えず、余裕を与える。
-    }, 20_000);
+    });
 
     it('documentId が無ければ照合しない（バッジ無し）', async () => {
         await render(<TranscriptAwareMarkdown markdown={TRANSCRIPT} review={review()} />);

--- a/src/components/TranscriptReviewPanel.test.tsx
+++ b/src/components/TranscriptReviewPanel.test.tsx
@@ -822,6 +822,44 @@ describe('TranscriptAwareMarkdown の段落バッジ', () => {
 });
 
 // ---------------------------------------------------------------------------
+// TranscriptAwareMarkdown: 文書離脱で候補ジャンプの追従一時停止を破棄（プレイヤーの有無に依存しない解除経路）
+// 音声の無い文書で立てた一時停止が、別文書を経て戻ったときに残り追従を殺すのを防ぐ（往復 A→B→A）。
+// ---------------------------------------------------------------------------
+
+describe('TranscriptAwareMarkdown: 文書離脱で追従一時停止を破棄', () => {
+    it('🔴 文書 ID が変わると、その文書で立てた一時停止(followPauseDocId)を解除し、戻っても復活しない', async () => {
+        // 音声の無い文書 A で候補ジャンプ相当の一時停止を立てる（プレイヤーは載っていない）
+        transcriptPlayback.pauseFollowForJump('doc-A');
+        await render(<TranscriptAwareMarkdown markdown={TRANSCRIPT} documentId="doc-A" review={null} />);
+        expect(transcriptPlayback.getSnapshot().followPauseDocId).toBe('doc-A');
+
+        // 別文書 B へ切替（documentId 変化）: A の一時停止は破棄される（attach の終了処理に依存しない）
+        await render(<TranscriptAwareMarkdown markdown={TRANSCRIPT} documentId="doc-B" review={null} />);
+        expect(transcriptPlayback.getSnapshot().followPauseDocId).toBeNull();
+
+        // A へ戻っても一時停止は復活しない（戻った A は最初から追従が効く）
+        await render(<TranscriptAwareMarkdown markdown={TRANSCRIPT} documentId="doc-A" review={null} />);
+        expect(transcriptPlayback.getSnapshot().followPauseDocId).toBeNull();
+    });
+
+    it('同じ文書のまま再描画しても一時停止は保たれる（documentId 不変ならクリーンアップは走らない）', async () => {
+        transcriptPlayback.pauseFollowForJump('doc-A');
+        await render(<TranscriptAwareMarkdown markdown={TRANSCRIPT} documentId="doc-A" review={null} />);
+        // 同じ documentId で本文だけ変えて再描画（親の再描画・本文編集の再現）
+        await render(<TranscriptAwareMarkdown markdown={`${TRANSCRIPT}\n\n[05:00](#t=300) **営業** 追記。`} documentId="doc-A" review={null} />);
+        expect(transcriptPlayback.getSnapshot().followPauseDocId).toBe('doc-A');
+    });
+
+    it('別文書が既に立てた一時停止は、離脱する文書のクリーンアップで消さない（docId 照合）', async () => {
+        // A をマウント → B の一時停止を立てる → A から C へ離脱しても、消すのは A の分だけ＝B の停止は残る
+        await render(<TranscriptAwareMarkdown markdown={TRANSCRIPT} documentId="doc-A" review={null} />);
+        transcriptPlayback.pauseFollowForJump('doc-B');
+        await render(<TranscriptAwareMarkdown markdown={TRANSCRIPT} documentId="doc-C" review={null} />);
+        expect(transcriptPlayback.getSnapshot().followPauseDocId).toBe('doc-B');
+    });
+});
+
+// ---------------------------------------------------------------------------
 // TranscriptAudioBar: URL 取得の loading / 失敗 / 再試行 / メディアエラー
 // ---------------------------------------------------------------------------
 

--- a/src/components/TranscriptReviewPanel.test.tsx
+++ b/src/components/TranscriptReviewPanel.test.tsx
@@ -1,0 +1,852 @@
+// @vitest-environment jsdom
+
+/**
+ * 「要確認箇所」パネル（仕様 B3）の錠。
+ * fixture は全て合成（架空の会話・架空の ID）。実データ・鍵は使わない。
+ */
+import { createHash } from 'node:crypto';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getAudioDownloadURL } = vi.hoisted(() => ({
+    getAudioDownloadURL: vi.fn<(path: string) => Promise<string>>(),
+}));
+vi.mock('@/lib/storage', () => ({ getAudioDownloadURL }));
+
+import type { ReviewCandidate, TranscriptReview } from '@/lib/transcriptReviewContract';
+import { hashTranscriptText, reviewAnchorsByLine } from '@/lib/transcriptDocument';
+import { TranscriptPlayer, transcriptPlayback } from './TranscriptPlayer';
+import { transcriptReviewSelection } from './transcriptReviewSelection';
+import { createTranscriptMarkdownComponents } from './transcriptMarkdownComponents';
+import { TranscriptAudioBar, TranscriptAwareMarkdown } from './TranscriptDocumentView';
+import {
+    REVIEW_PAGE_SIZE,
+    TranscriptReviewPanel,
+    describeReviewAudioStatus,
+    describeReviewReasons,
+    describeUnavailableReason,
+    formatConfidence,
+    formatReviewTimeRange,
+    speakTimestamp,
+    type TranscriptReviewPanelProps,
+} from './TranscriptReviewPanel';
+
+// ---------------------------------------------------------------------------
+// 合成 fixture
+// ---------------------------------------------------------------------------
+
+/** 生成 Markdown（1 行目・3 行目・5 行目=欠落注記・7 行目が段落） */
+const TRANSCRIPT = [
+    '[00:12](#t=12) **お客様** いえ、こちらこそ。',
+    '',
+    '[00:30](#t=30) **営業** 本日はお時間ありがとうございます。',
+    '',
+    '　　　⚠ 01:20:00 〜 01:45:00 は文字起こしできませんでした。［再試行］',
+    '',
+    '[02:00](#t=120) **営業** それでランディの画面なんですけれども。',
+].join('\n');
+
+const sha256 = (text: string): string => createHash('sha256').update(Buffer.from(text, 'utf8')).digest('hex');
+
+const DOC_ID = 'doc-synthetic-1';
+
+const CANDIDATES: ReviewCandidate[] = [
+    // 保存順はわざと時刻順にしない（UI 側で並べ直すことの錠）
+    {
+        phraseId: 'p-7', reasons: ['low_confidence'], excerpt: 'それでランディの画面なんですけれども', excerptTruncated: false,
+        confidence: 0.62, recognitionStatus: 'Success', speaker: '営業', startSec: 120.4, endSec: 123.9, paragraphStartLine: 7,
+    },
+    {
+        phraseId: 'p-9', reasons: ['recognition_status'], excerpt: '', excerptTruncated: false,
+        recognitionStatus: 'NoMatch', speaker: 'お客様',
+    },
+    {
+        phraseId: 'p-1', reasons: ['low_confidence', 'unknown_confidence'], excerpt: 'いえ、こちらこそ', excerptTruncated: false,
+        confidence: 0.4, speaker: 'お客様', startSec: 12.2, endSec: 14, paragraphStartLine: 1,
+    },
+    {
+        phraseId: 'p-3', reasons: ['low_confidence'], excerpt: 'ほ'.repeat(300), excerptTruncated: true,
+        confidence: 0.7, recognitionStatus: 'Success', speaker: '営業', startSec: 30, endSec: 31, paragraphStartLine: 3,
+    },
+];
+
+const review = (overrides: Partial<TranscriptReview> = {}): TranscriptReview => ({
+    version: 1,
+    threshold: 0.75,
+    sourceTextHash: sha256(TRANSCRIPT),
+    sourceJobId: 'job-synthetic-1',
+    summary: {
+        totalPhrases: 12, lowConfidence: 3, recognitionFlagged: 1, candidateTotal: 4,
+        unknownConfidence: 0, unknownRecognitionStatus: 0, noTimeCandidates: 1, savedCandidates: 4,
+    },
+    availability: 'complete',
+    candidates: CANDIDATES,
+    ...overrides,
+});
+
+const manyCandidates = (count: number): ReviewCandidate[] =>
+    Array.from({ length: count }, (_, index) => ({
+        phraseId: `m-${index}`,
+        reasons: ['low_confidence'] as ReviewCandidate['reasons'],
+        excerpt: `候補 ${index}`,
+        excerptTruncated: false,
+        confidence: 0.5,
+        startSec: index * 10,
+        endSec: index * 10 + 5,
+    }));
+
+// ---------------------------------------------------------------------------
+// 描画の道具
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+let root: Root;
+let scrollIntoView: ReturnType<typeof vi.fn>;
+
+const originalScrollIntoView = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView');
+const originalPlay = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'play');
+const originalPause = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'pause');
+
+beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(HTMLMediaElement.prototype, 'play', { configurable: true, value: vi.fn(async () => undefined) });
+    Object.defineProperty(HTMLMediaElement.prototype, 'pause', { configurable: true, value: vi.fn(() => undefined) });
+});
+
+afterAll(() => {
+    if (originalScrollIntoView) Object.defineProperty(Element.prototype, 'scrollIntoView', originalScrollIntoView);
+    else delete (Element.prototype as Partial<Element>).scrollIntoView;
+    if (originalPlay) Object.defineProperty(HTMLMediaElement.prototype, 'play', originalPlay);
+    else delete (HTMLMediaElement.prototype as Partial<HTMLMediaElement>).play;
+    if (originalPause) Object.defineProperty(HTMLMediaElement.prototype, 'pause', originalPause);
+    else delete (HTMLMediaElement.prototype as Partial<HTMLMediaElement>).pause;
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+});
+
+beforeEach(() => {
+    transcriptPlayback.reset();
+    transcriptReviewSelection.reset();
+    getAudioDownloadURL.mockReset();
+    scrollIntoView = vi.fn();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', { configurable: true, writable: true, value: scrollIntoView });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(async () => {
+    await act(async () => {
+        root.unmount();
+    });
+    container.remove();
+    transcriptPlayback.reset();
+    transcriptReviewSelection.reset();
+});
+
+async function render(element: React.ReactNode): Promise<void> {
+    await act(async () => {
+        root.render(<>{element}</>);
+    });
+}
+
+/** 本文ハッシュの非同期計算を待つ（同じ本文はキャッシュされた同じ Promise） */
+async function settleHash(text: string): Promise<void> {
+    await act(async () => {
+        await hashTranscriptText(text);
+        await new Promise(resolve => setTimeout(resolve, 0));
+    });
+}
+
+async function click(element: Element | null | undefined): Promise<void> {
+    if (!element) throw new Error('要素が見つかりません');
+    await act(async () => {
+        element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+}
+
+function findButton(text: string, scope: ParentNode = container): HTMLButtonElement | null {
+    return Array.from(scope.querySelectorAll<HTMLButtonElement>('button'))
+        .find(button => button.textContent?.trim() === text) ?? null;
+}
+
+function panelProps(overrides: Partial<TranscriptReviewPanelProps> = {}): TranscriptReviewPanelProps {
+    return {
+        documentId: DOC_ID,
+        review: review(),
+        bodyText: TRANSCRIPT,
+        bodyState: 'view',
+        canEdit: true,
+        onEditBody: vi.fn(),
+        ...overrides,
+    };
+}
+
+const panel = (): HTMLElement | null => container.querySelector('[data-testid="transcript-review-panel"]');
+const toggle = (): HTMLButtonElement | null => container.querySelector('button[aria-expanded]');
+const cards = (): HTMLLIElement[] => Array.from(container.querySelectorAll<HTMLLIElement>('li[data-review-card]'));
+const card = (phraseId: string): HTMLLIElement | null => container.querySelector(`li[data-review-card="${phraseId}"]`);
+const playButton = (phraseId: string): HTMLButtonElement | null =>
+    card(phraseId)?.querySelector<HTMLButtonElement>('button[aria-label$="音声を再生"], button[aria-label="音声を再生（時刻情報なし）"]') ?? null;
+const moveButton = (phraseId: string): HTMLButtonElement | null => findButton('本文の該当段落へ移動', card(phraseId) ?? container);
+
+async function renderExpanded(overrides: Partial<TranscriptReviewPanelProps> = {}): Promise<TranscriptReviewPanelProps> {
+    const props = panelProps(overrides);
+    await render(<TranscriptReviewPanel {...props} />);
+    await click(toggle());
+    return props;
+}
+
+// ---------------------------------------------------------------------------
+// 文言（純関数）
+// ---------------------------------------------------------------------------
+
+describe('文言の純関数', () => {
+    it('理由ラベルは「要確認（…）」で、複数は「・」区切り。未知の理由コードは読み飛ばす', () => {
+        expect(describeReviewReasons(['low_confidence'])).toBe('要確認（低信頼）');
+        expect(describeReviewReasons(['low_confidence', 'unknown_confidence'])).toBe('要確認（低信頼・認識状態不明）');
+        expect(describeReviewReasons(['recognition_status', 'empty_text'])).toBe('要確認（認識結果を確認・認識テキストなし）');
+        expect(describeReviewReasons(['future_reason' as never])).toBe('要確認');
+        expect(describeReviewReasons(undefined)).toBe('要確認');
+        expect(describeReviewReasons('low_confidence' as never)).toBe('要確認');
+    });
+
+    it('時刻表示は整数秒の見た目・内部は小数秒。時刻なしは「時刻情報なし」', () => {
+        expect(formatReviewTimeRange(120.4, 123.9)).toBe('02:00〜02:03');
+        expect(formatReviewTimeRange(12.2, 12.9)).toBe('00:12');
+        expect(formatReviewTimeRange(12, undefined)).toBe('00:12');
+        expect(formatReviewTimeRange(null, 5)).toBe('時刻情報なし');
+        expect(speakTimestamp(754)).toBe('12分34秒');
+        expect(speakTimestamp(3723.4)).toBe('1時間2分3秒');
+    });
+
+    it('信頼度は数値のときだけ小数 2 桁。％や「正答率」にしない', () => {
+        expect(formatConfidence(0.62)).toBe('0.62');
+        expect(formatConfidence(undefined)).toBeNull();
+        expect(formatConfidence(Number.NaN)).toBeNull();
+    });
+
+    it('unavailable の理由コードは短い注記に、未知コードはコードのまま添える', () => {
+        expect(describeUnavailableReason('no_phrases')).toContain('句が無く');
+        expect(describeUnavailableReason('storage_budget')).toContain('保存上限');
+        expect(describeUnavailableReason('internal_error')).toContain('作成に失敗');
+        expect(describeUnavailableReason('mystery')).toContain('理由コード: mystery');
+        expect(describeUnavailableReason(undefined)).toBe('信頼度情報を保存できませんでした。');
+    });
+
+    it('音声の状態文言: 読み込み中・再生不可・再生拒否。ready と none は無言', () => {
+        expect(describeReviewAudioStatus({ audio: 'loading', playbackBlocked: false })).toContain('音声を読み込んでいます');
+        expect(describeReviewAudioStatus({ audio: 'unavailable', playbackBlocked: false }))
+            .toBe('音声を再生できません。本文の確認・編集はできます。');
+        expect(describeReviewAudioStatus({ audio: 'ready', playbackBlocked: true })).toContain('プレイヤーの再生ボタン');
+        expect(describeReviewAudioStatus({ audio: 'ready', playbackBlocked: false })).toBeNull();
+        expect(describeReviewAudioStatus({ audio: 'none', playbackBlocked: false })).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 状態の出し分け（仕様 B3 の表）
+// ---------------------------------------------------------------------------
+
+describe('状態の出し分け', () => {
+    it('🔴 review の無い旧文書: 「信頼度情報がありません」。候補 0 件・評価済みに見せない・操作ボタンを出さない', async () => {
+        await render(<TranscriptReviewPanel {...panelProps({ review: undefined })} />);
+        const text = panel()?.textContent ?? '';
+        expect(panel()?.getAttribute('data-review-state')).toBe('missing');
+        expect(text).toContain('この文書には信頼度情報がありません');
+        expect(text).toContain('候補が 0 件という意味ではありません');
+        expect(text).not.toContain('生成時の候補');
+        expect(text).not.toContain('自動判定の要確認候補はありません');
+        expect(container.querySelector('button')).toBeNull();
+    });
+
+    it('🔴 availability=unavailable: summary の数字を描かず、理由に応じた短い注記', async () => {
+        await render(<TranscriptReviewPanel {...panelProps({
+            review: review({
+                availability: 'unavailable', unavailableReason: 'storage_budget', candidates: [],
+                summary: { ...review().summary, candidateTotal: 99 },
+            }),
+        })} />);
+        const text = panel()?.textContent ?? '';
+        expect(panel()?.getAttribute('data-review-state')).toBe('unavailable');
+        expect(text).toContain('信頼度情報がありません');
+        expect(text).toContain('保存上限');
+        expect(text).not.toContain('99');
+        expect(text).not.toContain('生成時の候補');
+    });
+
+    it('🔴 評価済みで候補 0 件: 「自動判定の要確認候補はありません。内容の正確さを保証するものではありません。」', async () => {
+        await render(<TranscriptReviewPanel {...panelProps({
+            review: review({ candidates: [], summary: { ...review().summary, candidateTotal: 0, savedCandidates: 0 } }),
+        })} />);
+        const text = panel()?.textContent ?? '';
+        expect(text).toContain('要確認箇所：生成時の候補 0 箇所');
+        expect(text).toContain('自動判定の要確認候補はありません。内容の正確さを保証するものではありません。');
+        expect(text).not.toContain('問題なし');
+        expect(toggle()).toBeNull();
+    });
+
+    it('未評価句がある: 信頼度／認識状態不明の件数を添え、0 件でも「全句に問題なし」としない', async () => {
+        await render(<TranscriptReviewPanel {...panelProps({
+            review: review({
+                candidates: [],
+                summary: { ...review().summary, candidateTotal: 0, savedCandidates: 0, unknownConfidence: 2, unknownRecognitionStatus: 1 },
+            }),
+        })} />);
+        const text = panel()?.textContent ?? '';
+        expect(text).toContain('信頼度不明 2 句・認識状態不明 1 句');
+        expect(text).toContain('全句に問題が無いという意味ではありません');
+    });
+
+    it('見出しは「生成時の候補 N 箇所」（「残り N」ではない）＋断定しない説明。既定は折りたたみ', async () => {
+        await render(<TranscriptReviewPanel {...panelProps()} />);
+        const text = panel()?.textContent ?? '';
+        expect(text).toContain('要確認箇所：生成時の候補 4 箇所');
+        expect(text).toContain('音声認識の信頼度などをもとにした候補です。誤りと断定するものではありません。');
+        expect(text).not.toContain('残り');
+        expect(toggle()?.getAttribute('aria-expanded')).toBe('false');
+        const regionId = toggle()?.getAttribute('aria-controls');
+        expect(regionId).toBeTruthy();
+        expect(document.getElementById(regionId!)?.hidden).toBe(true);
+
+        await click(toggle());
+        expect(toggle()?.getAttribute('aria-expanded')).toBe('true');
+        expect(document.getElementById(regionId!)?.hidden).toBe(false);
+    });
+
+    it('partial: 「候補 N 箇所のうち先頭 K 箇所を表示しています」', async () => {
+        await render(<TranscriptReviewPanel {...panelProps({
+            review: review({ availability: 'partial', summary: { ...review().summary, candidateTotal: 30, savedCandidates: 4 } }),
+        })} />);
+        expect(panel()?.textContent).toContain('候補 30 箇所のうち先頭 4 箇所を表示しています。');
+        expect(panel()?.textContent).toContain('生成時の候補 30 箇所');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 候補カード
+// ---------------------------------------------------------------------------
+
+describe('候補カード', () => {
+    it('時刻順（時刻なしは末尾）。見出しに候補番号・時刻・話者・理由。抜粋は引用として強調', async () => {
+        await renderExpanded();
+        expect(cards().map(element => element.getAttribute('data-review-card'))).toEqual(['p-1', 'p-3', 'p-7', 'p-9']);
+
+        const first = card('p-1')!;
+        const heading = first.querySelector('h4')!;
+        expect(heading.textContent).toContain('候補 1 / 4');
+        expect(heading.textContent).toContain('00:12〜00:14');
+        expect(heading.textContent).toContain('話者 お客様');
+        expect(heading.textContent).toContain('要確認（低信頼・認識状態不明）');
+        expect(first.getAttribute('aria-labelledby')).toBe(heading.id);
+        expect(first.tabIndex).toBe(-1);
+
+        const excerpt = first.querySelector('[data-review-excerpt]')!;
+        expect(excerpt.textContent).toContain('「いえ、こちらこそ」');
+        expect(excerpt.className).toContain('bg-amber-50');
+    });
+
+    it('抜粋が省略されていれば省略と分かる注記、無ければ「認識テキストなし」', async () => {
+        await renderExpanded();
+        expect(card('p-3')?.querySelector('[data-review-excerpt]')?.textContent).toContain('抜粋は上限で省略しています');
+        expect(card('p-9')?.querySelector('[data-review-excerpt]')?.textContent).toContain('認識テキストなし');
+    });
+
+    it('confidence は詳細を開いたときだけ「認識信頼度 0.62（判定の参考値…）」。％や正答率にしない', async () => {
+        await renderExpanded();
+        const details = card('p-7')?.querySelector('details');
+        expect(details).not.toBeNull();
+        expect(details?.textContent).toContain('認識信頼度');
+        expect(details?.textContent).toContain('0.62（判定の参考値');
+        expect(details?.textContent).toContain('認識状態');
+        expect(details?.textContent).toContain('Success');
+        expect(card('p-7')?.textContent).not.toContain('%');
+        expect(card('p-7')?.textContent).not.toContain('正答率');
+        // 見出し側（詳細の外）には数値を出さない
+        expect(card('p-7')?.querySelector('h4')?.textContent).not.toContain('0.62');
+    });
+
+    it('🔴 時刻不明の候補: 「時刻情報なし」。再生と本文移動は無効、抜粋は出る', async () => {
+        transcriptPlayback.setAudio('ready');
+        await settleHash(TRANSCRIPT);
+        await renderExpanded();
+        await settleHash(TRANSCRIPT);
+        const noTime = card('p-9')!;
+        expect(noTime.querySelector('h4')?.textContent).toContain('時刻情報なし');
+        expect(playButton('p-9')?.disabled).toBe(true);
+        expect(playButton('p-9')?.title).toContain('時刻情報がないため');
+        expect(moveButton('p-9')?.disabled).toBe(true);
+        expect(noTime.querySelector('[data-review-excerpt]')).not.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 音声（既存の seek 経路へ接続・状態の出し分け）
+// ---------------------------------------------------------------------------
+
+describe('音声の再生', () => {
+    it('🔴 音声 ready のとき「[mm:ss]から音声を再生」は既存 seek 経路で小数秒を渡す。選択だけでは再生しない', async () => {
+        await render(
+            <div>
+                <TranscriptReviewPanel {...panelProps()} />
+                <TranscriptPlayer audioUrl="https://example.test/synthetic.m4a" durationSec={600} />
+            </div>,
+        );
+        expect(transcriptPlayback.getSnapshot().audio).toBe('loading');
+        await act(async () => {
+            container.querySelector('audio')!.dispatchEvent(new Event('loadedmetadata'));
+        });
+        expect(transcriptPlayback.getSnapshot().audio).toBe('ready');
+        await click(toggle());
+
+        // 選ぶだけ（フォーカス）では再生しない
+        await act(async () => {
+            card('p-1')!.focus();
+        });
+        expect(transcriptReviewSelection.getSnapshot().selectedPhraseId).toBe('p-1');
+        expect(transcriptPlayback.getSnapshot().playing).toBe(false);
+        expect(transcriptPlayback.getSnapshot().currentSec).toBe(0);
+
+        const button = playButton('p-1')!;
+        expect(button.disabled).toBe(false);
+        expect(button.textContent).toContain('00:12から音声を再生');
+        expect(button.getAttribute('aria-label')).toBe('0分12秒から音声を再生');
+        await click(button);
+        expect(transcriptPlayback.getSnapshot().currentSec).toBe(12.2);
+        expect(transcriptPlayback.getSnapshot().playing).toBe(true);
+        // 見た目は整数秒（jsdom の音声要素は duration を持たないので総尺は見ない）
+        expect(container.querySelector('[data-testid="transcript-player-time"]')?.textContent).toMatch(/^00:12 \//);
+    });
+
+    it('🔴 音声の読み込み中: 「音声を読み込んでいます」・再生ボタンは無効', async () => {
+        transcriptPlayback.setAudio('loading');
+        await renderExpanded();
+        expect(container.querySelector('[data-testid="transcript-review-audio-note"]')?.textContent)
+            .toContain('音声を読み込んでいます');
+        expect(playButton('p-1')?.disabled).toBe(true);
+        expect(playButton('p-1')?.title).toBe('音声を読み込んでいます');
+    });
+
+    it('🔴 音声なし・URL 取得失敗・ロード失敗: 「音声を再生できません。本文の確認・編集はできます。」', async () => {
+        transcriptPlayback.setAudio('unavailable', 'url_failed');
+        await renderExpanded();
+        expect(container.querySelector('[data-testid="transcript-review-audio-note"]')?.textContent)
+            .toBe('音声を再生できません。本文の確認・編集はできます。');
+        expect(playButton('p-1')?.disabled).toBe(true);
+        // 本文移動・抜粋・編集導線は残る
+        expect(card('p-1')?.querySelector('[data-review-excerpt]')).not.toBeNull();
+        expect(findButton('本文を編集')).not.toBeNull();
+    });
+
+    it('再生がブラウザに拒否された: 再生済みに見せず、プレイヤーの操作を案内する', async () => {
+        transcriptPlayback.setAudio('ready');
+        transcriptPlayback.patch({ playbackBlocked: true, playing: false });
+        await renderExpanded();
+        expect(container.querySelector('[data-testid="transcript-review-audio-note"]')?.textContent)
+            .toContain('プレイヤーの再生ボタン');
+    });
+
+    it('時刻を持つ候補が無ければ音声の注記を出さない', async () => {
+        transcriptPlayback.setAudio('unavailable', 'no_audio');
+        await renderExpanded({ review: review({ candidates: [CANDIDATES[1]], summary: { ...review().summary, candidateTotal: 1 } }) });
+        expect(container.querySelector('[data-testid="transcript-review-audio-note"]')).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 本文との照合（ハッシュ）と編集の扱い
+// ---------------------------------------------------------------------------
+
+describe('本文との照合', () => {
+    it('🔴 表示本文のハッシュが一致: 「本文の該当段落へ移動」が有効になり、押すと段落への移動要求が出る', async () => {
+        await renderExpanded();
+        await settleHash(TRANSCRIPT);
+        expect(container.querySelector('[data-testid="transcript-review-anchor-note"]')).toBeNull();
+        expect(moveButton('p-1')?.disabled).toBe(false);
+        expect(moveButton('p-7')?.disabled).toBe(false);
+
+        await click(moveButton('p-7'));
+        const snapshot = transcriptReviewSelection.getSnapshot();
+        expect(snapshot.documentId).toBe(DOC_ID);
+        expect(snapshot.selectedPhraseId).toBe('p-7');
+        expect(snapshot.paragraphRequest?.line).toBe(7);
+    });
+
+    it('🔴 ハッシュ不一致（編集済み）: 「本文は編集されています。以下は生成時の要確認候補です。」。移動は無効、抜粋と再生は残る', async () => {
+        transcriptPlayback.setAudio('ready');
+        const edited = `${TRANSCRIPT}\n\n[03:00](#t=180) **営業** 追記した段落。`;
+        await renderExpanded({ bodyText: edited });
+        await settleHash(edited);
+        expect(container.querySelector('[data-testid="transcript-review-anchor-note"]')?.textContent)
+            .toBe('本文は編集されています。以下は生成時の要確認候補です。');
+        expect(moveButton('p-1')?.disabled).toBe(true);
+        expect(moveButton('p-1')?.title).toContain('本文が編集されている');
+        expect(playButton('p-1')?.disabled).toBe(false);
+        expect(card('p-1')?.querySelector('[data-review-excerpt]')?.textContent).toContain('いえ、こちらこそ');
+        expect(panel()?.textContent).toContain('生成時の候補 4 箇所');
+    });
+
+    it('🔴 編集モード中: 本文アンカーを無効化し、確定後に照合すると案内。「本文を編集」は出さない', async () => {
+        await renderExpanded({ bodyState: 'editing' });
+        await settleHash(TRANSCRIPT);
+        expect(container.querySelector('[data-testid="transcript-review-anchor-note"]')?.textContent)
+            .toContain('本文を編集中です');
+        expect(moveButton('p-1')?.disabled).toBe(true);
+        expect(moveButton('p-1')?.title).toContain('編集中は本文へ移動できません');
+        expect(findButton('本文を編集')).toBeNull();
+    });
+
+    it('アンカーの無い候補は一致していても移動できない（推測しない）', async () => {
+        await renderExpanded();
+        await settleHash(TRANSCRIPT);
+        expect(moveButton('p-9')?.disabled).toBe(true);
+        expect(moveButton('p-9')?.title).toContain('生成時に確定していません');
+    });
+
+    it('sourceTextHash の無い壊れた review では移動を出さないが候補は読める', async () => {
+        await renderExpanded({ review: review({ sourceTextHash: '' }) });
+        await settleHash(TRANSCRIPT);
+        expect(moveButton('p-1')?.disabled).toBe(true);
+        expect(cards()).toHaveLength(4);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 操作: 前後移動・さらに表示・本文を編集・閲覧専用
+// ---------------------------------------------------------------------------
+
+describe('操作', () => {
+    it('前の候補／次の候補: 選択とフォーカスが移り、端では無効。選択だけでは再生しない', async () => {
+        transcriptPlayback.setAudio('ready');
+        await renderExpanded();
+        const previous = findButton('前の候補')!;
+        const next = findButton('次の候補')!;
+        expect(previous.disabled).toBe(true);
+        expect(next.disabled).toBe(false);
+
+        await click(next);
+        expect(transcriptReviewSelection.getSnapshot().selectedPhraseId).toBe('p-1');
+        expect(document.activeElement).toBe(card('p-1'));
+        expect(card('p-1')?.getAttribute('aria-current')).toBe('true');
+        expect(findButton('前の候補')?.disabled).toBe(true);
+
+        await click(findButton('次の候補'));
+        expect(document.activeElement).toBe(card('p-3'));
+        expect(card('p-1')?.getAttribute('aria-current')).toBeNull();
+        expect(findButton('前の候補')?.disabled).toBe(false);
+
+        await click(findButton('次の候補'));
+        await click(findButton('次の候補'));
+        expect(document.activeElement).toBe(card('p-9'));
+        expect(findButton('次の候補')?.disabled).toBe(true);
+
+        await click(findButton('前の候補'));
+        expect(document.activeElement).toBe(card('p-7'));
+        expect(transcriptPlayback.getSnapshot().playing).toBe(false);
+    });
+
+    it('長い一覧は 20 件ずつ「さらに表示」。次の候補への移動は必要なカードを展開する', async () => {
+        const total = 45;
+        await renderExpanded({
+            review: review({ candidates: manyCandidates(total), summary: { ...review().summary, candidateTotal: total, savedCandidates: total } }),
+        });
+        expect(cards()).toHaveLength(REVIEW_PAGE_SIZE);
+        const more = findButton(`さらに表示（残り ${total - REVIEW_PAGE_SIZE} 件）`);
+        expect(more).not.toBeNull();
+        await click(more);
+        expect(cards()).toHaveLength(REVIEW_PAGE_SIZE * 2);
+        await click(findButton(`さらに表示（残り ${total - REVIEW_PAGE_SIZE * 2} 件）`));
+        expect(cards()).toHaveLength(total);
+        expect(Array.from(container.querySelectorAll('button')).some(button => button.textContent?.includes('さらに表示'))).toBe(false);
+    });
+
+    it('表示範囲の末尾を選んだ状態で「次の候補」を押すと、次のカードが展開されてフォーカスを受ける', async () => {
+        const total = 45;
+        await renderExpanded({
+            review: review({ candidates: manyCandidates(total), summary: { ...review().summary, candidateTotal: total, savedCandidates: total } }),
+        });
+        await act(async () => {
+            transcriptReviewSelection.select(DOC_ID, `m-${REVIEW_PAGE_SIZE - 1}`);
+        });
+        expect(card(`m-${REVIEW_PAGE_SIZE}`)).toBeNull();
+        await click(findButton('次の候補'));
+        expect(card(`m-${REVIEW_PAGE_SIZE}`)).not.toBeNull();
+        expect(document.activeElement).toBe(card(`m-${REVIEW_PAGE_SIZE}`));
+        expect(cards()).toHaveLength(REVIEW_PAGE_SIZE + 1);
+    });
+
+    it('「本文を編集」は既存の全文編集へ渡す（onEditBody）。閲覧専用（canEdit=false）では出さない', async () => {
+        const props = await renderExpanded();
+        await click(findButton('本文を編集'));
+        expect(props.onEditBody).toHaveBeenCalledTimes(1);
+
+        await render(<TranscriptReviewPanel {...panelProps({ canEdit: false })} />);
+        await click(toggle());
+        expect(findButton('本文を編集')).toBeNull();
+        // 確認・再生の操作は残る
+        expect(cards()).toHaveLength(4);
+        expect(playButton('p-1')).not.toBeNull();
+    });
+
+    it('🔴 文書を切り替える（パネルが破棄される）と、その文書の候補選択・移動要求は捨てられる', async () => {
+        await renderExpanded();
+        await settleHash(TRANSCRIPT);
+        await click(findButton('次の候補'));
+        await click(moveButton('p-1'));
+        expect(transcriptReviewSelection.getSnapshot().selectedPhraseId).toBe('p-1');
+        expect(transcriptReviewSelection.getSnapshot().paragraphRequest).not.toBeNull();
+
+        await render(<TranscriptReviewPanel key="other" {...panelProps({ documentId: 'doc-synthetic-2', review: undefined })} />);
+        expect(transcriptReviewSelection.getSnapshot()).toEqual({
+            documentId: null, selectedPhraseId: null, revealRequest: null, paragraphRequest: null,
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 本文（段落バッジ）との往復
+// ---------------------------------------------------------------------------
+
+describe('本文の段落バッジとの往復', () => {
+    const anchors = () => ({ documentId: DOC_ID, anchorsByLine: reviewAnchorsByLine(CANDIDATES) });
+
+    function bodyAndPanel(): React.ReactElement {
+        return (
+            <div>
+                <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={createTranscriptMarkdownComponents({ markdown: TRANSCRIPT, reviewAnchors: anchors() })}
+                >
+                    {TRANSCRIPT}
+                </ReactMarkdown>
+                <TranscriptReviewPanel {...panelProps()} />
+            </div>
+        );
+    }
+
+    it('アンカーのある段落だけに「要確認 N 箇所」バッジ（選択不可・印刷非表示）。段落全体を誤り扱いしない', async () => {
+        await render(bodyAndPanel());
+        const badges = Array.from(container.querySelectorAll<HTMLElement>('[data-review-badge]'));
+        expect(badges.map(badge => badge.getAttribute('data-review-badge'))).toEqual(['1', '3', '7']);
+        expect(badges[0].className).toContain('select-none');
+        expect(badges[0].className).toContain('print:hidden');
+        expect(badges[0].textContent).toBe('要確認 1 箇所');
+        expect(container.querySelector('p[data-review-line="3"]')?.textContent).not.toContain('誤り');
+        // 時刻リンクの段落自体は tabIndex=-1 で移動先になれる
+        expect(container.querySelector<HTMLElement>('p[data-review-line="7"]')?.tabIndex).toBe(-1);
+    });
+
+    it('🔴 段落バッジ → パネルが展開し、該当カードにフォーカスと選択が移る（再生はしない）', async () => {
+        transcriptPlayback.setAudio('ready');
+        await render(bodyAndPanel());
+        expect(toggle()?.getAttribute('aria-expanded')).toBe('false');
+
+        await click(container.querySelector('[data-review-badge="7"] button'));
+        expect(toggle()?.getAttribute('aria-expanded')).toBe('true');
+        expect(document.activeElement).toBe(card('p-7'));
+        expect(card('p-7')?.getAttribute('aria-current')).toBe('true');
+        expect(transcriptPlayback.getSnapshot().playing).toBe(false);
+    });
+
+    it('🔴 「本文の該当段落へ移動」→ 段落がフォーカスを受けて寄せられ、再生中の紫とは別の強調が付く', async () => {
+        await render(bodyAndPanel());
+        await click(toggle());
+        await settleHash(TRANSCRIPT);
+        scrollIntoView.mockClear();
+
+        await click(moveButton('p-7'));
+        const paragraph = container.querySelector<HTMLElement>('p[data-review-line="7"]')!;
+        expect(document.activeElement).toBe(paragraph);
+        expect(paragraph.getAttribute('data-review-target')).toBe('true');
+        expect(paragraph.className).toContain('ring-amber-400');
+        expect(paragraph.className).not.toContain('bg-purple-50/70');
+        expect(paragraph.getAttribute('data-transcript-active')).toBeNull();
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+        // 他の段落は移動先にならない
+        expect(container.querySelector('p[data-review-line="1"]')?.getAttribute('data-review-target')).toBeNull();
+
+        // 別の候補を選ぶと移動先の強調は解ける
+        await act(async () => {
+            card('p-1')!.focus();
+        });
+        expect(paragraph.getAttribute('data-review-target')).toBeNull();
+    });
+
+    it('別文書の移動要求には反応しない（文書 ID で照合）', async () => {
+        await render(bodyAndPanel());
+        scrollIntoView.mockClear();
+        await act(async () => {
+            transcriptReviewSelection.moveToParagraph('doc-synthetic-other', 7, 'p-7');
+        });
+        expect(container.querySelector('p[data-review-line="7"]')?.getAttribute('data-review-target')).toBeNull();
+        expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// TranscriptAwareMarkdown: ハッシュ一致のときだけ段落バッジ
+// ---------------------------------------------------------------------------
+
+describe('TranscriptAwareMarkdown の段落バッジ', () => {
+    it('🔴 表示本文のハッシュが review.sourceTextHash と一致するときだけバッジを描く', async () => {
+        // このテストだけの本文（他のテストでハッシュがキャッシュ済みだと「照合前」を観測できない）
+        const body = `${TRANSCRIPT}\n\n[04:00](#t=240) **営業** 照合テスト用の固有の段落。`;
+        const matching = review({ sourceTextHash: sha256(body) });
+        await render(<TranscriptAwareMarkdown markdown={body} documentId={DOC_ID} review={matching} />);
+        // 照合前はバッジ無し
+        expect(container.querySelector('[data-review-badge]')).toBeNull();
+        await settleHash(body);
+        expect(container.querySelectorAll('[data-review-badge]')).toHaveLength(3);
+
+        const edited = body.replace('こちらこそ', 'こちらこそ、');
+        await render(<TranscriptAwareMarkdown markdown={edited} documentId={DOC_ID} review={matching} />);
+        await settleHash(edited);
+        expect(container.querySelector('[data-review-badge]')).toBeNull();
+        // 時刻リンク自体は引き続き動く
+        expect(container.querySelector('a[data-timestamp-sec="12"]')).not.toBeNull();
+    // 🔴 2 回のレンダー＋2 回の非同期ハッシュ照合を含み、全体実行の並列負荷で既定 5000ms を超えることがある
+    //    （単体では緑）。判定内容は変えず、余裕を与える。
+    }, 20_000);
+
+    it('documentId が無ければ照合しない（バッジ無し）', async () => {
+        await render(<TranscriptAwareMarkdown markdown={TRANSCRIPT} review={review()} />);
+        await settleHash(TRANSCRIPT);
+        expect(container.querySelector('[data-review-badge]')).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// TranscriptAudioBar: URL 取得の loading / 失敗 / 再試行 / メディアエラー
+// ---------------------------------------------------------------------------
+
+describe('TranscriptAudioBar の音声状態', () => {
+    const audioDocument = { text: TRANSCRIPT, audioStoragePath: 'audio/synthetic-user/synthetic.m4a' };
+
+    function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: unknown) => void } {
+        let resolve!: (value: T) => void;
+        let reject!: (error: unknown) => void;
+        const promise = new Promise<T>((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return { promise, resolve, reject };
+    }
+
+    it('🔴 URL 取得中は loading（帯は「読み込んでいます」）、取得できたらプレイヤーが載る', async () => {
+        const pending = deferred<string>();
+        getAudioDownloadURL.mockReturnValueOnce(pending.promise);
+        await render(<TranscriptAudioBar document={audioDocument} />);
+        expect(transcriptPlayback.getSnapshot().audio).toBe('loading');
+        expect(container.querySelector('[data-testid="transcript-audio-status"]')?.textContent).toContain('音声を読み込んでいます');
+        expect(container.querySelector('[data-testid="transcript-player"]')).toBeNull();
+
+        await act(async () => {
+            pending.resolve('https://example.test/synthetic.m4a');
+            await pending.promise;
+        });
+        expect(container.querySelector('[data-testid="transcript-player"]')).not.toBeNull();
+        expect(container.querySelector('audio')?.getAttribute('src')).toBe('https://example.test/synthetic.m4a');
+        // 音声要素はまだメタデータを読めていない
+        expect(transcriptPlayback.getSnapshot().audio).toBe('loading');
+        await act(async () => {
+            container.querySelector('audio')!.dispatchEvent(new Event('loadedmetadata'));
+        });
+        expect(transcriptPlayback.getSnapshot().audio).toBe('ready');
+    });
+
+    it('🔴 URL 取得失敗: 「音声を再生できません」と再試行。再試行は URL の再取得だけ（submit は呼ばない）', async () => {
+        getAudioDownloadURL.mockRejectedValueOnce(new Error('storage/object-not-found'));
+        await render(<TranscriptAudioBar document={audioDocument} />);
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(transcriptPlayback.getSnapshot().audio).toBe('unavailable');
+        expect(transcriptPlayback.getSnapshot().audioReason).toBe('url_failed');
+        const strip = container.querySelector('[data-testid="transcript-audio-status"]');
+        expect(strip?.textContent).toContain('音声を再生できません。本文の確認・編集はできます。');
+        expect(getAudioDownloadURL).toHaveBeenCalledTimes(1);
+
+        getAudioDownloadURL.mockResolvedValueOnce('https://example.test/synthetic.m4a');
+        await click(findButton('音声の取得を再試行'));
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(getAudioDownloadURL).toHaveBeenCalledTimes(2);
+        expect(getAudioDownloadURL).toHaveBeenLastCalledWith(audioDocument.audioStoragePath);
+        expect(container.querySelector('[data-testid="transcript-player"]')).not.toBeNull();
+    });
+
+    it('音声要素のロード失敗: プレイヤーを状態表示に差し替え、再試行できる', async () => {
+        getAudioDownloadURL.mockResolvedValue('https://example.test/synthetic.m4a');
+        await render(<TranscriptAudioBar document={audioDocument} />);
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(container.querySelector('audio')).not.toBeNull();
+
+        await act(async () => {
+            container.querySelector('audio')!.dispatchEvent(new Event('error'));
+        });
+        expect(container.querySelector('[data-testid="transcript-player"]')).toBeNull();
+        expect(container.querySelector('[data-testid="transcript-audio-status"]')?.textContent).toContain('音声を再生できません');
+        expect(transcriptPlayback.getSnapshot().audio).toBe('unavailable');
+        expect(transcriptPlayback.getSnapshot().audioReason).toBe('media_failed');
+
+        await click(findButton('音声の取得を再試行'));
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(container.querySelector('[data-testid="transcript-player"]')).not.toBeNull();
+        expect(getAudioDownloadURL).toHaveBeenCalledTimes(2);
+    });
+
+    it('文字起こしだが音声参照が無い: 帯は出さず、状態は unavailable（no_audio）', async () => {
+        await render(<TranscriptAudioBar document={{ text: TRANSCRIPT }} />);
+        expect(container.innerHTML).toBe('');
+        expect(transcriptPlayback.getSnapshot().audio).toBe('unavailable');
+        expect(transcriptPlayback.getSnapshot().audioReason).toBe('no_audio');
+        expect(getAudioDownloadURL).not.toHaveBeenCalled();
+    });
+
+    it('🔴 時刻リンクの無い通常の文書では何もしない（音声があっても）', async () => {
+        await render(<TranscriptAudioBar document={{ text: '# 議事録\n\n本文。', audioStoragePath: 'audio/u/a.mp3' }} />);
+        expect(container.innerHTML).toBe('');
+        expect(transcriptPlayback.getSnapshot().audio).toBe('none');
+        expect(getAudioDownloadURL).not.toHaveBeenCalled();
+    });
+
+    it('時刻リンクが消えた本文でも review に有効時刻があれば音声 UI を出す', async () => {
+        getAudioDownloadURL.mockResolvedValue('https://example.test/synthetic.m4a');
+        await render(<TranscriptAudioBar document={{ text: '編集で時刻リンクを全部消した本文。', audioStoragePath: 'audio/u/a.mp3', transcriptReview: review() }} />);
+        await act(async () => {
+            await Promise.resolve();
+        });
+        expect(container.querySelector('[data-testid="transcript-player"]')).not.toBeNull();
+    });
+
+    it('🔴 別文書へ切り替えたら前文書の音声は載せず、状態も新文書のものに置き直す', async () => {
+        const first = deferred<string>();
+        getAudioDownloadURL.mockReturnValueOnce(first.promise);
+        await render(<TranscriptAudioBar document={audioDocument} />);
+
+        const second = deferred<string>();
+        getAudioDownloadURL.mockReturnValueOnce(second.promise);
+        await render(<TranscriptAudioBar document={{ ...audioDocument, audioStoragePath: 'audio/synthetic-user/other.m4a' }} />);
+        expect(transcriptPlayback.getSnapshot().audio).toBe('loading');
+
+        // 前文書の URL が遅れて届いても載せない
+        await act(async () => {
+            first.resolve('https://example.test/first.m4a');
+            await first.promise;
+        });
+        expect(container.querySelector('audio')).toBeNull();
+
+        await act(async () => {
+            second.resolve('https://example.test/other.m4a');
+            await second.promise;
+        });
+        expect(container.querySelector('audio')?.getAttribute('src')).toBe('https://example.test/other.m4a');
+    });
+});

--- a/src/components/TranscriptReviewPanel.test.tsx
+++ b/src/components/TranscriptReviewPanel.test.tsx
@@ -660,7 +660,7 @@ describe('本文の段落バッジとの往復', () => {
             <div>
                 <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
-                    components={createTranscriptMarkdownComponents({ markdown: TRANSCRIPT, reviewAnchors: anchors() })}
+                    components={createTranscriptMarkdownComponents({ markdown: TRANSCRIPT, documentId: DOC_ID, reviewAnchors: anchors() })}
                 >
                     {TRANSCRIPT}
                 </ReactMarkdown>
@@ -726,7 +726,7 @@ describe('本文の段落バッジとの往復', () => {
             <div>
                 <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
-                    components={createTranscriptMarkdownComponents({ markdown: TRANSCRIPT, reviewAnchors: anchors() })}
+                    components={createTranscriptMarkdownComponents({ markdown: TRANSCRIPT, documentId: DOC_ID, reviewAnchors: anchors() })}
                 >
                     {TRANSCRIPT}
                 </ReactMarkdown>
@@ -756,7 +756,7 @@ describe('本文の段落バッジとの往復', () => {
         expect(document.activeElement).toBe(target);
         expect(scrollIntoView).toHaveBeenCalledTimes(1); // ジャンプの 1 回だけ
         // 🔴 永続の follow は書き換えない（追従トグルは押されたまま）。一時停止だけが立つ
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: true });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPauseDocId: DOC_ID });
         expect(container.querySelector('button[aria-pressed]')?.getAttribute('aria-pressed')).toBe('true');
 
         // 次の時刻更新（120 秒 → 7 行目が現在行）でも、ジャンプ先から引き戻されない
@@ -770,7 +770,7 @@ describe('本文の段落バッジとの往復', () => {
         // 候補カードの「音声を再生」（＝シーク: 利用者が再生位置を動かした）で一時停止が解け、通常の追従に戻る
         scrollIntoView.mockClear();
         await click(playButton('p-3'));
-        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPausedByJump: false, currentSec: 30 });
+        expect(transcriptPlayback.getSnapshot()).toMatchObject({ follow: true, followPauseDocId: null, currentSec: 30 });
         expect(container.querySelector('[data-transcript-active="true"]')?.getAttribute('data-review-line')).toBe('3');
         expect(scrollIntoView).toHaveBeenCalled();
     });

--- a/src/components/TranscriptReviewPanel.tsx
+++ b/src/components/TranscriptReviewPanel.tsx
@@ -486,18 +486,22 @@ function ReviewCandidateCard({
 
     const line = candidate.paragraphStartLine;
     const hasAnchor = typeof line === 'number' && Number.isInteger(line) && line >= 1;
-    const canMove = hasAnchor && anchorsEnabled;
+    // 🔴 時刻不明（startSec===null）は再生も本文移動も無効（仕様 B3）。PR2 で音声長超の句は
+    //    時刻が除去されつつ段落アンカーは付与され得るため、アンカーの有無だけでは判定しない。
+    const canMove = hasAnchor && anchorsEnabled && startSec !== null;
     const moveTitle = !hasAnchor
         ? 'この候補の本文位置は生成時に確定していません'
-        : anchorState === 'editing'
-            ? '編集中は本文へ移動できません（表示に戻ると再確認します）'
-            : anchorState === 'mismatch'
-                ? '本文が編集されているため移動できません'
-                : anchorState === 'pending'
-                    ? '本文を照合しています'
-                    : anchorState === 'none'
-                        ? '本文の照合情報がありません'
-                        : undefined;
+        : startSec === null
+            ? '時刻情報がないため本文へ移動できません'
+            : anchorState === 'editing'
+                ? '編集中は本文へ移動できません（表示に戻ると再確認します）'
+                : anchorState === 'mismatch'
+                    ? '本文が編集されているため移動できません'
+                    : anchorState === 'pending'
+                        ? '本文を照合しています'
+                        : anchorState === 'none'
+                            ? '本文の照合情報がありません'
+                            : undefined;
 
     return (
         <li

--- a/src/components/TranscriptReviewPanel.tsx
+++ b/src/components/TranscriptReviewPanel.tsx
@@ -1,0 +1,594 @@
+'use client';
+
+/**
+ * 「要確認箇所」パネル（仕様 B3）。完成した文字起こし文書の本文上部に置く折りたたみ式の一覧。
+ *
+ * 🔴 これは「再試行」ではない。バッチは部分再実行できないので、生成時に保存した候補
+ *    （低信頼・認識結果要確認の句）を**可視化**し、既存の音声シークと全文編集へ導線を繋ぐだけ。
+ * 🔴 「低信頼＝誤り」「候補なし＝正確」と読める表現を使わない。件数は「残り N」ではなく「生成時の候補 N 箇所」。
+ * 🔴 本文への移動・段落バッジは、表示本文の SHA-256 が `review.sourceTextHash` と一致する間だけ有効。
+ *    編集モード中はハッシュを取らず（毎キー再ハッシュしない）、表示本文が確定してから照合する。
+ *
+ * `DocumentDetailPanel` から独立したコンポーネントにしているのは TranscriptDocumentView と同じ理由
+ * （パネル本体のテストは素の関数呼び出しで、ここで使うフックはそこでは走らない）。
+ */
+
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { ArrowDown, ArrowUp, ChevronDown, ChevronUp, FileText, Locate, Play } from 'lucide-react';
+import { formatTimestamp } from '@/lib/transcriptMerge';
+import {
+    hashTranscriptText,
+    orderReviewCandidates,
+    type OrderedReviewCandidate,
+} from '@/lib/transcriptDocument';
+import type { ReviewReason, TranscriptReview } from '@/lib/transcriptReviewContract';
+import {
+    scrollBehaviorForMotion,
+    transcriptPlayback,
+    useTranscriptPlayback,
+    type TranscriptAudioStatus,
+    type TranscriptPlaybackSnapshot,
+} from '@/components/TranscriptPlayer';
+import {
+    transcriptReviewSelection,
+    useTranscriptReviewSelection,
+} from '@/components/transcriptReviewSelection';
+
+// ---------------------------------------------------------------------------
+// 文言（純関数・テストで直接検査する）
+// ---------------------------------------------------------------------------
+
+/** 一覧の描画分割。保存上限（200 件）とは別の、画面上の分割 */
+export const REVIEW_PAGE_SIZE = 20;
+
+const REASON_LABELS: Readonly<Record<ReviewReason, string>> = {
+    low_confidence: '低信頼',
+    recognition_status: '認識結果を確認',
+    empty_text: '認識テキストなし',
+    unknown_confidence: '認識状態不明',
+};
+
+/** 候補の理由ラベル。「要確認（低信頼・認識状態不明）」の形。未知の理由コードは読み飛ばす（保存データを信じすぎない） */
+export const describeReviewReasons = (reasons: readonly ReviewReason[] | undefined): string => {
+    const list: readonly unknown[] = Array.isArray(reasons) ? reasons : [];
+    const labels: string[] = [];
+    for (const reason of list) {
+        if (typeof reason !== 'string') continue;
+        const label = (REASON_LABELS as Readonly<Record<string, string | undefined>>)[reason];
+        if (typeof label === 'string' && !labels.includes(label)) labels.push(label);
+    }
+    return labels.length > 0 ? `要確認（${labels.join('・')}）` : '要確認';
+};
+
+/** 「12:34〜12:41」。終端が無い／同じ表示なら開始だけ。時刻が無ければ「時刻情報なし」 */
+export const formatReviewTimeRange = (startSec: number | null, endSec: number | undefined): string => {
+    if (startSec === null) return '時刻情報なし';
+    const start = formatTimestamp(startSec);
+    if (typeof endSec === 'number' && Number.isFinite(endSec) && endSec >= startSec) {
+        const end = formatTimestamp(endSec);
+        if (end !== start) return `${start}〜${end}`;
+    }
+    return start;
+};
+
+/** 読み上げ用の時刻。「12分34秒」「1時間2分3秒」 */
+export const speakTimestamp = (sec: number): string => {
+    const total = Math.floor(Math.max(0, sec));
+    const hours = Math.floor(total / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+    const seconds = total % 60;
+    return `${hours > 0 ? `${hours}時間` : ''}${minutes}分${seconds}秒`;
+};
+
+/** 認識信頼度の表示。数値でなければ出さない（0 埋め・％換算をしない） */
+export const formatConfidence = (confidence: number | undefined): string | null =>
+    typeof confidence === 'number' && Number.isFinite(confidence) ? confidence.toFixed(2) : null;
+
+/** `availability === 'unavailable'` の理由コード → 短い注記 */
+export const describeUnavailableReason = (reason: string | undefined): string => {
+    switch (reason) {
+        case 'no_phrases':
+            return '認識結果に句が無く、信頼度を評価できませんでした。';
+        case 'storage_budget':
+            return '候補データが保存上限を超えたため、この文書には保存されていません。';
+        case 'internal_error':
+            return '候補データの作成に失敗したため、この文書には保存されていません。';
+        default:
+            return reason
+                ? `信頼度情報を保存できませんでした（理由コード: ${reason}）。`
+                : '信頼度情報を保存できませんでした。';
+    }
+};
+
+/** 音声の状態 → 候補カードの上に出す 1 行。案内が要らない状態では null */
+export const describeReviewAudioStatus = (
+    playback: Pick<TranscriptPlaybackSnapshot, 'audio' | 'playbackBlocked'>,
+): string | null => {
+    if (playback.playbackBlocked) {
+        return 'ブラウザが再生を開始しませんでした。下部のプレイヤーの再生ボタンで再生してください。';
+    }
+    switch (playback.audio) {
+        case 'loading':
+            return '音声を読み込んでいます。読み込みが終わると各候補から再生できます。';
+        case 'unavailable':
+            return '音声を再生できません。本文の確認・編集はできます。';
+        default:
+            return null;
+    }
+};
+
+const countOf = (value: unknown, fallback: number): number =>
+    typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
+
+// ---------------------------------------------------------------------------
+// 本文ハッシュのフック（パネルと本文の両方が使う。同じ本文の計算はキャッシュで 1 回）
+// ---------------------------------------------------------------------------
+
+/**
+ * `text` の SHA-256（hex）。`enabled` が false の間は計算せず null（編集モード中はここで止める）。
+ * 計算が終わるまで・別の本文に変わった直後も null（照合前としてアンカーを無効に保つ）。
+ */
+export function useTranscriptTextHash(text: string, enabled: boolean): string | null {
+    const [known, setKnown] = useState<{ text: string; hash: string } | null>(null);
+    useEffect(() => {
+        if (!enabled) return;
+        let cancelled = false;
+        void hashTranscriptText(text)
+            .then(hash => {
+                if (!cancelled) setKnown({ text, hash });
+            })
+            .catch(() => {
+                // 照合不能。アンカーは無効のまま（本文の閲覧・編集・再生には影響しない）
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [text, enabled]);
+    return enabled && known !== null && known.text === text ? known.hash : null;
+}
+
+// ---------------------------------------------------------------------------
+// パネル
+// ---------------------------------------------------------------------------
+
+export type TranscriptReviewBodyState = 'view' | 'editing';
+
+/** 本文アンカーの状態。`match` のときだけ「本文の該当段落へ移動」と段落バッジが有効 */
+export type TranscriptReviewAnchorState = 'none' | 'editing' | 'pending' | 'match' | 'mismatch';
+
+export interface TranscriptReviewPanelProps {
+    /** 文書 ID。選択・移動要求・非同期の破棄をこの単位で行う */
+    documentId: string;
+    /** 保存された要確認データ。旧文書では undefined */
+    review: TranscriptReview | null | undefined;
+    /** 表示中の本文（表示モードでは保存済み本文）。ハッシュ照合にだけ使う */
+    bodyText: string;
+    /** `editing` の間は本文アンカーを無効にし、再ハッシュしない */
+    bodyState: TranscriptReviewBodyState;
+    /** 「本文を編集」を出すか（編集権限があり保存中でない）。閲覧専用では false */
+    canEdit: boolean;
+    /** 「本文を編集」＝既存の全文編集へ移る（新しいエディタは作らない） */
+    onEditBody?: () => void;
+    className?: string;
+}
+
+const PANEL_CLASS = 'rounded-xl border border-gray-200 bg-white shadow-sm print:hidden';
+const SMALL_BUTTON_CLASS =
+    'inline-flex min-h-8 items-center gap-1 rounded-md border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500';
+
+export function TranscriptReviewPanel({
+    documentId,
+    review,
+    bodyText,
+    bodyState,
+    canEdit,
+    onEditBody,
+    className,
+}: TranscriptReviewPanelProps): React.ReactElement {
+    const headingId = useId();
+    const regionId = useId();
+    const [expanded, setExpanded] = useState(false);
+    const [visibleCount, setVisibleCount] = useState(REVIEW_PAGE_SIZE);
+    const [focusRequest, setFocusRequest] = useState<{ phraseId: string; nonce: number } | null>(null);
+    const cardRefs = useRef(new Map<string, HTMLLIElement>());
+    const playback = useTranscriptPlayback();
+    const selection = useTranscriptReviewSelection();
+
+    const hasReview = Boolean(review && typeof review === 'object');
+    const unavailable = hasReview && review?.availability === 'unavailable';
+    const ordered = useMemo(
+        () => (hasReview && !unavailable ? orderReviewCandidates(review?.candidates) : []),
+        [hasReview, unavailable, review],
+    );
+    const sourceHash = hasReview && typeof review?.sourceTextHash === 'string' && review.sourceTextHash !== ''
+        ? review.sourceTextHash
+        : null;
+    const bodyHash = useTranscriptTextHash(bodyText, bodyState === 'view' && sourceHash !== null);
+    const anchorState: TranscriptReviewAnchorState =
+        sourceHash === null ? 'none'
+            : bodyState === 'editing' ? 'editing'
+                : bodyHash === null ? 'pending'
+                    : bodyHash === sourceHash ? 'match'
+                        : 'mismatch';
+    const anchorsEnabled = anchorState === 'match';
+
+    const selectedPhraseId = selection.documentId === documentId ? selection.selectedPhraseId : null;
+    const selectedIndex = selectedPhraseId === null
+        ? -1
+        : ordered.findIndex(entry => entry.candidate.phraseId === selectedPhraseId);
+
+    // 文書の切替（key が変わり破棄される）で、この文書の選択・要求を捨てる
+    useEffect(() => () => {
+        transcriptReviewSelection.clear(documentId);
+    }, [documentId]);
+
+    /** カードを選び、必要なら展開・追加表示して、描画後にフォーカスを渡す（音声は再生しない） */
+    const focusCandidate = useCallback((index: number): void => {
+        const entry = ordered[index];
+        if (!entry) return;
+        transcriptReviewSelection.select(documentId, entry.candidate.phraseId);
+        setExpanded(true);
+        setVisibleCount(count => Math.max(count, index + 1));
+        setFocusRequest(previous => ({ phraseId: entry.candidate.phraseId, nonce: (previous?.nonce ?? 0) + 1 }));
+    }, [documentId, ordered]);
+
+    // 本文の段落バッジからの表示要求（この文書のものだけ）。ストアの購読で受け、同じ要求は 1 回だけ処理する
+    useEffect(() => {
+        let handledNonce: number | null = null;
+        const handleRequest = (): void => {
+            const snapshot = transcriptReviewSelection.getSnapshot();
+            const request = snapshot.documentId === documentId ? snapshot.revealRequest : null;
+            if (!request || request.nonce === handledNonce) return;
+            handledNonce = request.nonce;
+            const index = ordered.findIndex(entry => entry.candidate.phraseId === request.phraseId);
+            if (index < 0) return;
+            setExpanded(true);
+            setVisibleCount(count => Math.max(count, index + 1));
+            setFocusRequest(previous => ({ phraseId: request.phraseId, nonce: (previous?.nonce ?? 0) + 1 }));
+        };
+        return transcriptReviewSelection.subscribe(handleRequest);
+    }, [documentId, ordered]);
+
+    // 展開・追加表示と同じ描画でカードが出るので、その後にフォーカスを渡す
+    useEffect(() => {
+        if (!focusRequest) return;
+        const element = cardRefs.current.get(focusRequest.phraseId);
+        if (!element) return;
+        element.focus({ preventScroll: true });
+        if (typeof element.scrollIntoView === 'function') {
+            element.scrollIntoView({ block: 'nearest', behavior: scrollBehaviorForMotion() });
+        }
+    }, [focusRequest]);
+
+    const registerCard = useCallback((phraseId: string, element: HTMLLIElement | null): void => {
+        if (element) cardRefs.current.set(phraseId, element);
+        else cardRefs.current.delete(phraseId);
+    }, []);
+
+    const panelClass = `${PANEL_CLASS} ${className ?? ''}`.trim();
+
+    // --- 信頼度情報が無い（旧文書）／保存できなかった（unavailable）: summary を描かず、0 件に見せない ---
+    if (!hasReview || unavailable) {
+        return (
+            <section
+                aria-labelledby={headingId}
+                data-testid="transcript-review-panel"
+                data-review-state={unavailable ? 'unavailable' : 'missing'}
+                className={`${panelClass} px-4 py-3`}
+            >
+                <h3 id={headingId} className="text-sm font-semibold text-gray-800">
+                    要確認箇所：この文書には信頼度情報がありません
+                </h3>
+                <p className="mt-1 text-xs text-gray-600">
+                    {unavailable
+                        ? describeUnavailableReason(review?.unavailableReason)
+                        : '生成時に信頼度情報が保存されていないため、自動判定の候補は表示できません。'}
+                    {' '}候補が 0 件という意味ではありません。本文の確認・編集はこれまでどおり行えます。
+                </p>
+            </section>
+        );
+    }
+
+    const summary = review?.summary;
+    const total = countOf(summary?.candidateTotal, ordered.length);
+    const unknownConfidence = countOf(summary?.unknownConfidence, 0);
+    const unknownStatus = countOf(summary?.unknownRecognitionStatus, 0);
+    const partial = review?.availability === 'partial' || ordered.length < total;
+    const visible = ordered.slice(0, visibleCount);
+    const remaining = ordered.length - visible.length;
+    const hasPlayable = ordered.some(entry => entry.startSec !== null);
+    const audioNote = hasPlayable ? describeReviewAudioStatus(playback) : null;
+    const anchorNote =
+        anchorState === 'editing'
+            ? '本文を編集中です。本文の該当段落への移動は、表示に戻って本文が確定すると再確認します。'
+            : anchorState === 'mismatch'
+                ? '本文は編集されています。以下は生成時の要確認候補です。'
+                : anchorState === 'pending'
+                    ? '本文を照合しています…'
+                    : null;
+    const canGoPrevious = ordered.length > 0 && selectedIndex > 0;
+    const canGoNext = ordered.length > 0 && selectedIndex < ordered.length - 1;
+
+    return (
+        <section
+            aria-labelledby={headingId}
+            data-testid="transcript-review-panel"
+            data-review-state="ready"
+            className={panelClass}
+        >
+            <div className="flex flex-wrap items-start justify-between gap-2 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                    <h3 id={headingId} className="text-sm font-semibold text-gray-800">
+                        要確認箇所：生成時の候補 {total} 箇所
+                    </h3>
+                    <p className="mt-1 text-xs text-gray-600">
+                        音声認識の信頼度などをもとにした候補です。誤りと断定するものではありません。
+                    </p>
+                    {total === 0 && (
+                        <p className="mt-1 text-xs text-gray-700">
+                            自動判定の要確認候補はありません。内容の正確さを保証するものではありません。
+                        </p>
+                    )}
+                    {(unknownConfidence > 0 || unknownStatus > 0) && (
+                        <p className="mt-1 text-xs text-gray-600">
+                            自動判定できなかった句があります（信頼度不明 {unknownConfidence} 句・認識状態不明 {unknownStatus} 句）。
+                            候補が 0 件でも、全句に問題が無いという意味ではありません。
+                        </p>
+                    )}
+                    {partial && ordered.length > 0 && (
+                        <p className="mt-1 text-xs text-gray-600">
+                            候補 {total} 箇所のうち先頭 {ordered.length} 箇所を表示しています。
+                        </p>
+                    )}
+                </div>
+                {ordered.length > 0 && (
+                    <button
+                        type="button"
+                        aria-expanded={expanded}
+                        aria-controls={regionId}
+                        onClick={() => setExpanded(value => !value)}
+                        className={SMALL_BUTTON_CLASS}
+                    >
+                        {expanded
+                            ? <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+                            : <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />}
+                        <span>{expanded ? '閉じる' : '開く'}</span>
+                    </button>
+                )}
+            </div>
+
+            {ordered.length > 0 && (
+                <div id={regionId} hidden={!expanded} className="border-t border-gray-100 px-4 py-3">
+                    {anchorNote && (
+                        <p role="status" data-testid="transcript-review-anchor-note" className="mb-2 text-xs text-gray-700">
+                            {anchorNote}
+                        </p>
+                    )}
+                    {audioNote && (
+                        <p role="status" data-testid="transcript-review-audio-note" className="mb-2 text-xs text-gray-700">
+                            {audioNote}
+                        </p>
+                    )}
+                    <ol aria-label="要確認候補の一覧" className="space-y-3">
+                        {visible.map((entry, index) => (
+                            <ReviewCandidateCard
+                                key={entry.candidate.phraseId}
+                                entry={entry}
+                                position={index + 1}
+                                total={ordered.length}
+                                documentId={documentId}
+                                selected={entry.candidate.phraseId === selectedPhraseId}
+                                anchorState={anchorState}
+                                anchorsEnabled={anchorsEnabled}
+                                audioStatus={playback.audio}
+                                threshold={review?.threshold}
+                                registerRef={registerCard}
+                            />
+                        ))}
+                    </ol>
+                    {remaining > 0 && (
+                        <button
+                            type="button"
+                            onClick={() => setVisibleCount(count => count + REVIEW_PAGE_SIZE)}
+                            className={`${SMALL_BUTTON_CLASS} mt-3`}
+                        >
+                            さらに表示（残り {remaining} 件）
+                        </button>
+                    )}
+                    <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+                        <div className="flex flex-wrap gap-2" role="group" aria-label="候補の移動">
+                            <button
+                                type="button"
+                                disabled={!canGoPrevious}
+                                onClick={() => focusCandidate(selectedIndex - 1)}
+                                className={SMALL_BUTTON_CLASS}
+                            >
+                                <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
+                                <span>前の候補</span>
+                            </button>
+                            <button
+                                type="button"
+                                disabled={!canGoNext}
+                                onClick={() => focusCandidate(selectedIndex + 1)}
+                                className={SMALL_BUTTON_CLASS}
+                            >
+                                <ArrowDown className="h-3.5 w-3.5" aria-hidden="true" />
+                                <span>次の候補</span>
+                            </button>
+                        </div>
+                        {canEdit && bodyState === 'view' && onEditBody && (
+                            <button
+                                type="button"
+                                onClick={onEditBody}
+                                className={SMALL_BUTTON_CLASS}
+                            >
+                                <FileText className="h-3.5 w-3.5" aria-hidden="true" />
+                                <span>本文を編集</span>
+                            </button>
+                        )}
+                    </div>
+                </div>
+            )}
+        </section>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 候補カード
+// ---------------------------------------------------------------------------
+
+interface ReviewCandidateCardProps {
+    entry: OrderedReviewCandidate;
+    position: number;
+    total: number;
+    documentId: string;
+    selected: boolean;
+    anchorState: TranscriptReviewAnchorState;
+    anchorsEnabled: boolean;
+    audioStatus: TranscriptAudioStatus;
+    threshold: number | undefined;
+    registerRef: (phraseId: string, element: HTMLLIElement | null) => void;
+}
+
+function ReviewCandidateCard({
+    entry,
+    position,
+    total,
+    documentId,
+    selected,
+    anchorState,
+    anchorsEnabled,
+    audioStatus,
+    threshold,
+    registerRef,
+}: ReviewCandidateCardProps): React.ReactElement {
+    const { candidate, startSec } = entry;
+    const headingId = useId();
+    const reasonLabel = describeReviewReasons(candidate.reasons);
+    const timeLabel = formatReviewTimeRange(startSec, candidate.endSec);
+    const speaker = typeof candidate.speaker === 'string' && candidate.speaker !== '' ? candidate.speaker : null;
+    const excerpt = typeof candidate.excerpt === 'string' ? candidate.excerpt : '';
+    const truncated = candidate.excerptTruncated === true;
+    const confidence = formatConfidence(candidate.confidence);
+    const recognitionStatus = typeof candidate.recognitionStatus === 'string' && candidate.recognitionStatus !== ''
+        ? candidate.recognitionStatus
+        : null;
+    const thresholdLabel = typeof threshold === 'number' && Number.isFinite(threshold) ? threshold.toFixed(2) : null;
+
+    const canPlay = startSec !== null && audioStatus === 'ready';
+    const playTitle = startSec === null
+        ? '時刻情報がないため再生できません'
+        : audioStatus === 'loading'
+            ? '音声を読み込んでいます'
+            : audioStatus !== 'ready'
+                ? '音声を再生できません'
+                : undefined;
+
+    const line = candidate.paragraphStartLine;
+    const hasAnchor = typeof line === 'number' && Number.isInteger(line) && line >= 1;
+    const canMove = hasAnchor && anchorsEnabled;
+    const moveTitle = !hasAnchor
+        ? 'この候補の本文位置は生成時に確定していません'
+        : anchorState === 'editing'
+            ? '編集中は本文へ移動できません（表示に戻ると再確認します）'
+            : anchorState === 'mismatch'
+                ? '本文が編集されているため移動できません'
+                : anchorState === 'pending'
+                    ? '本文を照合しています'
+                    : anchorState === 'none'
+                        ? '本文の照合情報がありません'
+                        : undefined;
+
+    return (
+        <li
+            ref={element => registerRef(candidate.phraseId, element)}
+            tabIndex={-1}
+            aria-labelledby={headingId}
+            aria-current={selected ? 'true' : undefined}
+            data-review-card={candidate.phraseId}
+            data-review-selected={selected ? 'true' : undefined}
+            onFocus={() => transcriptReviewSelection.select(documentId, candidate.phraseId)}
+            className={`rounded-lg border p-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 ${
+                selected ? 'border-purple-300 bg-purple-50/40' : 'border-gray-200 bg-white'
+            }`}
+        >
+            <h4 id={headingId} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm font-semibold text-gray-800">
+                <span>候補 {position} / {total}</span>
+                <span className="font-mono text-xs font-normal tabular-nums text-gray-600">{timeLabel}</span>
+                {speaker && <span className="text-xs font-normal text-gray-600">話者 {speaker}</span>}
+                <span className="rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-900">
+                    {reasonLabel}
+                </span>
+                {selected && <span className="text-xs font-normal text-purple-700">選択中</span>}
+            </h4>
+            <blockquote
+                data-review-excerpt
+                className="mt-2 rounded-md border-l-4 border-amber-300 bg-amber-50 px-3 py-2 text-sm leading-relaxed text-gray-900"
+            >
+                {excerpt !== ''
+                    ? <span>「{excerpt}{truncated ? '…' : ''}」</span>
+                    : <span className="text-gray-600">認識テキストなし</span>}
+                {truncated && (
+                    <span className="mt-1 block text-xs text-gray-600">
+                        抜粋は上限で省略しています（認識結果が途切れているとは限りません）。
+                    </span>
+                )}
+            </blockquote>
+            {(confidence !== null || recognitionStatus !== null) && (
+                <details className="mt-2 text-xs text-gray-600">
+                    <summary className="cursor-pointer select-none">詳細</summary>
+                    <dl className="mt-1 space-y-0.5">
+                        {confidence !== null && (
+                            <div>
+                                <dt className="inline font-medium">認識信頼度</dt>
+                                {' '}
+                                <dd className="inline">
+                                    {confidence}（判定の参考値{thresholdLabel ? `・判定に用いた閾値 ${thresholdLabel}` : ''}）
+                                </dd>
+                            </div>
+                        )}
+                        {recognitionStatus !== null && (
+                            <div>
+                                <dt className="inline font-medium">認識状態</dt>
+                                {' '}
+                                <dd className="inline">{recognitionStatus}</dd>
+                            </div>
+                        )}
+                    </dl>
+                </details>
+            )}
+            <div className="mt-2 flex flex-wrap gap-2">
+                <button
+                    type="button"
+                    disabled={!canPlay}
+                    title={playTitle}
+                    aria-label={startSec === null ? '音声を再生（時刻情報なし）' : `${speakTimestamp(startSec)}から音声を再生`}
+                    onClick={() => {
+                        if (startSec === null) return;
+                        transcriptReviewSelection.select(documentId, candidate.phraseId);
+                        transcriptPlayback.seek(startSec);
+                    }}
+                    className={SMALL_BUTTON_CLASS}
+                >
+                    <Play className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span>{startSec === null ? '時刻情報なし' : `${formatTimestamp(startSec)}から音声を再生`}</span>
+                </button>
+                <button
+                    type="button"
+                    disabled={!canMove}
+                    title={moveTitle}
+                    onClick={() => {
+                        if (!canMove || !hasAnchor) return;
+                        transcriptReviewSelection.moveToParagraph(documentId, line, candidate.phraseId);
+                    }}
+                    className={SMALL_BUTTON_CLASS}
+                >
+                    <Locate className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span>本文の該当段落へ移動</span>
+                </button>
+            </div>
+        </li>
+    );
+}
+
+export default TranscriptReviewPanel;

--- a/src/components/transcriptMarkdownComponents.test.tsx
+++ b/src/components/transcriptMarkdownComponents.test.tsx
@@ -4,8 +4,10 @@
  * 本文段落（transcriptMarkdownComponents）× 再生追従 × 候補ジャンプの錠（仕様 B3「候補移動と追従を区別」）。
  *
  * 🔴 候補ジャンプは追従を「一時停止」するだけで、利用者の永続設定 follow を書き換えない。
- *    書き換える実装（setFollow(false)）には 2 つの回帰があった:
- *    (a) 文書 A でジャンプ → 文書 B へ切替後も追従が戻らない（attach の終了処理は follow を持ち越す）。
+ *    一時停止は文書 ID に紐づく（followPauseDocId）。過去の回帰:
+ *    (a) 文書 A でジャンプ → 文書 B へ切替後も追従が戻らない（setFollow(false) 版は follow を持ち越す）。
+ *    (a2) 音声の無い文書 A ではプレイヤーが載らず attach の終了処理が走らない。boolean 版は A の一時停止が
+ *         解けないまま B に持ち越された（docId 照合で解決）。
  *    (b) ジャンプ effect が段落の再マウントで再発火し、利用者が追従を再開しても再び切られる。
  * fixture は全て合成（架空の会話・架空の ID）。実データ・鍵は使わない。
  */
@@ -134,6 +136,8 @@ function view({ documentId, markdown, anchors, bodyKey, playerKey, audioUrl }: V
                 remarkPlugins={[remarkGfm]}
                 components={createTranscriptMarkdownComponents({
                     markdown,
+                    // 🔴 追従の一時停止を「この文書」に限定するため、本文にも文書 ID を渡す（本番の TranscriptDocumentView と同じ）
+                    documentId,
                     reviewAnchors: { documentId, anchorsByLine: anchors },
                 })}
             >
@@ -141,6 +145,26 @@ function view({ documentId, markdown, anchors, bodyKey, playerKey, audioUrl }: V
             </ReactMarkdown>
             <TranscriptPlayer key={playerKey} audioUrl={audioUrl} durationSec={3600} />
         </div>
+    );
+}
+
+/**
+ * 本文（段落バッジ付き）だけ。プレイヤーを載せない＝音声の無い文書の再現。
+ * この文書では `transcriptPlayback.attach` が一度も起きない＝attach の終了処理も走らない。
+ */
+function viewBodyOnly({ documentId, markdown, anchors, bodyKey }: ViewOptions): React.ReactElement {
+    return (
+        <ReactMarkdown
+            key={bodyKey}
+            remarkPlugins={[remarkGfm]}
+            components={createTranscriptMarkdownComponents({
+                markdown,
+                documentId,
+                reviewAnchors: { documentId, anchorsByLine: anchors },
+            })}
+        >
+            {markdown}
+        </ReactMarkdown>
     );
 }
 
@@ -183,7 +207,7 @@ async function jump(documentId: string, line: number, phraseId: string): Promise
 describe('再生追従の通常動作', () => {
     it('follow ON では再生中の段落へ寄せ、follow OFF では強調だけ続けてスクロールしない', async () => {
         await render(view(VIEW_A));
-        expect(playback()).toMatchObject({ ready: true, follow: true, followPausedByJump: false });
+        expect(playback()).toMatchObject({ ready: true, follow: true, followPauseDocId: null });
 
         scrollIntoView.mockClear();
         await tick(30);
@@ -191,7 +215,7 @@ describe('再生追従の通常動作', () => {
         expect(scrolledElements()).toContain(paragraph(3));
 
         await click(followButton());
-        expect(playback()).toMatchObject({ follow: false, followPausedByJump: false });
+        expect(playback()).toMatchObject({ follow: false, followPauseDocId: null });
         scrollIntoView.mockClear();
         await tick(120);
         expect(activeLine()).toBe('7');
@@ -219,7 +243,7 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         expect(scrolledElements()).toEqual([target]);
 
         // 🔴 follow は書き換えない（追従トグルは押されたまま）。一時停止だけが立ち、要求は処理済みになる
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: true });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: DOC_A });
         expect(followButton()?.getAttribute('aria-pressed')).toBe('true');
         const selection = transcriptReviewSelection.getSnapshot();
         expect(selection.paragraphRequest).not.toBeNull();
@@ -240,11 +264,11 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         await render(view(VIEW_A));
         await tick(30);
         await jump(DOC_A, 1, 'p-1');
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: true });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: DOC_A });
 
         // 1 回目: 追従 OFF（永続設定）。一時停止も解ける
         await click(followButton());
-        expect(playback()).toMatchObject({ follow: false, followPausedByJump: false });
+        expect(playback()).toMatchObject({ follow: false, followPauseDocId: null });
         scrollIntoView.mockClear();
         await tick(120);
         expect(activeLine()).toBe('7');
@@ -253,7 +277,7 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         // 2 回目: 追従 ON → 再生中の段落へ寄せる
         scrollIntoView.mockClear();
         await click(followButton());
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: null });
         expect(scrolledElements()).toContain(paragraph(7));
     });
 
@@ -261,11 +285,11 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         await render(view(VIEW_A));
         await tick(30);
         await jump(DOC_A, 1, 'p-1');
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: true });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: DOC_A });
 
         scrollIntoView.mockClear();
         await click(container.querySelector('a[data-timestamp-sec="120"]'));
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false, currentSec: 120 });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: null, currentSec: 120 });
         expect(activeLine()).toBe('7');
         expect(scrolledElements()).toContain(paragraph(7));
     });
@@ -277,7 +301,7 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         // 追従を再開（OFF → ON）
         await click(followButton());
         await click(followButton());
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: null });
 
         scrollIntoView.mockClear();
         await jump(DOC_A, 7, 'p-7');
@@ -285,7 +309,7 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         expect(scrolledElements()).toContain(paragraph(7));
         expect(paragraph(7)?.getAttribute('data-review-target')).toBe('true');
         expect(paragraph(1)?.getAttribute('data-review-target')).toBeNull();
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: true });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: DOC_A });
         const selection = transcriptReviewSelection.getSnapshot();
         expect(selection.consumedNonce).toBe(selection.paragraphRequest?.nonce);
     });
@@ -312,7 +336,7 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         });
         expect(container.querySelector('p[data-review-line="5"]')?.textContent).toContain('三つ目の段落');
         // 🔴 一時停止は文書切替で解け、永続の follow は保持される
-        expect(playback()).toMatchObject({ ready: true, follow: true, followPausedByJump: false, currentSec: 0 });
+        expect(playback()).toMatchObject({ ready: true, follow: true, followPauseDocId: null, currentSec: 0 });
         expect(container.querySelector('[data-review-target]')).toBeNull();
         expect(scrollIntoView).not.toHaveBeenCalled();
 
@@ -320,6 +344,65 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         await tick(30);
         expect(activeLine()).toBe('3');
         expect(container.querySelector('[data-transcript-active="true"]')?.textContent).toContain('二つ目の段落');
+        expect(scrolledElements()).toContain(paragraph(3));
+    });
+
+    // 回帰(a2): 音声の無い文書 A ではプレイヤーが載らない＝attach が起きず終了処理も走らない。
+    // 一時停止を boolean で持つと A の一時停止が解けないまま B に持ち越され、B で追従が戻らなかった。
+    // docId に紐づける（followPauseDocId）ことで、attach の有無に依存せず文書切替で追従が復帰する。
+    it('🔴 回帰(a2): 音声の無い文書 A でジャンプ → 音声付き文書 B へ切替 → B の通常再生で追従が効く', async () => {
+        // 文書 A: プレイヤーを載せない（音声が取得できない文書）。attach は一度も起きない
+        await render(viewBodyOnly(VIEW_A));
+        expect(playback()).toMatchObject({ ready: false, follow: true, followPauseDocId: null });
+
+        // A の段落へジャンプ: プレイヤーが無くても一時停止は docId=A で立つ
+        await jump(DOC_A, 1, 'p-1');
+        expect(document.activeElement).toBe(paragraph(1));
+        expect(playback()).toMatchObject({ ready: false, follow: true, followPauseDocId: DOC_A });
+
+        // 文書 B（音声あり）へ切替。A にはプレイヤーが無かったので終了処理は走っておらず、
+        // B の attach は ready を立てるだけで一時停止は解かない → followPauseDocId は A のまま残る。
+        await act(async () => {
+            transcriptReviewSelection.clear(DOC_A);
+            root.render(<>{view(VIEW_B)}</>);
+        });
+        expect(container.querySelector('p[data-review-line="5"]')?.textContent).toContain('三つ目の段落');
+        // 🔴 一時停止フラグ自体は A のまま持ち越されている（＝終了処理では解けていない）。
+        //    それでも B は自分の docId と照合するので一時停止扱いにならない。
+        expect(playback()).toMatchObject({ ready: true, follow: true, followPauseDocId: DOC_A });
+
+        // B の通常再生: 追従が効く（旧 boolean モデルではここで引き戻されず追従が死んでいた）
+        await tick(30);
+        expect(activeLine()).toBe('3');
+        expect(container.querySelector('[data-transcript-active="true"]')?.textContent).toContain('二つ目の段落');
+        expect(scrolledElements()).toContain(paragraph(3));
+    });
+
+    // 回帰(a3): 追従の可否は「effect が走る時点の live なストア」で判定する。StrictMode は mount で effect を
+    // 二重起動する（create → destroy → create）。「描画時の値を ref で 1 回飛ばす」実装は二度目の起動で
+    // 誤って寄せてしまうが、live 判定なら二度とも「切替直後は未接続（ready=false）」を見て寄せない。
+    it('🔴 回帰(a3): StrictMode（effect 二重起動）でも文書切替で誤って寄せない', async () => {
+        const renderStrict = async (element: React.ReactElement): Promise<void> => {
+            await act(async () => {
+                root.render(<React.StrictMode>{element}</React.StrictMode>);
+            });
+        };
+        await renderStrict(view(VIEW_A));
+        await tick(30);
+        await jump(DOC_A, 1, 'p-1');
+        await tick(120); // 再生位置を 120 に。B の 5 行目（開始 120）が stale に active 判定されうる位置
+
+        scrollIntoView.mockClear();
+        await act(async () => {
+            transcriptReviewSelection.clear(DOC_A);
+            root.render(<React.StrictMode>{view(VIEW_B)}</React.StrictMode>);
+        });
+        // 🔴 切替の瞬間に前文書の再生位置で誤追従しない（二重起動でも）
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        // 切替後の B の通常再生では追従する
+        await tick(30);
+        expect(activeLine()).toBe('3');
         expect(scrolledElements()).toContain(paragraph(3));
     });
 
@@ -342,7 +425,7 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         await act(async () => {
             transcriptPlayback.setFollow(true);
         });
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: null });
         expect(scrolledElements()).toContain(paragraph(7));
 
         // 親の再描画で本文（段落）が再マウントされる。移動要求（同じ nonce）はストアに残ったまま
@@ -351,7 +434,7 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         expect(transcriptReviewSelection.getSnapshot().paragraphRequest?.nonce).toBe(nonce);
 
         // 🔴 同じ要求を再処理しない: 追従は再び止められず（follow も一時停止も動かない）、ジャンプ先へのフォーカス・寄せも起こさない
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: null });
         expect(document.activeElement).not.toBe(paragraph(1));
         expect(scrolledElements()).not.toContain(paragraph(1));
         expect(transcriptReviewSelection.getSnapshot().consumedNonce).toBe(nonce);
@@ -363,6 +446,6 @@ describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
         await tick(30);
         expect(activeLine()).toBe('3');
         expect(scrolledElements()).toContain(paragraph(3));
-        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(playback()).toMatchObject({ follow: true, followPauseDocId: null });
     });
 });

--- a/src/components/transcriptMarkdownComponents.test.tsx
+++ b/src/components/transcriptMarkdownComponents.test.tsx
@@ -1,0 +1,368 @@
+// @vitest-environment jsdom
+
+/**
+ * 本文段落（transcriptMarkdownComponents）× 再生追従 × 候補ジャンプの錠（仕様 B3「候補移動と追従を区別」）。
+ *
+ * 🔴 候補ジャンプは追従を「一時停止」するだけで、利用者の永続設定 follow を書き換えない。
+ *    書き換える実装（setFollow(false)）には 2 つの回帰があった:
+ *    (a) 文書 A でジャンプ → 文書 B へ切替後も追従が戻らない（attach の終了処理は follow を持ち越す）。
+ *    (b) ジャンプ effect が段落の再マウントで再発火し、利用者が追従を再開しても再び切られる。
+ * fixture は全て合成（架空の会話・架空の ID）。実データ・鍵は使わない。
+ */
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TranscriptPlayer, transcriptPlayback } from './TranscriptPlayer';
+import { transcriptReviewSelection } from './transcriptReviewSelection';
+import { createTranscriptMarkdownComponents } from './transcriptMarkdownComponents';
+
+// ---------------------------------------------------------------------------
+// 合成 fixture
+// ---------------------------------------------------------------------------
+
+/** 文書 A（1 行目・3 行目・5 行目=欠落注記・7 行目が段落） */
+const TRANSCRIPT_A = [
+    '[00:12](#t=12) **お客様** いえ、こちらこそ。',
+    '',
+    '[00:30](#t=30) **営業** 本日はお時間ありがとうございます。',
+    '',
+    '　　　⚠ 01:20:00 〜 01:45:00 は文字起こしできませんでした。［再試行］',
+    '',
+    '[02:00](#t=120) **営業** それでランディの画面なんですけれども。',
+].join('\n');
+const DOC_A = 'doc-synthetic-a';
+const ANCHORS_A: ReadonlyMap<number, readonly string[]> = new Map([
+    [1, ['p-1']],
+    [3, ['p-3']],
+    [7, ['p-7']],
+]);
+
+/** 文書 B（別の会話・1 行目・3 行目・5 行目が段落） */
+const TRANSCRIPT_B = [
+    '[00:12](#t=12) **司会** 別の文書の冒頭です。',
+    '',
+    '[00:30](#t=30) **参加者** 二つ目の段落です。',
+    '',
+    '[02:00](#t=120) **司会** 三つ目の段落です。',
+].join('\n');
+const DOC_B = 'doc-synthetic-b';
+const ANCHORS_B: ReadonlyMap<number, readonly string[]> = new Map([
+    [1, ['q-1']],
+    [3, ['q-3']],
+    [5, ['q-5']],
+]);
+
+// ---------------------------------------------------------------------------
+// 描画の道具
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+let root: Root;
+let scrollIntoView: ReturnType<typeof vi.fn>;
+
+const originalScrollIntoView = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView');
+const originalPlay = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'play');
+const originalPause = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'pause');
+
+beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(HTMLMediaElement.prototype, 'play', { configurable: true, value: vi.fn(async () => undefined) });
+    Object.defineProperty(HTMLMediaElement.prototype, 'pause', { configurable: true, value: vi.fn(() => undefined) });
+});
+
+afterAll(() => {
+    if (originalScrollIntoView) Object.defineProperty(Element.prototype, 'scrollIntoView', originalScrollIntoView);
+    else delete (Element.prototype as Partial<Element>).scrollIntoView;
+    if (originalPlay) Object.defineProperty(HTMLMediaElement.prototype, 'play', originalPlay);
+    else delete (HTMLMediaElement.prototype as Partial<HTMLMediaElement>).play;
+    if (originalPause) Object.defineProperty(HTMLMediaElement.prototype, 'pause', originalPause);
+    else delete (HTMLMediaElement.prototype as Partial<HTMLMediaElement>).pause;
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+});
+
+beforeEach(() => {
+    transcriptPlayback.reset();
+    transcriptReviewSelection.reset();
+    scrollIntoView = vi.fn();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', { configurable: true, writable: true, value: scrollIntoView });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(async () => {
+    await act(async () => {
+        root.unmount();
+    });
+    container.remove();
+    transcriptPlayback.reset();
+    transcriptReviewSelection.reset();
+});
+
+async function render(element: React.ReactNode): Promise<void> {
+    await act(async () => {
+        root.render(<>{element}</>);
+    });
+}
+
+async function click(element: Element | null | undefined): Promise<void> {
+    if (!element) throw new Error('要素が見つかりません');
+    await act(async () => {
+        element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+}
+
+interface ViewOptions {
+    documentId: string;
+    markdown: string;
+    anchors: ReadonlyMap<number, readonly string[]>;
+    /** 本文の key。変えると本文（段落）だけが再マウントされる（親の再描画の再現） */
+    bodyKey: string;
+    /** プレイヤーの key。変えるとプレイヤーが再マウント（attach の終了 → 再 attach）される（文書切替の再現） */
+    playerKey: string;
+    audioUrl: string;
+}
+
+/** 本文（段落バッジ付き）＋プレイヤー。パネルは置かず、移動要求はストアへ直接出す */
+function view({ documentId, markdown, anchors, bodyKey, playerKey, audioUrl }: ViewOptions): React.ReactElement {
+    return (
+        <div>
+            <ReactMarkdown
+                key={bodyKey}
+                remarkPlugins={[remarkGfm]}
+                components={createTranscriptMarkdownComponents({
+                    markdown,
+                    reviewAnchors: { documentId, anchorsByLine: anchors },
+                })}
+            >
+                {markdown}
+            </ReactMarkdown>
+            <TranscriptPlayer key={playerKey} audioUrl={audioUrl} durationSec={3600} />
+        </div>
+    );
+}
+
+const VIEW_A: ViewOptions = {
+    documentId: DOC_A, markdown: TRANSCRIPT_A, anchors: ANCHORS_A,
+    bodyKey: 'body-a', playerKey: 'player-a', audioUrl: 'https://example.test/a.m4a',
+};
+const VIEW_B: ViewOptions = {
+    documentId: DOC_B, markdown: TRANSCRIPT_B, anchors: ANCHORS_B,
+    bodyKey: 'body-b', playerKey: 'player-b', audioUrl: 'https://example.test/b.m4a',
+};
+
+const paragraph = (line: number): HTMLElement | null =>
+    container.querySelector<HTMLElement>(`p[data-review-line="${line}"]`);
+const activeLine = (): string | null =>
+    container.querySelector('[data-transcript-active="true"]')?.getAttribute('data-review-line') ?? null;
+const followButton = (): HTMLButtonElement | null => container.querySelector<HTMLButtonElement>('button[aria-pressed]');
+const playback = () => transcriptPlayback.getSnapshot();
+/** scrollIntoView が「どの要素に対して」呼ばれたか（呼び出しの this） */
+const scrolledElements = (): unknown[] => scrollIntoView.mock.contexts;
+
+/** 再生位置の更新（音声要素の timeupdate 相当） */
+async function tick(sec: number): Promise<void> {
+    await act(async () => {
+        transcriptPlayback.patch({ currentSec: sec });
+    });
+}
+
+/** 候補カードの「本文の該当段落へ移動」相当 */
+async function jump(documentId: string, line: number, phraseId: string): Promise<void> {
+    await act(async () => {
+        transcriptReviewSelection.moveToParagraph(documentId, line, phraseId);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// 追従の通常動作
+// ---------------------------------------------------------------------------
+
+describe('再生追従の通常動作', () => {
+    it('follow ON では再生中の段落へ寄せ、follow OFF では強調だけ続けてスクロールしない', async () => {
+        await render(view(VIEW_A));
+        expect(playback()).toMatchObject({ ready: true, follow: true, followPausedByJump: false });
+
+        scrollIntoView.mockClear();
+        await tick(30);
+        expect(activeLine()).toBe('3');
+        expect(scrolledElements()).toContain(paragraph(3));
+
+        await click(followButton());
+        expect(playback()).toMatchObject({ follow: false, followPausedByJump: false });
+        scrollIntoView.mockClear();
+        await tick(120);
+        expect(activeLine()).toBe('7');
+        expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 候補ジャンプと追従の区別（仕様 B3）
+// ---------------------------------------------------------------------------
+
+describe('候補ジャンプと再生追従の区別（仕様 B3）', () => {
+    it('🔴 ジャンプは追従を一時停止する: 次の時刻更新で引き戻されず、永続の follow は書き換えない', async () => {
+        await render(view(VIEW_A));
+        await tick(30);
+        expect(activeLine()).toBe('3');
+
+        scrollIntoView.mockClear();
+        await jump(DOC_A, 1, 'p-1');
+        const target = paragraph(1)!;
+        expect(target.getAttribute('data-review-target')).toBe('true');
+        expect(document.activeElement).toBe(target);
+        // ジャンプ先への 1 回だけ（再生中の 3 行目へは寄せ直さない）
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+        expect(scrolledElements()).toEqual([target]);
+
+        // 🔴 follow は書き換えない（追従トグルは押されたまま）。一時停止だけが立ち、要求は処理済みになる
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: true });
+        expect(followButton()?.getAttribute('aria-pressed')).toBe('true');
+        const selection = transcriptReviewSelection.getSnapshot();
+        expect(selection.paragraphRequest).not.toBeNull();
+        expect(selection.consumedNonce).toBe(selection.paragraphRequest?.nonce);
+
+        // 次の時刻更新（120 秒 → 7 行目が再生中）でも、ジャンプ先から引き戻されない
+        scrollIntoView.mockClear();
+        await tick(120);
+        expect(activeLine()).toBe('7');
+        expect(scrollIntoView).not.toHaveBeenCalled();
+        // 再生中の強調とジャンプ先の強調は別の段落に別の色で付く
+        expect(paragraph(7)?.className).toContain('bg-purple-50/70');
+        expect(target.className).toContain('ring-amber-400');
+        expect(target.getAttribute('data-transcript-active')).toBeNull();
+    });
+
+    it('追従トグルで一時停止が解ける（OFF は永続設定として止まり、ON で再生中の段落へ戻る）', async () => {
+        await render(view(VIEW_A));
+        await tick(30);
+        await jump(DOC_A, 1, 'p-1');
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: true });
+
+        // 1 回目: 追従 OFF（永続設定）。一時停止も解ける
+        await click(followButton());
+        expect(playback()).toMatchObject({ follow: false, followPausedByJump: false });
+        scrollIntoView.mockClear();
+        await tick(120);
+        expect(activeLine()).toBe('7');
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        // 2 回目: 追従 ON → 再生中の段落へ寄せる
+        scrollIntoView.mockClear();
+        await click(followButton());
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(scrolledElements()).toContain(paragraph(7));
+    });
+
+    it('シーク（時刻リンク＝利用者が再生位置を動かした）で一時停止が解け、追従に戻る', async () => {
+        await render(view(VIEW_A));
+        await tick(30);
+        await jump(DOC_A, 1, 'p-1');
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: true });
+
+        scrollIntoView.mockClear();
+        await click(container.querySelector('a[data-timestamp-sec="120"]'));
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false, currentSec: 120 });
+        expect(activeLine()).toBe('7');
+        expect(scrolledElements()).toContain(paragraph(7));
+    });
+
+    it('別の候補への新しいジャンプ（採番が進む）は処理され、追従を再び一時停止する', async () => {
+        await render(view(VIEW_A));
+        await tick(30);
+        await jump(DOC_A, 1, 'p-1');
+        // 追従を再開（OFF → ON）
+        await click(followButton());
+        await click(followButton());
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+
+        scrollIntoView.mockClear();
+        await jump(DOC_A, 7, 'p-7');
+        expect(document.activeElement).toBe(paragraph(7));
+        expect(scrolledElements()).toContain(paragraph(7));
+        expect(paragraph(7)?.getAttribute('data-review-target')).toBe('true');
+        expect(paragraph(1)?.getAttribute('data-review-target')).toBeNull();
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: true });
+        const selection = transcriptReviewSelection.getSnapshot();
+        expect(selection.consumedNonce).toBe(selection.paragraphRequest?.nonce);
+    });
+
+    // 回帰(a): setFollow(false) 版では follow=false が attach の終了処理で持ち越され、文書 B でも追従が戻らなかった
+    it('🔴 回帰(a): 文書 A でジャンプ → 文書 B へ切替（プレイヤー再 attach）→ B の通常再生で追従が効く', async () => {
+        await render(view(VIEW_A));
+        await tick(30);
+        expect(activeLine()).toBe('3');
+        await jump(DOC_A, 1, 'p-1');
+        expect(document.activeElement).toBe(paragraph(1));
+        // ジャンプ中は追従が止まっている（A の時刻更新では寄せない）
+        scrollIntoView.mockClear();
+        await tick(120);
+        expect(activeLine()).toBe('7');
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        // 文書 B へ切替: パネルは破棄時に A の選択・要求を捨て（TranscriptReviewPanel の cleanup と同じ）、
+        // 本文とプレイヤーは key が変わって再マウント（プレイヤーの attach 終了 → 再 attach）
+        scrollIntoView.mockClear();
+        await act(async () => {
+            transcriptReviewSelection.clear(DOC_A);
+            root.render(<>{view(VIEW_B)}</>);
+        });
+        expect(container.querySelector('p[data-review-line="5"]')?.textContent).toContain('三つ目の段落');
+        // 🔴 一時停止は文書切替で解け、永続の follow は保持される
+        expect(playback()).toMatchObject({ ready: true, follow: true, followPausedByJump: false, currentSec: 0 });
+        expect(container.querySelector('[data-review-target]')).toBeNull();
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        // B の通常再生: 追従が効く
+        await tick(30);
+        expect(activeLine()).toBe('3');
+        expect(container.querySelector('[data-transcript-active="true"]')?.textContent).toContain('二つ目の段落');
+        expect(scrolledElements()).toContain(paragraph(3));
+    });
+
+    // 回帰(b): 依存 [targetNonce] だけのジャンプ effect は段落の再マウントで再発火し、setFollow(false) で追従を再び切っていた
+    it('🔴 回帰(b): ジャンプ → 追従を再開 → 段落の再マウントで同じ要求が残っていても、追従を再び止めず再処理しない', async () => {
+        await render(view(VIEW_A));
+        await tick(30);
+        await jump(DOC_A, 1, 'p-1');
+        expect(document.activeElement).toBe(paragraph(1));
+        const nonce = transcriptReviewSelection.getSnapshot().paragraphRequest?.nonce ?? null;
+        expect(nonce).not.toBeNull();
+        // ジャンプ中は追従が止まっている
+        scrollIntoView.mockClear();
+        await tick(120);
+        expect(activeLine()).toBe('7');
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        // 利用者が追従を ON にする（追従トグル相当）→ 再生中の 7 行目へ寄せる
+        scrollIntoView.mockClear();
+        await act(async () => {
+            transcriptPlayback.setFollow(true);
+        });
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(scrolledElements()).toContain(paragraph(7));
+
+        // 親の再描画で本文（段落）が再マウントされる。移動要求（同じ nonce）はストアに残ったまま
+        scrollIntoView.mockClear();
+        await render(view({ ...VIEW_A, bodyKey: 'body-a-remounted' }));
+        expect(transcriptReviewSelection.getSnapshot().paragraphRequest?.nonce).toBe(nonce);
+
+        // 🔴 同じ要求を再処理しない: 追従は再び止められず（follow も一時停止も動かない）、ジャンプ先へのフォーカス・寄せも起こさない
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+        expect(document.activeElement).not.toBe(paragraph(1));
+        expect(scrolledElements()).not.toContain(paragraph(1));
+        expect(transcriptReviewSelection.getSnapshot().consumedNonce).toBe(nonce);
+        // 移動先の強調自体は残る（別の候補を選ぶ／文書を切り替えるまで）
+        expect(paragraph(1)?.getAttribute('data-review-target')).toBe('true');
+
+        // 追従は生きている: 次の時刻更新で再生中の段落へ寄せる
+        scrollIntoView.mockClear();
+        await tick(30);
+        expect(activeLine()).toBe('3');
+        expect(scrolledElements()).toContain(paragraph(3));
+        expect(playback()).toMatchObject({ follow: true, followPausedByJump: false });
+    });
+});

--- a/src/components/transcriptMarkdownComponents.tsx
+++ b/src/components/transcriptMarkdownComponents.tsx
@@ -219,6 +219,8 @@ function TranscriptLine({
         //    （currentSec）と ready が載っている。すると前文書の位置に対応する新文書の段落が一瞬 active と判定され、
         //    描画時の値で寄せると誤追従になる。前プレイヤーの離脱（＝ストア初期化）は、この create effect より前の
         //    destroy フェーズで走るので、flush 時に読み直せば正しく「まだ未接続（ready=false）」を見て寄せない。
+        //    ⚠ これは本文とプレイヤーが同じ document から同一コミットで再構成される前提に依る（現状 DocumentDetailPanel）。
+        //    本文とプレイヤーを別タイミングで供給する構成にすると、この保証は崩れる。
         //    依存配列は「再生位置が進む・follow / 一時停止が変わる」という描画由来の変化で再評価するための引き金。
         const snap = transcriptPlayback.getSnapshot();
         const followPausedNow = snap.followPauseDocId !== null && snap.followPauseDocId === currentDocumentId;

--- a/src/components/transcriptMarkdownComponents.tsx
+++ b/src/components/transcriptMarkdownComponents.tsx
@@ -174,6 +174,11 @@ function ReviewParagraphBadge({ anchor }: { anchor: TranscriptReviewParagraphAnc
  *
  * 要確認アンカーを持つ行は、候補カードからの移動要求（同じ文書・同じ開始行）を受けて
  * 1 回だけ寄せてフォーカスを受ける。🔴 これは再生中の追従とは別（追従の入切に関係なく動き、色も分ける）。
+ *
+ * 🔴 候補ジャンプと追従の区別（B3）:
+ * - ジャンプ中は追従を「一時停止」する（`followPausedByJump`）。利用者の永続設定 `follow` は書き換えない。
+ *   書き換えると、文書を切り替えても追従が戻らない／利用者が追従を再開しても再マウントで再び切られる。
+ * - 同じ移動要求は 1 回だけ処理する（`consumedNonce`）。段落が再マウントされても同じ nonce では再処理しない。
  */
 function TranscriptLine({
     startSec,
@@ -187,8 +192,9 @@ function TranscriptLine({
     reviewAnchor: TranscriptReviewParagraphAnchor | null;
     children?: React.ReactNode;
 } & React.HTMLAttributes<HTMLParagraphElement>): React.ReactElement {
-    const { currentSec, follow, ready } = useTranscriptPlayback();
+    const { currentSec, follow, followPausedByJump, ready } = useTranscriptPlayback();
     const selection = useTranscriptReviewSelection();
+    const consumedNonce = selection.consumedNonce;
     const ref = useRef<HTMLParagraphElement | null>(null);
     const active =
         ready && currentSec >= startSec && (nextSec === null || currentSec < nextSec);
@@ -202,28 +208,32 @@ function TranscriptLine({
     const isTarget = targetNonce !== null;
 
     useEffect(() => {
-        if (!active || !follow) return;
+        // 🔴 追従は利用者が止められる（follow）。候補ジャンプ中は一時停止（followPausedByJump）。どちらでもここへ来ない
+        if (!active || !follow || followPausedByJump) return;
         const element = ref.current;
-        // 🔴 追従は利用者が止められる。止めているときはここへ来ない
         if (element && typeof element.scrollIntoView === 'function') {
             element.scrollIntoView({ block: 'center', behavior: scrollBehaviorForMotion() });
         }
-    }, [active, follow]);
+    }, [active, follow, followPausedByJump]);
 
     useEffect(() => {
-        if (targetNonce === null) return;
-        // 🔴 候補ジャンプ中は再生追従を止める（次の時刻更新でジャンプ先から引き戻さない）。
-        //    B3「選択した候補の移動と再生中段落の追従は区別する」。利用者が「追従」を押し直すと再開する。
-        //    追従スクロールとジャンプは別動作なので、ジャンプ先のフォーカス・寄せはこの後そのまま行う。
-        transcriptPlayback.setFollow(false);
+        // 🔴 未処理の要求だけを処理する。処理済み（consumedNonce）の同じ nonce が再マウントで再び来ても何もしない
+        if (targetNonce === null || targetNonce === consumedNonce) return;
+        // 🔴 候補ジャンプ中は再生追従を「一時停止」する（次の時刻更新でジャンプ先から引き戻さない）。
+        //    B3「選択した候補の移動と再生中段落の追従は区別する」。永続設定 follow は書き換えない
+        //    （setFollow(false) だと文書切替後も追従が戻らず、再開しても再マウントで再び切られる）。
+        //    解除は追従トグル・シーク・文書切替（プレイヤーの再 attach）。
+        transcriptPlayback.pauseFollowForJump();
         const element = ref.current;
-        if (!element) return;
-        // 候補からの移動。フォーカスを渡してから寄せる（動きを減らす設定ではアニメーションなし）
-        if (typeof element.focus === 'function') element.focus({ preventScroll: true });
-        if (typeof element.scrollIntoView === 'function') {
-            element.scrollIntoView({ block: 'center', behavior: scrollBehaviorForMotion() });
+        if (element) {
+            // 候補からの移動。フォーカスを渡してから寄せる（動きを減らす設定ではアニメーションなし）
+            if (typeof element.focus === 'function') element.focus({ preventScroll: true });
+            if (typeof element.scrollIntoView === 'function') {
+                element.scrollIntoView({ block: 'center', behavior: scrollBehaviorForMotion() });
+            }
         }
-    }, [targetNonce]);
+        transcriptReviewSelection.consumeParagraphRequest(targetNonce);
+    }, [targetNonce, consumedNonce]);
 
     return (
         <p

--- a/src/components/transcriptMarkdownComponents.tsx
+++ b/src/components/transcriptMarkdownComponents.tsx
@@ -8,13 +8,27 @@
  *    それ以外の要素は一切上書きしない＝他の文書と同じ見た目・同じ操作のまま。
  *
  * 🔴 利用者は本文を自由に編集できる。壊れた行は「単に押せない」だけにし、例外は投げない。
+ *
+ * 仕様 B3（要確認箇所）で足したもの: 生成時に確定した段落アンカー（`paragraphStartLine`）と
+ * 描画ノードの元ソース行（`node.position.start.line`）が一致する段落に「要確認 N 箇所」のバッジを付け、
+ * 候補カードからの「本文の該当段落へ移動」を受ける。
+ * 🔴 アンカーは呼び出し側が「表示本文のハッシュが review.sourceTextHash と一致する」ときだけ渡す。
+ *    ここでは本文の文字列検索・最寄り時刻・同じ #t= の先頭一致でアンカーを推測しない（仕様 B2）。
  */
 
 import React, { useEffect, useRef, useState } from 'react';
 import type { Components } from 'react-markdown';
 import type { Element as HastElement } from 'hast';
 import { formatTimestamp, parseTimestampHref, parseTranscriptTimestamps } from '@/lib/transcriptMerge';
-import { transcriptPlayback, useTranscriptPlayback } from '@/components/TranscriptPlayer';
+import {
+    scrollBehaviorForMotion,
+    transcriptPlayback,
+    useTranscriptPlayback,
+} from '@/components/TranscriptPlayer';
+import {
+    transcriptReviewSelection,
+    useTranscriptReviewSelection,
+} from '@/components/transcriptReviewSelection';
 
 /**
  * 通常リンクの見た目。MarkdownDocument.tsx の `a` と同一にする。
@@ -110,49 +124,121 @@ const leadingTimestampSec = (node: HastElement | undefined): number | null => {
     return typeof href === 'string' ? parseTimestampHref(href) : null;
 };
 
+/** 描画ノードの元ソース上の開始行（1 始まり）。無ければ null（アンカーを付けない） */
+const sourceStartLine = (node: HastElement | undefined): number | null => {
+    const line = node?.position?.start?.line;
+    return typeof line === 'number' && Number.isInteger(line) && line >= 1 ? line : null;
+};
+
 // ---------------------------------------------------------------------------
 // 部品
 // ---------------------------------------------------------------------------
 
+/** 段落に付く要確認アンカー（呼び出し側がハッシュ一致を確認したときだけ渡される） */
+export interface TranscriptReviewParagraphAnchor {
+    documentId: string;
+    /** 段落の開始行（1 始まり）。候補カードからの移動要求はこの行で照合する */
+    line: number;
+    /** この段落に属する候補の phraseId（表示順） */
+    phraseIds: readonly string[];
+}
+
+/**
+ * 段落の「要確認 N 箇所」バッジ。押すと候補カード側がその候補を表示してフォーカスを受ける。
+ * 🔴 段落全体を誤り扱いする表現にしない。色だけでなく文言で区別する。
+ * 🔴 選択不可（select-none）・印刷非表示: 本文のコピー・PDF に操作 UI を混ぜない。
+ */
+function ReviewParagraphBadge({ anchor }: { anchor: TranscriptReviewParagraphAnchor }): React.ReactElement {
+    const count = anchor.phraseIds.length;
+    return (
+        <span
+            className="ml-2 inline-flex select-none align-baseline print:hidden"
+            data-review-badge={anchor.line}
+        >
+            <button
+                type="button"
+                onClick={() => transcriptReviewSelection.reveal(anchor.documentId, anchor.phraseIds[0])}
+                aria-label={`この段落の要確認候補 ${count} 箇所を、要確認箇所の一覧で表示`}
+                title="要確認箇所の一覧で該当の候補を表示"
+                className="rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium leading-none text-amber-900 hover:bg-amber-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+            >
+                要確認 {count} 箇所
+            </button>
+        </span>
+    );
+}
+
 /**
  * 再生中の行。淡くハイライトし、追従が入なら画面内へ寄せる。
  * 本文の色とサイズは他の文書と同じまま（背景だけを足す）。
+ *
+ * 要確認アンカーを持つ行は、候補カードからの移動要求（同じ文書・同じ開始行）を受けて
+ * 1 回だけ寄せてフォーカスを受ける。🔴 これは再生中の追従とは別（追従の入切に関係なく動き、色も分ける）。
  */
 function TranscriptLine({
     startSec,
     nextSec,
+    reviewAnchor,
     children,
     ...rest
 }: {
     startSec: number;
     nextSec: number | null;
+    reviewAnchor: TranscriptReviewParagraphAnchor | null;
     children?: React.ReactNode;
 } & React.HTMLAttributes<HTMLParagraphElement>): React.ReactElement {
     const { currentSec, follow, ready } = useTranscriptPlayback();
+    const selection = useTranscriptReviewSelection();
     const ref = useRef<HTMLParagraphElement | null>(null);
     const active =
         ready && currentSec >= startSec && (nextSec === null || currentSec < nextSec);
+    const targetNonce =
+        reviewAnchor !== null
+            && selection.documentId === reviewAnchor.documentId
+            && selection.paragraphRequest !== null
+            && selection.paragraphRequest.line === reviewAnchor.line
+            ? selection.paragraphRequest.nonce
+            : null;
+    const isTarget = targetNonce !== null;
 
     useEffect(() => {
         if (!active || !follow) return;
         const element = ref.current;
         // 🔴 追従は利用者が止められる。止めているときはここへ来ない
         if (element && typeof element.scrollIntoView === 'function') {
-            element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            element.scrollIntoView({ block: 'center', behavior: scrollBehaviorForMotion() });
         }
     }, [active, follow]);
+
+    useEffect(() => {
+        if (targetNonce === null) return;
+        const element = ref.current;
+        if (!element) return;
+        // 候補からの移動。フォーカスを渡してから寄せる（動きを減らす設定ではアニメーションなし）
+        if (typeof element.focus === 'function') element.focus({ preventScroll: true });
+        if (typeof element.scrollIntoView === 'function') {
+            element.scrollIntoView({ block: 'center', behavior: scrollBehaviorForMotion() });
+        }
+    }, [targetNonce]);
 
     return (
         <p
             ref={ref}
             data-transcript-active={active ? 'true' : undefined}
             aria-current={active ? 'location' : undefined}
-            className={`mb-4 leading-relaxed ${
-                active ? '-mx-2 rounded-md bg-purple-50/70 px-2' : ''
-            }`}
+            tabIndex={reviewAnchor ? -1 : undefined}
+            data-review-line={reviewAnchor ? reviewAnchor.line : undefined}
+            data-review-target={isTarget ? 'true' : undefined}
+            className={[
+                'mb-4 leading-relaxed',
+                active ? '-mx-2 rounded-md bg-purple-50/70 px-2' : '',
+                reviewAnchor ? 'rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500' : '',
+                isTarget ? 'ring-2 ring-amber-400 ring-offset-2' : '',
+            ].filter(Boolean).join(' ')}
             {...rest}
         >
             {children}
+            {reviewAnchor && <ReviewParagraphBadge anchor={reviewAnchor} />}
         </p>
     );
 }
@@ -284,6 +370,13 @@ function SpeakerLabel({
 // components 上書き本体
 // ---------------------------------------------------------------------------
 
+/** 要確認候補の段落アンカー。呼び出し側が本文ハッシュの一致を確認したときだけ渡す */
+export interface TranscriptReviewAnchorOptions {
+    documentId: string;
+    /** 段落開始行（1 始まり）→ その段落に属する候補の phraseId（表示順） */
+    anchorsByLine: ReadonlyMap<number, readonly string[]>;
+}
+
 export interface TranscriptMarkdownComponentsOptions {
     /** 表示している本文。話者ラベルの検出と「何箇所変わるか」の算出に使う */
     markdown: string;
@@ -291,12 +384,15 @@ export interface TranscriptMarkdownComponentsOptions {
     onRename?: (from: string, to: string) => void;
     /** 欠落区間の再試行 */
     onRetryGap?: (gap: TranscriptGap) => void;
+    /** 要確認候補の段落バッジ。渡さなければ本文の描画は従来どおり */
+    reviewAnchors?: TranscriptReviewAnchorOptions;
 }
 
 export const createTranscriptMarkdownComponents = ({
     markdown,
     onRename,
     onRetryGap,
+    reviewAnchors,
 }: TranscriptMarkdownComponentsOptions): Components => {
     const timestamps = parseTranscriptTimestamps(markdown)
         .map(entry => entry.sec)
@@ -308,6 +404,15 @@ export const createTranscriptMarkdownComponents = ({
             if (candidate > sec) return candidate;
         }
         return null;
+    };
+
+    const anchorFor = (node: HastElement | undefined): TranscriptReviewParagraphAnchor | null => {
+        if (!reviewAnchors) return null;
+        const line = sourceStartLine(node);
+        if (line === null) return null;
+        const phraseIds = reviewAnchors.anchorsByLine.get(line);
+        if (!phraseIds || phraseIds.length === 0) return null;
+        return { documentId: reviewAnchors.documentId, line, phraseIds };
     };
 
     return {
@@ -371,6 +476,7 @@ export const createTranscriptMarkdownComponents = ({
                 <TranscriptLine
                     startSec={startSec}
                     nextSec={nextTimestampAfter(startSec)}
+                    reviewAnchor={anchorFor(node)}
                     {...rest}
                 >
                     {children}

--- a/src/components/transcriptMarkdownComponents.tsx
+++ b/src/components/transcriptMarkdownComponents.tsx
@@ -176,7 +176,7 @@ function ReviewParagraphBadge({ anchor }: { anchor: TranscriptReviewParagraphAnc
  * 1 回だけ寄せてフォーカスを受ける。🔴 これは再生中の追従とは別（追従の入切に関係なく動き、色も分ける）。
  *
  * 🔴 候補ジャンプと追従の区別（B3）:
- * - ジャンプ中は追従を「一時停止」する（`followPausedByJump`）。利用者の永続設定 `follow` は書き換えない。
+ * - ジャンプ中は追従を「一時停止」する（`followPauseDocId`＝その文書に限定）。利用者の永続設定 `follow` は書き換えない。
  *   書き換えると、文書を切り替えても追従が戻らない／利用者が追従を再開しても再マウントで再び切られる。
  * - 同じ移動要求は 1 回だけ処理する（`consumedNonce`）。段落が再マウントされても同じ nonce では再処理しない。
  */
@@ -184,17 +184,23 @@ function TranscriptLine({
     startSec,
     nextSec,
     reviewAnchor,
+    currentDocumentId,
     children,
     ...rest
 }: {
     startSec: number;
     nextSec: number | null;
     reviewAnchor: TranscriptReviewParagraphAnchor | null;
+    /** この本文が属する文書 ID。候補ジャンプの一時停止をこの文書に限定するために使う */
+    currentDocumentId?: string;
     children?: React.ReactNode;
 } & React.HTMLAttributes<HTMLParagraphElement>): React.ReactElement {
-    const { currentSec, follow, followPausedByJump, ready } = useTranscriptPlayback();
+    const { currentSec, follow, followPauseDocId, ready } = useTranscriptPlayback();
     const selection = useTranscriptReviewSelection();
     const consumedNonce = selection.consumedNonce;
+    // 🔴 追従の一時停止は「その文書」に限定する。別文書を開けば docId が一致せず自動的に解ける
+    //    （音声の無い文書でジャンプ→音声付き文書へ切替でも復帰する。attach の終了処理に依存しない）。
+    const followPaused = followPauseDocId !== null && followPauseDocId === currentDocumentId;
     const ref = useRef<HTMLParagraphElement | null>(null);
     const active =
         ready && currentSec >= startSec && (nextSec === null || currentSec < nextSec);
@@ -208,13 +214,22 @@ function TranscriptLine({
     const isTarget = targetNonce !== null;
 
     useEffect(() => {
-        // 🔴 追従は利用者が止められる（follow）。候補ジャンプ中は一時停止（followPausedByJump）。どちらでもここへ来ない
-        if (!active || !follow || followPausedByJump) return;
+        // 🔴 追従の可否は「effect が走る時点（flush）の live なストア」で判定する（描画時に固定した値では判定しない）。
+        //    文書を切り替えた瞬間、React は新文書の段落を先に描画し、そのとき共有ストアにはまだ前文書の再生位置
+        //    （currentSec）と ready が載っている。すると前文書の位置に対応する新文書の段落が一瞬 active と判定され、
+        //    描画時の値で寄せると誤追従になる。前プレイヤーの離脱（＝ストア初期化）は、この create effect より前の
+        //    destroy フェーズで走るので、flush 時に読み直せば正しく「まだ未接続（ready=false）」を見て寄せない。
+        //    依存配列は「再生位置が進む・follow / 一時停止が変わる」という描画由来の変化で再評価するための引き金。
+        const snap = transcriptPlayback.getSnapshot();
+        const followPausedNow = snap.followPauseDocId !== null && snap.followPauseDocId === currentDocumentId;
+        const activeNow = snap.ready && snap.currentSec >= startSec && (nextSec === null || snap.currentSec < nextSec);
+        // 🔴 追従は利用者が止められる（follow）。候補ジャンプ中はこの文書だけ一時停止（followPausedNow）。どちらでもここへ来ない
+        if (!activeNow || !snap.follow || followPausedNow) return;
         const element = ref.current;
         if (element && typeof element.scrollIntoView === 'function') {
             element.scrollIntoView({ block: 'center', behavior: scrollBehaviorForMotion() });
         }
-    }, [active, follow, followPausedByJump]);
+    }, [active, follow, followPaused, startSec, nextSec, currentDocumentId]);
 
     useEffect(() => {
         // 🔴 未処理の要求だけを処理する。処理済み（consumedNonce）の同じ nonce が再マウントで再び来ても何もしない
@@ -222,8 +237,8 @@ function TranscriptLine({
         // 🔴 候補ジャンプ中は再生追従を「一時停止」する（次の時刻更新でジャンプ先から引き戻さない）。
         //    B3「選択した候補の移動と再生中段落の追従は区別する」。永続設定 follow は書き換えない
         //    （setFollow(false) だと文書切替後も追従が戻らず、再開しても再マウントで再び切られる）。
-        //    解除は追従トグル・シーク・文書切替（プレイヤーの再 attach）。
-        transcriptPlayback.pauseFollowForJump();
+        //    解除は追従トグル・シーク・文書切替（docId 照合で自動）。
+        if (reviewAnchor) transcriptPlayback.pauseFollowForJump(reviewAnchor.documentId);
         const element = ref.current;
         if (element) {
             // 候補からの移動。フォーカスを渡してから寄せる（動きを減らす設定ではアニメーションなし）
@@ -394,6 +409,11 @@ export interface TranscriptReviewAnchorOptions {
 export interface TranscriptMarkdownComponentsOptions {
     /** 表示している本文。話者ラベルの検出と「何箇所変わるか」の算出に使う */
     markdown: string;
+    /**
+     * この本文が属する文書 ID。候補ジャンプによる追従の一時停止をこの文書に限定するために使う
+     * （別文書を開けば docId が一致せず自動的に解ける）。文書 ID が無い文脈では未指定でよい。
+     */
+    documentId?: string;
     /** 話者改名。実際の保存は呼び出し側（このコンポーネントは呼ぶところまで） */
     onRename?: (from: string, to: string) => void;
     /** 欠落区間の再試行 */
@@ -404,6 +424,7 @@ export interface TranscriptMarkdownComponentsOptions {
 
 export const createTranscriptMarkdownComponents = ({
     markdown,
+    documentId,
     onRename,
     onRetryGap,
     reviewAnchors,
@@ -491,6 +512,7 @@ export const createTranscriptMarkdownComponents = ({
                     startSec={startSec}
                     nextSec={nextTimestampAfter(startSec)}
                     reviewAnchor={anchorFor(node)}
+                    {...(documentId !== undefined && { currentDocumentId: documentId })}
                     {...rest}
                 >
                     {children}

--- a/src/components/transcriptMarkdownComponents.tsx
+++ b/src/components/transcriptMarkdownComponents.tsx
@@ -212,6 +212,10 @@ function TranscriptLine({
 
     useEffect(() => {
         if (targetNonce === null) return;
+        // 🔴 候補ジャンプ中は再生追従を止める（次の時刻更新でジャンプ先から引き戻さない）。
+        //    B3「選択した候補の移動と再生中段落の追従は区別する」。利用者が「追従」を押し直すと再開する。
+        //    追従スクロールとジャンプは別動作なので、ジャンプ先のフォーカス・寄せはこの後そのまま行う。
+        transcriptPlayback.setFollow(false);
         const element = ref.current;
         if (!element) return;
         // 候補からの移動。フォーカスを渡してから寄せる（動きを減らす設定ではアニメーションなし）

--- a/src/components/transcriptReviewSelection.test.ts
+++ b/src/components/transcriptReviewSelection.test.ts
@@ -1,0 +1,114 @@
+/**
+ * 要確認候補の選択ストア（仕様 B3）の錠。
+ * 「同じ移動要求を 1 回だけ処理する」ための処理済み採番（consumedNonce）を中心に見る。
+ * fixture は全て合成（架空の文書 ID・架空の phraseId）。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { transcriptReviewSelection } from './transcriptReviewSelection';
+
+const DOC_A = 'doc-synthetic-a';
+const DOC_B = 'doc-synthetic-b';
+
+beforeEach(() => {
+    transcriptReviewSelection.reset();
+});
+
+afterEach(() => {
+    transcriptReviewSelection.reset();
+});
+
+describe('移動要求の処理済み採番（consumedNonce）', () => {
+    it('初期状態では未処理（null）', () => {
+        expect(transcriptReviewSelection.getSnapshot()).toEqual({
+            documentId: null, selectedPhraseId: null, revealRequest: null, paragraphRequest: null, consumedNonce: null,
+        });
+    });
+
+    it('moveToParagraph は未処理の新しい要求を出し、consumeParagraphRequest で処理済みになる', () => {
+        transcriptReviewSelection.moveToParagraph(DOC_A, 7, 'p-7');
+        const first = transcriptReviewSelection.getSnapshot();
+        expect(first.paragraphRequest).toEqual({ line: 7, nonce: 1 });
+        expect(first.consumedNonce).toBeNull();
+
+        transcriptReviewSelection.consumeParagraphRequest(1);
+        const consumed = transcriptReviewSelection.getSnapshot();
+        expect(consumed.consumedNonce).toBe(1);
+        // 🔴 要求そのものは残す（移動先の強調は別の候補を選ぶまで続く）
+        expect(consumed.paragraphRequest).toEqual({ line: 7, nonce: 1 });
+        expect(consumed.selectedPhraseId).toBe('p-7');
+    });
+
+    it('同じ nonce を二度 consume しても通知しない（購読側の無駄な再描画を起こさない）', () => {
+        transcriptReviewSelection.moveToParagraph(DOC_A, 7, 'p-7');
+        transcriptReviewSelection.consumeParagraphRequest(1);
+        const listener = vi.fn();
+        const unsubscribe = transcriptReviewSelection.subscribe(listener);
+        const before = transcriptReviewSelection.getSnapshot();
+        transcriptReviewSelection.consumeParagraphRequest(1);
+        expect(listener).not.toHaveBeenCalled();
+        expect(transcriptReviewSelection.getSnapshot()).toBe(before);
+        unsubscribe();
+    });
+
+    it('🔴 処理済みの後に出した新しい要求は採番が進み、必ず未処理になる（同じ段落への再ジャンプも含む）', () => {
+        transcriptReviewSelection.moveToParagraph(DOC_A, 7, 'p-7');
+        transcriptReviewSelection.consumeParagraphRequest(1);
+
+        transcriptReviewSelection.moveToParagraph(DOC_A, 7, 'p-7');
+        const again = transcriptReviewSelection.getSnapshot();
+        expect(again.paragraphRequest).toEqual({ line: 7, nonce: 2 });
+        // 処理済みは据え置き＝新しい nonce(2) と一致しない＝未処理
+        expect(again.consumedNonce).toBe(1);
+        expect(again.paragraphRequest?.nonce).not.toBe(again.consumedNonce);
+    });
+
+    it('select / reveal は要求を消すが処理済み採番は据え置く（次の要求は採番が進むので影響しない）', () => {
+        transcriptReviewSelection.moveToParagraph(DOC_A, 7, 'p-7');
+        transcriptReviewSelection.consumeParagraphRequest(1);
+
+        transcriptReviewSelection.select(DOC_A, 'p-1');
+        expect(transcriptReviewSelection.getSnapshot().paragraphRequest).toBeNull();
+        expect(transcriptReviewSelection.getSnapshot().consumedNonce).toBe(1);
+
+        transcriptReviewSelection.reveal(DOC_A, 'p-3');
+        expect(transcriptReviewSelection.getSnapshot().revealRequest).toEqual({ phraseId: 'p-3', nonce: 2 });
+        expect(transcriptReviewSelection.getSnapshot().paragraphRequest).toBeNull();
+        expect(transcriptReviewSelection.getSnapshot().consumedNonce).toBe(1);
+
+        // reveal で採番が進んだ後の移動要求（nonce 3）も未処理
+        transcriptReviewSelection.moveToParagraph(DOC_A, 1, 'p-1');
+        expect(transcriptReviewSelection.getSnapshot().paragraphRequest).toEqual({ line: 1, nonce: 3 });
+        expect(transcriptReviewSelection.getSnapshot().consumedNonce).toBe(1);
+    });
+
+    it('select は同じ内容なら通知しない（処理済み採番を含めて状態が同じ）', () => {
+        transcriptReviewSelection.select(DOC_A, 'p-1');
+        const listener = vi.fn();
+        const unsubscribe = transcriptReviewSelection.subscribe(listener);
+        transcriptReviewSelection.select(DOC_A, 'p-1');
+        expect(listener).not.toHaveBeenCalled();
+        unsubscribe();
+    });
+
+    it('clear（文書の切替・パネルの破棄）と reset で処理済み採番も初期化される', () => {
+        transcriptReviewSelection.moveToParagraph(DOC_A, 7, 'p-7');
+        transcriptReviewSelection.consumeParagraphRequest(1);
+
+        // 別文書の clear は壊さない
+        transcriptReviewSelection.clear(DOC_B);
+        expect(transcriptReviewSelection.getSnapshot().consumedNonce).toBe(1);
+
+        transcriptReviewSelection.clear(DOC_A);
+        expect(transcriptReviewSelection.getSnapshot()).toEqual({
+            documentId: null, selectedPhraseId: null, revealRequest: null, paragraphRequest: null, consumedNonce: null,
+        });
+
+        transcriptReviewSelection.moveToParagraph(DOC_A, 3, 'p-3');
+        transcriptReviewSelection.consumeParagraphRequest(2);
+        transcriptReviewSelection.reset();
+        expect(transcriptReviewSelection.getSnapshot().consumedNonce).toBeNull();
+        // reset は採番も戻す
+        transcriptReviewSelection.moveToParagraph(DOC_A, 3, 'p-3');
+        expect(transcriptReviewSelection.getSnapshot().paragraphRequest).toEqual({ line: 3, nonce: 1 });
+    });
+});

--- a/src/components/transcriptReviewSelection.ts
+++ b/src/components/transcriptReviewSelection.ts
@@ -9,6 +9,8 @@
  *
  * 🔴 状態と要求は文書 ID 付き。別文書へ切り替えた直後に、前文書の要求が新文書の同じ行・同じ ID へ届かないようにする。
  * 🔴 選ぶだけでは音声を再生しない（再生は候補カードの「音声を再生」だけ・仕様 B3）。
+ * 🔴 段落への移動要求は「同じ要求を 1 回だけ処理する」。処理済みの採番（`consumedNonce`）をストアで持ち、
+ *    本文側の段落が再マウントされても（親の再描画・文書の再表示）同じ要求を再処理しない。
  */
 import { useSyncExternalStore } from 'react';
 
@@ -20,6 +22,11 @@ export interface TranscriptReviewSelectionSnapshot {
     revealRequest: { phraseId: string; nonce: number } | null;
     /** パネル → 本文: 「この開始行（1 始まり）の段落へ移動せよ」 */
     paragraphRequest: { line: number; nonce: number } | null;
+    /**
+     * 本文側が処理済みの `paragraphRequest.nonce`。null = 未処理。
+     * 同じ要求は 1 回だけ処理する（段落の再マウントを跨いで残る。新しい要求は採番が進むので必ず未処理になる）
+     */
+    consumedNonce: number | null;
 }
 
 type Listener = () => void;
@@ -29,6 +36,7 @@ const INITIAL_SNAPSHOT: TranscriptReviewSelectionSnapshot = {
     selectedPhraseId: null,
     revealRequest: null,
     paragraphRequest: null,
+    consumedNonce: null,
 };
 
 const createTranscriptReviewSelectionStore = () => {
@@ -60,17 +68,46 @@ const createTranscriptReviewSelectionStore = () => {
                 && state.revealRequest === null
                 && state.paragraphRequest === null
             ) return;
-            set({ documentId, selectedPhraseId: phraseId, revealRequest: null, paragraphRequest: null });
+            set({
+                documentId,
+                selectedPhraseId: phraseId,
+                revealRequest: null,
+                paragraphRequest: null,
+                consumedNonce: state.consumedNonce,
+            });
         },
         /** 本文の段落バッジから。パネルはこの候補を表示（必要なら展開）してフォーカスを渡す */
         reveal: (documentId: string, phraseId: string): void => {
             nonce += 1;
-            set({ documentId, selectedPhraseId: phraseId, revealRequest: { phraseId, nonce }, paragraphRequest: null });
+            set({
+                documentId,
+                selectedPhraseId: phraseId,
+                revealRequest: { phraseId, nonce },
+                paragraphRequest: null,
+                consumedNonce: state.consumedNonce,
+            });
         },
-        /** カードの「本文の該当段落へ移動」から。本文側の該当段落が 1 回だけ寄せてフォーカスを受ける */
+        /**
+         * カードの「本文の該当段落へ移動」から。本文側の該当段落が 1 回だけ寄せてフォーカスを受ける。
+         * 採番を進めるので、直前の要求が処理済み（consumedNonce）でも新しい要求は必ず未処理になる
+         */
         moveToParagraph: (documentId: string, line: number, phraseId: string): void => {
             nonce += 1;
-            set({ documentId, selectedPhraseId: phraseId, revealRequest: null, paragraphRequest: { line, nonce } });
+            set({
+                documentId,
+                selectedPhraseId: phraseId,
+                revealRequest: null,
+                paragraphRequest: { line, nonce },
+                consumedNonce: state.consumedNonce,
+            });
+        },
+        /**
+         * 本文側が移動要求を処理した印。同じ nonce の要求は以後（段落が再マウントされても）再処理しない。
+         * 🔴 要求（paragraphRequest）自体は残す＝移動先の強調は、別の候補を選ぶ／文書を切り替えるまで続く
+         */
+        consumeParagraphRequest: (nonce: number): void => {
+            if (state.consumedNonce === nonce) return;
+            set({ ...state, consumedNonce: nonce });
         },
         /**
          * 文書の切替・パネルの破棄。`documentId` を渡すと、その文書の状態だけを捨てる

--- a/src/components/transcriptReviewSelection.ts
+++ b/src/components/transcriptReviewSelection.ts
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * 要確認候補の「選択」と、パネル ⇄ 本文の移動要求を繋ぐ小さなストア（仕様 B3）。
+ *
+ * 候補カード（TranscriptReviewPanel）と本文の段落バッジ（transcriptMarkdownComponents）は別コンポーネントで、
+ * 間に居る DocumentDetailPanel はテスト都合で新しいフックを足せない（素の関数呼び出しでテストされる）。
+ * TranscriptPlayer と同じ「モジュール内シングルトン + useSyncExternalStore」で繋ぐ（同時に開く文書は常に 1 本）。
+ *
+ * 🔴 状態と要求は文書 ID 付き。別文書へ切り替えた直後に、前文書の要求が新文書の同じ行・同じ ID へ届かないようにする。
+ * 🔴 選ぶだけでは音声を再生しない（再生は候補カードの「音声を再生」だけ・仕様 B3）。
+ */
+import { useSyncExternalStore } from 'react';
+
+export interface TranscriptReviewSelectionSnapshot {
+    documentId: string | null;
+    /** 選択中の候補（カードの強調と前後移動の基準）。null = 未選択 */
+    selectedPhraseId: string | null;
+    /** 本文の段落バッジ → パネル: 「この候補のカードを表示してフォーカスせよ」 */
+    revealRequest: { phraseId: string; nonce: number } | null;
+    /** パネル → 本文: 「この開始行（1 始まり）の段落へ移動せよ」 */
+    paragraphRequest: { line: number; nonce: number } | null;
+}
+
+type Listener = () => void;
+
+const INITIAL_SNAPSHOT: TranscriptReviewSelectionSnapshot = {
+    documentId: null,
+    selectedPhraseId: null,
+    revealRequest: null,
+    paragraphRequest: null,
+};
+
+const createTranscriptReviewSelectionStore = () => {
+    let state: TranscriptReviewSelectionSnapshot = INITIAL_SNAPSHOT;
+    let nonce = 0;
+    const listeners = new Set<Listener>();
+
+    const emit = (): void => {
+        for (const listener of [...listeners]) listener();
+    };
+    const set = (next: TranscriptReviewSelectionSnapshot): void => {
+        state = next;
+        emit();
+    };
+
+    return {
+        subscribe: (listener: Listener): (() => void) => {
+            listeners.add(listener);
+            return () => {
+                listeners.delete(listener);
+            };
+        },
+        getSnapshot: (): TranscriptReviewSelectionSnapshot => state,
+        /** カードを選ぶ（フォーカス移動・再生はしない）。段落の移動先の強調は解く */
+        select: (documentId: string, phraseId: string | null): void => {
+            if (
+                state.documentId === documentId
+                && state.selectedPhraseId === phraseId
+                && state.revealRequest === null
+                && state.paragraphRequest === null
+            ) return;
+            set({ documentId, selectedPhraseId: phraseId, revealRequest: null, paragraphRequest: null });
+        },
+        /** 本文の段落バッジから。パネルはこの候補を表示（必要なら展開）してフォーカスを渡す */
+        reveal: (documentId: string, phraseId: string): void => {
+            nonce += 1;
+            set({ documentId, selectedPhraseId: phraseId, revealRequest: { phraseId, nonce }, paragraphRequest: null });
+        },
+        /** カードの「本文の該当段落へ移動」から。本文側の該当段落が 1 回だけ寄せてフォーカスを受ける */
+        moveToParagraph: (documentId: string, line: number, phraseId: string): void => {
+            nonce += 1;
+            set({ documentId, selectedPhraseId: phraseId, revealRequest: null, paragraphRequest: { line, nonce } });
+        },
+        /**
+         * 文書の切替・パネルの破棄。`documentId` を渡すと、その文書の状態だけを捨てる
+         * （別文書の状態が既に載っている＝新しい文書側が先に触っている＝なら壊さない）。
+         */
+        clear: (documentId?: string): void => {
+            if (state === INITIAL_SNAPSHOT) return;
+            if (documentId !== undefined && state.documentId !== null && state.documentId !== documentId) return;
+            set(INITIAL_SNAPSHOT);
+        },
+        /** テスト用。状態と採番を初期化する */
+        reset: (): void => {
+            nonce = 0;
+            state = INITIAL_SNAPSHOT;
+            emit();
+        },
+    };
+};
+
+export const transcriptReviewSelection = createTranscriptReviewSelectionStore();
+
+export const useTranscriptReviewSelection = (): TranscriptReviewSelectionSnapshot =>
+    useSyncExternalStore(
+        transcriptReviewSelection.subscribe,
+        transcriptReviewSelection.getSnapshot,
+        transcriptReviewSelection.getSnapshot,
+    );

--- a/src/lib/transcriptDocument.test.ts
+++ b/src/lib/transcriptDocument.test.ts
@@ -1,0 +1,204 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+    hashTranscriptText,
+    hasTranscriptTimestampLinks,
+    orderReviewCandidates,
+    reviewAnchorsByLine,
+    reviewCandidateStartSec,
+    reviewHasPlayableTime,
+    sha256Hex,
+    shouldEnableTranscriptUi,
+    shouldShowTranscriptReviewPanel,
+} from './transcriptDocument';
+import type { ReviewCandidate, TranscriptReview } from './transcriptReviewContract';
+
+/** 合成の文字起こし本文（架空の会話） */
+const TRANSCRIPT = [
+    '[00:12](#t=12) **お客様** いえ、こちらこそ。',
+    '',
+    '[00:30](#t=30) **営業** 本日はお時間ありがとうございます。',
+].join('\n');
+
+/** 時刻リンクの無い通常の議事録 */
+const ORDINARY = '# 商談メモ\n\n- 予算はおよそ1億2,000万円\n';
+
+const candidate = (overrides: Partial<ReviewCandidate> & { phraseId: string }): ReviewCandidate => ({
+    reasons: ['low_confidence'],
+    excerpt: '抜粋',
+    excerptTruncated: false,
+    ...overrides,
+});
+
+const review = (overrides: Partial<TranscriptReview> = {}): TranscriptReview => ({
+    version: 1,
+    threshold: 0.75,
+    sourceTextHash: 'deadbeef',
+    sourceJobId: 'job-synthetic',
+    summary: {
+        totalPhrases: 3, lowConfidence: 1, recognitionFlagged: 0, candidateTotal: 1,
+        unknownConfidence: 0, unknownRecognitionStatus: 0, noTimeCandidates: 0, savedCandidates: 1,
+    },
+    availability: 'complete',
+    candidates: [candidate({ phraseId: 'p-0', startSec: 12.2, endSec: 14 })],
+    ...overrides,
+});
+
+describe('候補の時刻（再生に使える開始秒）', () => {
+    it('有限・0 以上・start ≤ end のときだけ返す', () => {
+        expect(reviewCandidateStartSec({ startSec: 12.25, endSec: 14 })).toBe(12.25);
+        expect(reviewCandidateStartSec({ startSec: 0, endSec: 0 })).toBe(0);
+        expect(reviewCandidateStartSec({ startSec: 5 })).toBe(5);
+    });
+
+    it.each([
+        ['startSec 無し', {}],
+        ['負の秒', { startSec: -1, endSec: 3 }],
+        ['NaN', { startSec: Number.NaN, endSec: 3 }],
+        ['Infinity', { startSec: Number.POSITIVE_INFINITY }],
+        ['end < start', { startSec: 10, endSec: 9 }],
+        ['end が NaN', { startSec: 10, endSec: Number.NaN }],
+        ['文字列', { startSec: '12' as unknown as number }],
+    ])('%s は null（ゼロ秒に置き換えない）', (_label, value) => {
+        expect(reviewCandidateStartSec(value as Partial<ReviewCandidate>)).toBeNull();
+    });
+
+    it('null / undefined は null', () => {
+        expect(reviewCandidateStartSec(null)).toBeNull();
+        expect(reviewCandidateStartSec(undefined)).toBeNull();
+    });
+});
+
+describe('文字起こし UI の有効化（仕様 B3）', () => {
+    it('🔴 本文に時刻リンクが無く review も無い文書は、音声があっても対象外（audioStoragePath を条件にしない）', () => {
+        expect(shouldEnableTranscriptUi({ text: ORDINARY, audioStoragePath: 'audio/u/a.mp3' })).toBe(false);
+        expect(hasTranscriptTimestampLinks({ text: ORDINARY })).toBe(false);
+    });
+
+    it('本文に時刻リンクがあれば review が無くても対象', () => {
+        expect(shouldEnableTranscriptUi({ text: TRANSCRIPT })).toBe(true);
+        expect(shouldEnableTranscriptUi({ transcription: TRANSCRIPT })).toBe(true);
+    });
+
+    it('🔴 本文編集で時刻リンクが全て消えても、review に有効な時刻の候補があれば再確認用に有効化する', () => {
+        expect(shouldEnableTranscriptUi({ text: ORDINARY, transcriptReview: review() })).toBe(true);
+        expect(reviewHasPlayableTime(review())).toBe(true);
+    });
+
+    it('review があっても有効な時刻の候補が無ければ有効化しない（音声があっても）', () => {
+        const noTime = review({ candidates: [candidate({ phraseId: 'p-0' })] });
+        expect(shouldEnableTranscriptUi({ text: ORDINARY, audioStoragePath: 'audio/u/a.mp3', transcriptReview: noTime })).toBe(false);
+        const badTime = review({ candidates: [candidate({ phraseId: 'p-0', startSec: 10, endSec: 3 })] });
+        expect(shouldEnableTranscriptUi({ text: ORDINARY, transcriptReview: badTime })).toBe(false);
+        expect(shouldEnableTranscriptUi({ text: ORDINARY, transcriptReview: review({ candidates: [] }) })).toBe(false);
+    });
+
+    it('null / 本文なしは対象外（例外にしない）', () => {
+        expect(shouldEnableTranscriptUi(null)).toBe(false);
+        expect(shouldEnableTranscriptUi(undefined)).toBe(false);
+        expect(shouldEnableTranscriptUi({})).toBe(false);
+        expect(shouldEnableTranscriptUi({ transcriptReview: { candidates: 'broken' } as unknown as TranscriptReview })).toBe(false);
+    });
+});
+
+describe('要確認パネルを置く文書か', () => {
+    it('🔴 時刻リンクの無い通常の議事録には置かない（既存文書の見た目を変えない）', () => {
+        expect(shouldShowTranscriptReviewPanel({ text: ORDINARY, audioStoragePath: 'audio/u/a.mp3' })).toBe(false);
+    });
+
+    it('review を持つ完成文書には置く（候補 0 件・unavailable でも）', () => {
+        expect(shouldShowTranscriptReviewPanel({ text: ORDINARY, transcriptReview: review({ candidates: [] }) })).toBe(true);
+        expect(shouldShowTranscriptReviewPanel({
+            text: TRANSCRIPT,
+            transcriptReview: review({ availability: 'unavailable', unavailableReason: 'no_phrases', candidates: [] }),
+        })).toBe(true);
+    });
+
+    it('review の無い旧文書は、本文が文字起こし（時刻リンクあり）のときだけ置く', () => {
+        expect(shouldShowTranscriptReviewPanel({ text: TRANSCRIPT })).toBe(true);
+        expect(shouldShowTranscriptReviewPanel({ text: ORDINARY })).toBe(false);
+    });
+
+    it('処理中の仮本文には置かない', () => {
+        expect(shouldShowTranscriptReviewPanel({ text: TRANSCRIPT, status: 'processing', transcriptReview: review() })).toBe(false);
+        expect(shouldShowTranscriptReviewPanel(null)).toBe(false);
+    });
+});
+
+describe('候補の表示順（時刻順・時刻なしは末尾・同時刻は元 index 順）', () => {
+    it('保存順に依存せず並べ直し、中身は変えない', () => {
+        const candidates = [
+            candidate({ phraseId: 'late', startSec: 120, endSec: 121 }),
+            candidate({ phraseId: 'no-time-b' }),
+            candidate({ phraseId: 'early', startSec: 12, endSec: 13 }),
+            candidate({ phraseId: 'no-time-a', startSec: -5 }),
+            candidate({ phraseId: 'tie-2', startSec: 30, endSec: 31 }),
+            candidate({ phraseId: 'tie-1', startSec: 30, endSec: 33 }),
+        ];
+        const ordered = orderReviewCandidates(candidates);
+        expect(ordered.map(entry => entry.candidate.phraseId)).toEqual([
+            'early', 'tie-2', 'tie-1', 'late', 'no-time-b', 'no-time-a',
+        ]);
+        expect(ordered.map(entry => entry.startSec)).toEqual([12, 30, 30, 120, null, null]);
+        expect(ordered[0].candidate).toBe(candidates[2]);
+    });
+
+    it('配列でない／壊れた要素は落として例外にしない', () => {
+        expect(orderReviewCandidates(undefined)).toEqual([]);
+        expect(orderReviewCandidates('x' as unknown as ReviewCandidate[])).toEqual([]);
+        const mixed = [null, { reasons: [] }, candidate({ phraseId: 'ok' })] as unknown as ReviewCandidate[];
+        expect(orderReviewCandidates(mixed).map(entry => entry.candidate.phraseId)).toEqual(['ok']);
+    });
+});
+
+describe('段落アンカー（開始行 → 候補 ID）', () => {
+    it('生成時の paragraphStartLine だけを使い、無い候補は載せない', () => {
+        const byLine = reviewAnchorsByLine([
+            candidate({ phraseId: 'b', startSec: 30, paragraphStartLine: 3 }),
+            candidate({ phraseId: 'a', startSec: 12, paragraphStartLine: 3 }),
+            candidate({ phraseId: 'c', startSec: 40 }),
+            candidate({ phraseId: 'd', paragraphStartLine: 0 }),
+            candidate({ phraseId: 'e', paragraphStartLine: 2.5 }),
+            candidate({ phraseId: 'f', paragraphStartLine: 7 }),
+        ]);
+        expect([...byLine.entries()]).toEqual([[3, ['a', 'b']], [7, ['f']]]);
+    });
+});
+
+describe('本文ハッシュ（UTF-8 の SHA-256・hex）', () => {
+    const nodeSha256 = (text: string): string =>
+        createHash('sha256').update(Buffer.from(text, 'utf8')).digest('hex');
+
+    const samples = [
+        '',
+        'a',
+        '日本語\n',
+        TRANSCRIPT,
+        'x'.repeat(55), 'x'.repeat(56), 'x'.repeat(63), 'x'.repeat(64), 'x'.repeat(65),
+        'あ'.repeat(119), 'あ'.repeat(120), 'あ'.repeat(1000),
+        '改行\r\nと CRLF\r\n',
+        '🙂 サロゲートペア',
+    ];
+
+    it('純 JS の実装はサーバ（node:crypto）と同じ値を返す（ブロック境界・多バイト文字を含む）', () => {
+        for (const sample of samples) {
+            expect(sha256Hex(sample)).toBe(nodeSha256(sample));
+        }
+        expect(sha256Hex('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+    });
+
+    it('hashTranscriptText もサーバと同じ値（crypto.subtle または純 JS）', async () => {
+        for (const sample of samples) {
+            await expect(hashTranscriptText(sample)).resolves.toBe(nodeSha256(sample));
+        }
+    });
+
+    it('同じ本文は同じ Promise を返す（パネルと本文で二重計算しない）', () => {
+        const first = hashTranscriptText('同じ本文');
+        expect(hashTranscriptText('同じ本文')).toBe(first);
+    });
+
+    it('改行 1 文字の違いで値が変わる（厳密一致の判定用）', async () => {
+        await expect(hashTranscriptText(TRANSCRIPT)).resolves.not.toBe(await hashTranscriptText(`${TRANSCRIPT}\n`));
+    });
+});

--- a/src/lib/transcriptDocument.ts
+++ b/src/lib/transcriptDocument.ts
@@ -1,5 +1,5 @@
 /**
- * 文書が「文字起こし」として扱われるかの判定。
+ * 文書が「文字起こし」として扱われるかの判定と、要確認箇所（transcriptReview）の表示用の純関数。
  *
  * 🔴 条件は「音声があるか」ではなく **「本文に時刻リンクがあるか」**。
  *
@@ -8,23 +8,241 @@
  * **既存の議事録文書にもプレイヤーが出て見た目が変わる**。
  * 実際に飛べる先がある文書だけを対象にする (設計 §6.5-3)。
  *
+ * 🔴 例外は 1 つだけ（仕様 B3）: 本文編集で時刻リンクが全て消えても、バッチが保存した
+ * `transcriptReview` に**再生できる時刻を持つ候補**があれば、再確認用の音声 UI は有効にする。
+ * これも「音声があるか」ではなく「飛べる先（候補の時刻）があるか」で決めている。
+ *
  * 判定を UI から切り離してあるのは、コンポーネントを import せずに錠をかけられるようにするため
  * (`DocumentDetailPanel` を import すると Firebase の初期化が走る)。
  */
 import { parseTranscriptTimestamps } from '@/lib/transcriptMerge';
+import type { ReviewCandidate, TranscriptReview } from '@/lib/transcriptReviewContract';
 
 /** 判定に必要な最小限。`Transcription` でも `TranscriptionDocument` でも受けられる */
 export interface TranscriptCandidateDocument {
     text?: string;
     transcription?: string;
     audioStoragePath?: string;
+    status?: string;
+    transcriptReview?: TranscriptReview | null;
 }
 
-export function shouldEnableTranscriptUi(doc: TranscriptCandidateDocument | null | undefined): boolean {
-    if (!doc) return false;
-    const body = typeof doc.text === 'string' ? doc.text
+const bodyOf = (doc: TranscriptCandidateDocument): string | null =>
+    typeof doc.text === 'string' ? doc.text
         : typeof doc.transcription === 'string' ? doc.transcription
             : null;
+
+/** 本文に押せる時刻リンク（`#t=秒`）が 1 つでもあるか */
+export function hasTranscriptTimestampLinks(doc: TranscriptCandidateDocument | null | undefined): boolean {
+    if (!doc) return false;
+    const body = bodyOf(doc);
     if (body === null) return false;
     return parseTranscriptTimestamps(body).length > 0;
+}
+
+/**
+ * 候補の再生に使える開始秒。有限・0 以上・（endSec があれば）start ≤ end のときだけ返す。
+ * 🔴 読めない時刻はゼロ秒に置き換えず null（再生・本文移動を無効にするだけで、候補自体は表示する）。
+ */
+export function reviewCandidateStartSec(
+    candidate: Pick<ReviewCandidate, 'startSec' | 'endSec'> | null | undefined,
+): number | null {
+    if (!candidate) return null;
+    const { startSec, endSec } = candidate;
+    if (typeof startSec !== 'number' || !Number.isFinite(startSec) || startSec < 0) return null;
+    if (endSec !== undefined) {
+        if (typeof endSec !== 'number' || !Number.isFinite(endSec) || endSec < startSec) return null;
+    }
+    return startSec;
+}
+
+/** 保存された候補に、再生へ飛べる時刻を持つものが 1 つでもあるか */
+export function reviewHasPlayableTime(review: TranscriptReview | null | undefined): boolean {
+    if (!review || !Array.isArray(review.candidates)) return false;
+    return review.candidates.some(candidate => reviewCandidateStartSec(candidate) !== null);
+}
+
+/**
+ * 文字起こし UI（時刻リンク再生・話者改名・従属プレイヤー）を出すか。
+ * 本文の時刻リンクが第一条件。無くても、保存済み候補に有効な時刻があれば再確認用に有効化する（仕様 B3）。
+ */
+export function shouldEnableTranscriptUi(doc: TranscriptCandidateDocument | null | undefined): boolean {
+    if (!doc) return false;
+    if (hasTranscriptTimestampLinks(doc)) return true;
+    return reviewHasPlayableTime(doc.transcriptReview);
+}
+
+/**
+ * 「要確認箇所」パネルを置く文書か（仕様 B3）。
+ * - 処理中の仮本文には置かない（文字起こし結果ではない）
+ * - `transcriptReview` を持つ完成文書には置く（候補 0 件・unavailable でも「評価済み／情報なし」を伝えるため）
+ * - review の無い旧文書は、本文が文字起こし（時刻リンクあり）のときだけ「信頼度情報がありません」を置く。
+ *   🔴 時刻リンクの無い通常の議事録には置かない（既存文書の見た目を変えない）
+ */
+export function shouldShowTranscriptReviewPanel(doc: TranscriptCandidateDocument | null | undefined): boolean {
+    if (!doc) return false;
+    if (doc.status === 'processing') return false;
+    if (doc.transcriptReview && typeof doc.transcriptReview === 'object') return true;
+    return hasTranscriptTimestampLinks(doc);
+}
+
+export interface OrderedReviewCandidate {
+    candidate: ReviewCandidate;
+    /** 保存配列上の元 index（同時刻の安定順・ID 以外の識別に使わない） */
+    index: number;
+    /** 再生に使える開始秒。無ければ null（カードは末尾へ） */
+    startSec: number | null;
+}
+
+/**
+ * 候補の表示順（仕様 B3）: 時刻あり → 時刻昇順（同時刻は元 index 順）、その後に時刻なしを元 index 順。
+ * 保存順に依存せず UI 側で並べ直す。候補の中身は変えない。
+ */
+export function orderReviewCandidates(
+    candidates: readonly ReviewCandidate[] | null | undefined,
+): OrderedReviewCandidate[] {
+    if (!Array.isArray(candidates)) return [];
+    const ordered = candidates
+        .filter((candidate): candidate is ReviewCandidate =>
+            Boolean(candidate) && typeof candidate === 'object' && typeof candidate.phraseId === 'string')
+        .map((candidate, index) => ({ candidate, index, startSec: reviewCandidateStartSec(candidate) }));
+    ordered.sort((a, b) => {
+        if (a.startSec === null && b.startSec === null) return a.index - b.index;
+        if (a.startSec === null) return 1;
+        if (b.startSec === null) return -1;
+        return a.startSec - b.startSec || a.index - b.index;
+    });
+    return ordered;
+}
+
+/**
+ * 段落開始行（1 始まり）→ その段落に属する候補の phraseId（表示順）。
+ * 生成時に確定したアンカーだけを使い、行が無い候補は載せない（本文からの推測はしない・仕様 B2）。
+ */
+export function reviewAnchorsByLine(
+    candidates: readonly ReviewCandidate[] | null | undefined,
+): Map<number, string[]> {
+    const byLine = new Map<number, string[]>();
+    for (const { candidate } of orderReviewCandidates(candidates)) {
+        const line = candidate.paragraphStartLine;
+        if (typeof line !== 'number' || !Number.isInteger(line) || line < 1) continue;
+        const bucket = byLine.get(line);
+        if (bucket) bucket.push(candidate.phraseId);
+        else byLine.set(line, [candidate.phraseId]);
+    }
+    return byLine;
+}
+
+// ---------------------------------------------------------------------------
+// 本文ハッシュ（仕様 B2）: 表示本文の UTF-8 バイト列の SHA-256（hex）。
+// サーバの `sourceTextHashOf`（node:crypto）と同じ規則。一致する間だけ本文の段落バッジ・移動を有効にする。
+// ---------------------------------------------------------------------------
+
+const HEX = Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, '0'));
+
+const toHex = (bytes: Uint8Array): string => {
+    let out = '';
+    for (let i = 0; i < bytes.length; i += 1) out += HEX[bytes[i]];
+    return out;
+};
+
+const SHA256_K = new Uint32Array([
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+const rotr = (x: number, n: number): number => (x >>> n) | (x << (32 - n));
+
+/**
+ * 純 JS の SHA-256（hex）。`crypto.subtle` が使えない実行環境（非セキュアコンテキスト等）の退避先。
+ * 🔴 通常は `hashTranscriptText` を使う。こちらは同期で、大きな本文では主スレッドを数十 ms 使う。
+ */
+export function sha256Hex(input: string | Uint8Array): string {
+    const bytes = typeof input === 'string' ? new TextEncoder().encode(input) : input;
+    const bitLength = bytes.length * 8;
+    const paddedLength = (((bytes.length + 9) + 63) >> 6) << 6;
+    const padded = new Uint8Array(paddedLength);
+    padded.set(bytes);
+    padded[bytes.length] = 0x80;
+    const view = new DataView(padded.buffer);
+    view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000));
+    view.setUint32(paddedLength - 4, bitLength >>> 0);
+
+    const hash = new Uint32Array([
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ]);
+    const words = new Uint32Array(64);
+    for (let offset = 0; offset < paddedLength; offset += 64) {
+        for (let t = 0; t < 16; t += 1) words[t] = view.getUint32(offset + t * 4);
+        for (let t = 16; t < 64; t += 1) {
+            const w15 = words[t - 15];
+            const w2 = words[t - 2];
+            const s0 = rotr(w15, 7) ^ rotr(w15, 18) ^ (w15 >>> 3);
+            const s1 = rotr(w2, 17) ^ rotr(w2, 19) ^ (w2 >>> 10);
+            words[t] = (words[t - 16] + s0 + words[t - 7] + s1) >>> 0;
+        }
+        let a = hash[0], b = hash[1], c = hash[2], d = hash[3];
+        let e = hash[4], f = hash[5], g = hash[6], h = hash[7];
+        for (let t = 0; t < 64; t += 1) {
+            const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+            const ch = (e & f) ^ (~e & g);
+            const t1 = (h + S1 + ch + SHA256_K[t] + words[t]) >>> 0;
+            const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+            const maj = (a & b) ^ (a & c) ^ (b & c);
+            const t2 = (S0 + maj) >>> 0;
+            h = g; g = f; f = e; e = (d + t1) >>> 0;
+            d = c; c = b; b = a; a = (t1 + t2) >>> 0;
+        }
+        hash[0] = (hash[0] + a) >>> 0; hash[1] = (hash[1] + b) >>> 0;
+        hash[2] = (hash[2] + c) >>> 0; hash[3] = (hash[3] + d) >>> 0;
+        hash[4] = (hash[4] + e) >>> 0; hash[5] = (hash[5] + f) >>> 0;
+        hash[6] = (hash[6] + g) >>> 0; hash[7] = (hash[7] + h) >>> 0;
+    }
+    const out = new Uint8Array(32);
+    const outView = new DataView(out.buffer);
+    for (let i = 0; i < 8; i += 1) outView.setUint32(i * 4, hash[i]);
+    return toHex(out);
+}
+
+const subtleSha256Hex = async (bytes: Uint8Array): Promise<string | null> => {
+    const subtle = globalThis.crypto?.subtle;
+    if (!subtle || typeof subtle.digest !== 'function') return null;
+    try {
+        // 共有バッファに乗らない自前のコピーを渡す（BufferSource の型と実行環境の差を吸収）
+        const copy = new Uint8Array(bytes.byteLength);
+        copy.set(bytes);
+        const digest = await subtle.digest('SHA-256', copy);
+        return toHex(new Uint8Array(digest));
+    } catch {
+        return null;
+    }
+};
+
+/** 同じ本文を複数の表示（パネルと本文）が別々にハッシュしないための小さなキャッシュ */
+const HASH_CACHE_LIMIT = 8;
+const hashCache = new Map<string, Promise<string>>();
+
+/**
+ * 表示本文の SHA-256（hex）。`crypto.subtle` を優先し、無ければ純 JS で計算する。
+ * 🔴 呼び出し側は「本文が確定したとき」だけ呼ぶ（編集中の毎キー入力で呼ばない・仕様 B2）。
+ */
+export function hashTranscriptText(text: string): Promise<string> {
+    const cached = hashCache.get(text);
+    if (cached) return cached;
+    const promise = (async (): Promise<string> => {
+        const bytes = new TextEncoder().encode(text);
+        return (await subtleSha256Hex(bytes)) ?? sha256Hex(bytes);
+    })();
+    if (hashCache.size >= HASH_CACHE_LIMIT) {
+        const oldest = hashCache.keys().next().value;
+        if (oldest !== undefined) hashCache.delete(oldest);
+    }
+    hashCache.set(text, promise);
+    return promise;
 }


### PR DESCRIPTION
## 概要

PR3「要確認箇所の UI」＋不具合連絡先の常時表示＋ヘッダー高の初期レイアウトシフト対策。Fable 5.1 の3レーンで実装、lead が統合・検証、Opus 5 と Codex の二審。

## PR3: 要確認箇所の UI（仕様 §B3）
PR2 で文書に保存した `transcriptReview`（低信頼句・理由・抜粋・時刻・段落アンカー・本文ハッシュ）を消費して表示。
- 折りたたみ式「要確認箇所」パネル（本文上部・PDF/コピー領域の外）。候補カードに時刻・話者・理由・原文抜粋。前/次移動・20件ずつ「さらに表示」。
- 「音声を再生」は既存の時刻シーク再生に接続。「本文の該当段落へ移動」は **表示本文の SHA-256 が sourceTextHash と一致するときだけ**有効。編集後は無効化し「本文は編集されています」を表示（抜粋・再生は残す）。
- 状態の出し分け: 旧文書=信頼度情報なし・評価済み0件・未評価件数・partial・時刻情報なし・音声読み込み中/失敗/再生拒否。
- 本文の時刻リンクが編集で消えても review に有効時刻があれば音声UIを有効化（audioStoragePath 一律有効化はしない）。a11y・B5「やらないこと」遵守。

## 不具合連絡先の常時表示
- 「サービスの不具合や気づいた点は東野までお知らせください。」を定数1箇所に置き、sticky ヘッダー内の細いバーで常時表示（東野指示）。メール/URL 未指定のため氏名のみ。role=note・AA コントラスト。
- バー追加でヘッダーが約109pxになるため、AppShell の Suspense プレースホルダを h-20→h-28 にして hydration 時のレイアウトシフトを縮小。

## テスト・レビュー
- 全体 1,991 passed / 0 failed。tsc・lint 緑。負荷で揺れたハッシュ照合テストに余裕を付与。
- Opus 5 と Codex の二審を実施（結果反映済み）。

## 既知（別対応）
- ホーム補助ペインの sticky top が元からヘッダー高を織り込んでおらず、本バーで隠れ量が僅かに増える（視認確認のうえ別途）。
- 上司共有UIの改善（監査済み・要判断）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
