### PR TITLE
feat(アップロード): 音声アップロード上限を 100MB → 500MB に引き上げ

### DIFF
--- a/src/components/ConversionSettings.test.tsx
+++ b/src/components/ConversionSettings.test.tsx
@@ -17,11 +17,11 @@ const radios = (markup: string): string[] =>
     [...markup.matchAll(/<input\b[^>]*type="radio"[^>]*>/g)].map(match => match[0]);
 
 describe('ConversionSettings (S2-1: ビットレート選択)', () => {
-    it('既定は 96k (主用途の 2〜3 時間の商談が 128k では上限に届かない)', () => {
+    it('既定は 96k (音声認識には十分。サイズ上限 500MB では 4 時間の商談も余裕で収まる)', () => {
         expect(DEFAULT_AUDIO_BITRATE).toBe('96k');
         expect(AUDIO_BITRATE_OPTIONS.map(option => option.value)).toContain(DEFAULT_AUDIO_BITRATE);
-        // 既定は 2 時間の商談をそのまま扱えること (128k の約 109 分では足りない)
-        expect(estimateMaxRecordingMinutes(DEFAULT_AUDIO_BITRATE)).toBeGreaterThanOrEqual(120);
+        // 既定は主用途の 2〜3 時間の商談（〜4 時間の文字起こし上限）をサイズ上限内で扱えること
+        expect(estimateMaxRecordingMinutes(DEFAULT_AUDIO_BITRATE)).toBeGreaterThanOrEqual(240);
     });
 
     it('64 / 96 / 128 / 192 kbps を選べる', () => {
@@ -35,12 +35,14 @@ describe('ConversionSettings (S2-1: ビットレート選択)', () => {
         expect(checked[0]).toContain('value="64k"');
     });
 
-    it('各選択肢に Storage 上限 (100MB) から逆算した「扱える録音の長さ」を出す', () => {
+    it('「扱える録音の長さ」は全文文字起こしの上限 (4時間) で頭打ちにする (500MB では全ビットレートがサイズより先に時間上限へ)', () => {
         const markup = render('96k');
-        expect(markup).toContain('約3時間38分までの録音に対応');
-        expect(markup).toContain('約2時間25分までの録音に対応');
-        expect(markup).toContain('約1時間49分までの録音に対応');
-        expect(markup).toContain('約1時間12分までの録音に対応');
+        // 500MB のサイズ上限では全ビットレートが 4 時間ぶんを超える → 表示は文字起こしの上限 4 時間で頭打ち
+        expect(markup).toContain('約4時間までの録音に対応');
+        // サイズ由来の生の長さ (18/12/9/6 時間) は出さない: 文字起こしできない長さを「対応」と誤認させないため
+        for (const stale of ['約18時間', '約12時間', '約9時間', '約6時間']) {
+            expect(markup).not.toContain(stale);
+        }
     });
 
     it('inline 予算 (Files API へ迂回すれば超えられる内部の分岐点) の分数は出さない', () => {

--- a/src/components/ConversionSettings.tsx
+++ b/src/components/ConversionSettings.tsx
@@ -2,20 +2,28 @@
 
 import React from 'react';
 import { estimateMaxRecordingMinutes, formatDurationJa } from '@/lib/inlineMediaBudget';
+import { AZURE_BATCH_MAX_AUDIO_SEC } from '@/lib/azureBatchContract';
 
 /**
  * S2-1: 既定は 128k だった。192k だと約 10 分で inline 予算に達し、長い商談録音が全滅していた。
  *
- * 本サービスの主用途は 2〜3 時間の営業商談。128k では Storage 上限 (100MB) に約 1 時間 49 分でぶつかり、
- * 2 時間の商談が扱えない。音声認識の用途では 96k で十分なので、既定を 96k (約 2 時間 25 分) に下げる。
+ * 本サービスの主用途は 2〜3 時間の営業商談。音声認識の用途では 96k で十分なので既定は 96k。
+ *
+ * 🔴 アップロード上限を 500MB に上げてからは、通常のビットレートではサイズより先に
+ *    全文文字起こしの時間上限 (4 時間) にぶつかる。よって「扱える録音の長さ」の表示は
+ *    サイズ由来値と 4 時間の min を取る（下記 RECORDING_CAP_MIN）。ビットレートは実質「音質と
+ *    アップロードのデータ量」の選択になり、対応時間はどれでも 4 時間まで同じ。
  */
 export const DEFAULT_AUDIO_BITRATE = '96k';
 
+/** 画面に出す「扱える録音の長さ」の頭打ち = 全文文字起こしの時間上限（分）。 */
+const RECORDING_CAP_MIN = Math.floor(AZURE_BATCH_MAX_AUDIO_SEC / 60);
+
 export const AUDIO_BITRATE_OPTIONS = [
-    { value: '64k', label: '64 kbps', description: '長い録音向け（音質は低め）' },
+    { value: '64k', label: '64 kbps', description: '音質は低め・データ量は最小' },
     { value: '96k', label: '96 kbps', description: '標準（推奨）' },
     { value: '128k', label: '128 kbps', description: '高音質' },
-    { value: '192k', label: '192 kbps', description: '最高音質（短い録音向け）' },
+    { value: '192k', label: '192 kbps', description: '最高音質・データ量は最大' },
 ] as const;
 
 interface ConversionSettingsProps {
@@ -45,11 +53,14 @@ export const ConversionSettings: React.FC<ConversionSettingsProps> = ({
             </p>
         )}
         <p className="mt-1 text-[13px] text-gray-700">
-            低いほど長い録音を扱えます。2 時間程度の商談は 96 kbps、3 時間を超える録音は 64 kbps を選んでください。表示の長さを超えるファイルは変換できないため、ビットレートを下げるか、ファイルを分割してください。
+            どのビットレートでも最長 4 時間（全文文字起こしの上限）まで対応します。ビットレートは音質の選択で、高いほどアップロードのデータ量が増えます。音声認識の用途では 96 kbps で十分です。4 時間を超える録音は分割してください。
         </p>
         <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
             {AUDIO_BITRATE_OPTIONS.map(option => {
-                const minutes = estimateMaxRecordingMinutes(option.value);
+                const sizeMax = estimateMaxRecordingMinutes(option.value);
+                // 🔴 サイズ由来の最長と、全文文字起こしの時間上限(4時間)の小さいほう。
+                //    500MB では通常ビットレートは 4 時間側で頭打ちになる（サイズより時間が先に効く）。
+                const minutes = sizeMax === null ? null : Math.min(sizeMax, RECORDING_CAP_MIN);
                 return (
                     <label
                         key={option.value}

--- a/src/lib/generateApiContract.ts
+++ b/src/lib/generateApiContract.ts
@@ -15,8 +15,8 @@ export const GENERATE_API_PATH = '/api/generate';
 /** サーバが受け付ける入力メディアの MIME (Storage 上の contentType ではなく、元ファイルの種別) */
 export const GENERATE_ALLOWED_MIME_PREFIXES = ['audio/', 'video/'] as const;
 
-/** Storage 上のファイルサイズ上限 (storage.rules の 100MB と一致させる) */
-export const GENERATE_MAX_MEDIA_BYTES = 100 * 1024 * 1024;
+/** Storage 上のファイルサイズ上限 (storage.rules の 500MB と一致させる) */
+export const GENERATE_MAX_MEDIA_BYTES = 500 * 1024 * 1024;
 
 export interface GenerateRequestPrompt {
     /** 監査ログ・エラー文言用の表示名 */

--- a/src/lib/inlineMediaBudget.test.ts
+++ b/src/lib/inlineMediaBudget.test.ts
@@ -135,12 +135,13 @@ describe('describeInlineBudgetExceeded (実行可能な文言)', () => {
 });
 
 describe('estimateMaxRecordingMinutes (画面に出す「扱える録音の長さ」)', () => {
-    it('Storage 上限 100MB から逆算する (inline 予算 16MB ではない)', () => {
-        // 100MB / (kbps*1000/8) / 60 の切り捨て。inline 予算由来の 26/17/13/8 分とは別物
-        expect(estimateMaxRecordingMinutes('64k')).toBe(218);
-        expect(estimateMaxRecordingMinutes('96k')).toBe(145);
-        expect(estimateMaxRecordingMinutes('128k')).toBe(109);
-        expect(estimateMaxRecordingMinutes('192k')).toBe(72);
+    it('Storage 上限 500MB から逆算する (inline 予算 16MB ではない)', () => {
+        // 500MB / (kbps*1000/8) / 60 の切り捨て。inline 予算由来の分数とは別物。
+        // 🔴 これは「サイズ上限から逆算した最長」。画面表示は別途、文字起こしの上限(4時間)と min を取る（ConversionSettings）。
+        expect(estimateMaxRecordingMinutes('64k')).toBe(1092);
+        expect(estimateMaxRecordingMinutes('96k')).toBe(728);
+        expect(estimateMaxRecordingMinutes('128k')).toBe(546);
+        expect(estimateMaxRecordingMinutes('192k')).toBe(364);
     });
 
     it('inline 予算の目安より必ず長い (Files API 迂回のぶん実際に扱える)', () => {

--- a/src/lib/inlineMediaBudget.ts
+++ b/src/lib/inlineMediaBudget.ts
@@ -78,10 +78,14 @@ export const describeInlineBudgetExceeded = (bitrate?: string): string => {
 };
 
 /**
- * そのビットレートで扱える録音の長さ (分・切り捨て)。
+ * そのビットレートで「サイズ上限から逆算した」最長録音の長さ (分・切り捨て)。
  *
  * inline 予算 (estimateInlineLimitMinutes) は Files API へ迂回すれば超えられる内部の分岐点でしかなく、
- * 利用者が実際にぶつかる壁は Storage のサイズ上限 (100MB) のほう。画面にはこちらを出す。
+ * 利用者が実際にぶつかる壁は Storage のサイズ上限 (500MB) のほう。
+ * 🔴 これは純粋にサイズ由来。上限を 500MB に上げてからは、通常のビットレートではサイズより先に
+ *    全文文字起こしの時間上限 (4 時間 = AZURE_BATCH_MAX_AUDIO_SEC) にぶつかる。画面表示はその上限と
+ *    min を取ること（ConversionSettings）。ここでその上限を混ぜないのは、生のサイズ由来値を
+ *    テスト・他用途で使えるようにするため。
  */
 export const estimateMaxRecordingMinutes = (
     bitrate: string,

--- a/src/lib/mediaInput.ts
+++ b/src/lib/mediaInput.ts
@@ -14,7 +14,8 @@ export const isAudioInput = (file: File): boolean => getSupportedMediaKind(file)
  * 音声ファイルでも「変換を飛ばして元ファイルをそのまま上げてよい」とは限らない。
  *
  * 🔴 実害 (2026-09-04): 1時間22分・16kHz ステレオの **WAV は 301MB** あり、
- * Storage ルールの 100MB 上限に当たって `storage/unauthorized` になっていた。
+ * 当時の Storage ルールの 100MB 上限に当たって `storage/unauthorized` になっていた
+ * （上限はその後 500MB=GENERATE_MAX_MEDIA_BYTES に引き上げ）。
  * 「権限がありません」と表示されるので原因が権限だと誤読され、しかも
  * **ビットレートの選択は変換を通らないため一切効かなかった**（64k にしても同じ 301MB が上がる）。
  *

--- a/src/server/geminiServer.test.ts
+++ b/src/server/geminiServer.test.ts
@@ -150,6 +150,21 @@ describe('GeminiServerClient.generate — files_api', () => {
         expect(doubles.filesDelete).toHaveBeenCalledWith({ name: 'files/abc' });
     });
 
+    it('🔴 files_api 経路ではバッファ全量を Base64 文字列化しない（~384MiB 超で Node の最大文字列長を超え ERR_STRING_TOO_LONG になる回帰を防ぐ）', async () => {
+        doubles.filesUpload.mockResolvedValue({ name: 'files/big', state: 'ACTIVE', uri: 'https://files/big', mimeType: 'audio/mpeg' });
+        doubles.filesDelete.mockResolvedValue(undefined);
+        // 🔴 経路判定は Base64 の「長さ」だけで行い、実際の toString('base64') は inline のときだけ。
+        //    旧実装は判定前に全量を toString('base64') しており、上限を 500MB に上げると ~384MiB 超で
+        //    Base64 文字列が Node の最大文字列長 (536,870,888) を超え ERR_STRING_TOO_LONG で 502 になっていた。
+        const toStringSpy = vi.spyOn(bigBytes, 'toString');
+        const client = new GeminiServerClient({ pollIntervalMs: 0 });
+        const result = await client.generate({ bytes: bigBytes, mimeType: 'audio/mpeg', fileName: 'big.mp3', prompt });
+        expect(result.transport).toBe('files_api');
+        // 🔴 files_api 経路ではバッファを Base64 化していない（これがあると巨大ファイルで例外になる）
+        expect(toStringSpy).not.toHaveBeenCalledWith('base64');
+        toStringSpy.mockRestore();
+    });
+
     it('境界: base64+prompt が予算ちょうど以下は inline、1 バイト超で files_api', async () => {
         // prompt 'p' は 1 バイト。bytes = (budget-4)/4*3 → base64 = budget-4 → 合計 budget-3 (inline)
         const inlineBytes = ((INLINE_REQUEST_BUDGET_BYTES - 4) / 4) * 3;

--- a/src/server/geminiServer.ts
+++ b/src/server/geminiServer.ts
@@ -9,6 +9,7 @@ import { resolveGeminiModel } from '@/constants/geminiModels';
 import { resolveThinkingLevelForModel, type GeminiThinkingLevel } from '@/constants/geminiThinking';
 import type { GenerateTransport, GenerateUsage } from '@/lib/generateApiContract';
 import {
+    base64LengthForBytes,
     INLINE_REQUEST_BUDGET_BYTES,
     selectMediaTransport,
     utf8ByteLength,
@@ -241,18 +242,21 @@ export class GeminiServerClient {
                 'アップロードされたファイルが空です。ファイルを選び直して、もう一度変換してください。');
         }
 
-        const base64 = bytes.toString('base64');
-        const transport: GenerateTransport = selectMediaTransport(base64.length, promptBytes);
+        // 🔴 経路（inline / Files API）は Base64 の「長さ」だけで決める。全量を先に toString('base64') すると、
+        //    ~384MiB 超で Base64 文字列が Node の最大文字列長 (536,870,888) を超え ERR_STRING_TOO_LONG で落ちる。
+        //    上限を 500MB に上げた今、この範囲が実際に来る。実際の Base64 化は inline（≤20MB 予算）のときだけ行う。
+        const base64Length = base64LengthForBytes(bytes.length);
+        const transport: GenerateTransport = selectMediaTransport(base64Length, promptBytes);
         logger.info('送信経路を決定', {
             fileName, mimeType, transport, sizeBytes: bytes.length,
-            base64LengthChars: base64.length, promptBytes, budgetBytes: INLINE_REQUEST_BUDGET_BYTES,
+            base64LengthChars: base64Length, promptBytes, budgetBytes: INLINE_REQUEST_BUDGET_BYTES,
             modelName: targetModel, thinkingLevel: usedThinkingLevel, promptName: input.prompt.name,
         });
 
         let uploaded: UploadedRef | null = null;
         try {
             const mediaPart = transport === 'inline'
-                ? { inlineData: { mimeType, data: base64 } }
+                ? { inlineData: { mimeType, data: bytes.toString('base64') } }
                 : await (async () => {
                     uploaded = await this.uploadMedia(bytes, mimeType, fileName);
                     return { fileData: { fileUri: uploaded.fileUri, mimeType: uploaded.mimeType } };

--- a/src/server/mediaSource.ts
+++ b/src/server/mediaSource.ts
@@ -67,7 +67,7 @@ const toSizeBytes = (value: unknown): number => {
 
 /**
  * 存在とサイズだけ確認する (本文は取らない)。無ければ 404、上限超なら 413。
- * 🔴 `maxBytes` を渡せる。同期経路は 100MB (GENERATE_MAX_MEDIA_BYTES)、
+ * 🔴 `maxBytes` を渡せる。文書生成（Gemini）経路は 500MB (GENERATE_MAX_MEDIA_BYTES)、
  *    非同期バッチ経路は Azure の 1GB (AZURE_BATCH_MAX_AUDIO_BYTES) と、上限が違うため。
  */
 export async function statMedia(

--- a/storage.rules
+++ b/storage.rules
@@ -25,9 +25,12 @@ service firebase.storage {
 
       // 作成・更新:
       //   - ファイルサイズ上限: 500MB（GENERATE_MAX_MEDIA_BYTES と一致させる）
+      //   - 🔴 境界は <=（ちょうど 500MB を許可）。クライアントの事前チェック（> で拒否）と
+      //     canSendAudioAsIs（<= で「そのまま送る」）はちょうど 500MB を通すため、ここも <= に揃える。
+      //     < のままだと、ちょうど 500MB の圧縮済み音声が変換を飛ばして上がり storage/unauthorized になる。
       //   - content-type: audio/* のみ許可
       allow create, update: if isOwner()
-        && request.resource.size < 500 * 1024 * 1024
+        && request.resource.size <= 500 * 1024 * 1024
         && request.resource.contentType.matches('audio/.*');
 
       // 削除:

--- a/storage.rules
+++ b/storage.rules
@@ -24,10 +24,10 @@ service firebase.storage {
       }
 
       // 作成・更新:
-      //   - ファイルサイズ上限: 100MB
+      //   - ファイルサイズ上限: 500MB（GENERATE_MAX_MEDIA_BYTES と一致させる）
       //   - content-type: audio/* のみ許可
       allow create, update: if isOwner()
-        && request.resource.size < 100 * 1024 * 1024
+        && request.resource.size < 500 * 1024 * 1024
         && request.resource.contentType.matches('audio/.*');
 
       // 削除:


### PR DESCRIPTION
## 目的
議事録生成（Gemini）のアップロード上限 100MB で、実運用の 139MB 商談音声が弾かれた（東野報告）。関数リソースの都合で低くしていたが実害が出たため 500MB へ引き上げる。

## 変更
- `GENERATE_MAX_MEDIA_BYTES` 100MB → 500MB（クライアント事前チェック・サーバ mediaSource 既定・inline/Files API 選択が参照）
- `storage.rules` audio アップロード上限 100MB → 500MB
- 文字起こし（Azure バッチ）はサーバ側で既に 1GB。storage 500MB が実効天井（240分の時間上限が先に効く）
- ConversionSettings の「扱える録音の長さ」を全文文字起こしの上限(4時間)で頭打ち（500MB では全ビットレートがサイズより先に 4 時間へ達し「約18時間対応」等の誤表示になるため）。ビットレートは実質「音質・データ量」の選択に。

## 🔴 配備の順序（重要）
`storage.rules` の反映には **`firebase deploy --only storage`** が必要（CI では配備されない）。
**安全な順序: 先にルールを配備 → 後でこの PR をマージ（コード配備）**。逆だとクライアントが 500MB を許可しても実ルールが 100MB のままで `storage/unauthorized` になる。

## 未対応（後続 PR）
再試行時にファイルサイズを小さくする再変換（低ビットレート）。500MB を超える・生成が重い場合の救済。

## テスト
tsc / eslint / 全 2033 テスト green。