### PR TITLE
fix(文字起こし): 長すぎる本文で終端確定が失敗し「処理中」で固まるのを防ぐ

### DIFF
--- a/src/app/api/transcribe/batch.contract.test.ts
+++ b/src/app/api/transcribe/batch.contract.test.ts
@@ -966,6 +966,36 @@ describe('POST /api/transcribe/status（確定処理の配線）', () => {
         },
     );
 
+    it('🔴 本文だけで 1 MiB を超えるときは末尾を省いて completed にする（終端 commit を失敗させて「処理中」で固めない）', async () => {
+        // 240 分の時間上限内でも密度が高いと本文が 1 MiB を超えうる。従来はそのまま書いて終端 commit が失敗し、
+        // finalizing のまま処理中で固まっていた。末尾を省いてでも必ず completed にすること。
+        const hugeBodyChars = 1_500_000; // ~1.43 MiB（Firestore 1 MiB 上限を明確に超える）
+        vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
+        vi.mocked(fetchBatchResult).mockResolvedValue({
+            durationMilliseconds: 60_000,
+            recognizedPhrases: [{
+                offsetMilliseconds: 0, durationMilliseconds: 2000, speaker: 1, recognitionStatus: 'Success',
+                nBest: [{ display: 'あ'.repeat(hugeBodyChars), confidence: 0.95 }],
+            }],
+        });
+        const res = await statusPOST(req({ jobId: 'job-1' }));
+        // 502 で固まらず succeeded を返す
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual(expectedStatus('succeeded', { observed: true }));
+        // 文書は completed に終端化し、ジョブも succeeded、Azure 結果も後始末される（＝再確定ループにならない）
+        expect(documentDb.data).toMatchObject({ status: 'completed' });
+        expect(documentDb.jobData).toMatchObject({ status: 'succeeded' });
+        expect(deleteBatchJob).toHaveBeenCalledTimes(1);
+        // 🔴 実際に Firestore へ書ける大きさ（1 MiB 以内）に収まっている
+        expect(Buffer.byteLength(JSON.stringify(documentDb.data), 'utf8')).toBeLessThanOrEqual(1024 * 1024);
+        // 本文は末尾を省いた断りで終わり、元の巨大本文より短い
+        const body = documentDb.data?.transcription as string;
+        expect(body).toContain('この文字起こしは長すぎて全文を保存できなかった');
+        expect(body.length).toBeLessThan(hugeBodyChars);
+        // 末尾を省くと候補の行番号がずれるため候補は載せない
+        expect(documentDb.data).not.toHaveProperty('transcriptReview');
+    });
+
     it('commit 失敗後の再確定でも要確認候補は同じ入力から同じ内容になる（append しない）', async () => {
         vi.mocked(getBatchJob).mockResolvedValue({ status: 'Succeeded' });
         vi.mocked(fetchBatchResult).mockResolvedValue(reviewAzureResult());

--- a/src/server/transcriptionJob.ts
+++ b/src/server/transcriptionJob.ts
@@ -31,6 +31,32 @@ const FIRESTORE_DOC_LIMIT_BYTES = 1024 * 1024;
 const DOC_WRITE_MARGIN_BYTES = 32 * 1024;
 
 /**
+ * 本文だけで 1 文書上限を超えるとき、末尾を省いて保存する旨の断り。
+ * 🔴 240 分の時間上限内でも密度が高い文字起こしは 1 MiB を超えうる。超えたまま書くと終端 commit が失敗し、
+ *    ジョブが finalizing のまま「処理中」で固まる（リース切れごとに同じ失敗を繰り返す）。本文優先（B4）で、
+ *    review を落とし、それでも超えるなら本文の末尾を省いてでも**必ず終端化する**。
+ */
+const TRANSCRIPT_TRUNCATION_NOTICE =
+    '\n\n---\n（この文字起こしは長すぎて全文を保存できなかったため、ここまでを保存しました。'
+    + '全文が必要な場合は、録音を分割してから再度お試しください。）';
+
+/**
+ * UTF-8 バイト数で maxBytes 以下に収まる最大の前置きを返す。可能なら行境界（改行）で切る。
+ * 多バイト文字を途中で割らない（割れた末尾は継続バイトを後退して落とす）。
+ */
+function truncateUtf8AtLine(text: string, maxBytes: number): string {
+    const buf = Buffer.from(text, 'utf8');
+    if (buf.length <= maxBytes) return text;
+    let cut = Math.max(0, Math.min(maxBytes, buf.length));
+    // 継続バイト (10xxxxxx) の途中で切らないよう後退する
+    while (cut > 0 && (buf[cut] & 0xc0) === 0x80) cut--;
+    let sliced = buf.subarray(0, cut).toString('utf8');
+    const lastNewline = sliced.lastIndexOf('\n');
+    if (lastNewline > 0) sliced = sliced.slice(0, lastNewline);
+    return sliced;
+}
+
+/**
  * `finalizing` は確定処理中の一時状態（内部用）。
  * 🔴 並行に status が 2 回叩かれても確定を 1 回にするための CAS ロック（設計 §3.7・冪等性）。
  *    利用者向けの公開ステータスは running / succeeded / failed の 3 値だけ（finalizing は running 相当に見せる）。
@@ -220,34 +246,59 @@ export async function commitTerminalOutcome(params: {
             logger.warn('処理中でない文書の終端更新をスキップ', { docId });
         } else if (doc.jobId !== undefined && doc.jobId !== jobId) {
             logger.warn('ジョブが異なる文書の終端更新をスキップ', { docId });
-        } else {
-            // 🔴 文書全体（既存フィールド＋本文＋review）が 1MiB を超えないか、実フィールドで最終判定する。
-            //    超えるなら review を落として本文だけ保存する（B4: 本文は必ず完成させる）。
-            let reviewToWrite = outcome.kind === 'succeeded' ? outcome.review : undefined;
-            if (reviewToWrite !== undefined && outcome.kind === 'succeeded') {
-                const projected = {
+        } else if (outcome.kind === 'succeeded') {
+            // 🔴 文書全体（既存フィールド＋本文＋review）が 1MiB を超えると終端 commit 自体が失敗し、
+            //    ジョブが finalizing のまま「処理中」で固まる（リース切れごとに同じ失敗を繰り返す）。
+            //    必ず収まるよう、まず review を落とし（本文優先・B4）、それでも本文だけで超えるなら本文の末尾を省く。
+            const budget = FIRESTORE_DOC_LIMIT_BYTES - DOC_WRITE_MARGIN_BYTES;
+            const projectedBytes = (body: string, review: TranscriptReview | undefined): number => {
+                const projected: Record<string, unknown> = {
                     ...doc,
-                    transcription: outcome.transcription,
+                    transcription: body,
                     generatedByModel: outcome.generatedByModel,
                     status: 'completed',
-                    transcriptReview: reviewToWrite,
+                    ...(review !== undefined && { transcriptReview: review }),
                 };
-                delete (projected as Record<string, unknown>).processingProgress;
-                const projectedBytes = Buffer.byteLength(JSON.stringify(projected), 'utf8');
-                if (projectedBytes > FIRESTORE_DOC_LIMIT_BYTES - DOC_WRITE_MARGIN_BYTES) {
-                    logger.warn('文書全体が保存上限に近いため要確認データを省いて本文だけ保存', { docId, projectedBytes });
-                    reviewToWrite = undefined;
-                }
+                delete projected.processingProgress;
+                return Buffer.byteLength(JSON.stringify(projected), 'utf8');
+            };
+
+            let reviewToWrite = outcome.review;
+            let transcriptionToWrite = outcome.transcription;
+            if (reviewToWrite !== undefined && projectedBytes(transcriptionToWrite, reviewToWrite) > budget) {
+                logger.warn('文書全体が保存上限に近いため要確認データを省いて本文だけ保存', { docId });
+                reviewToWrite = undefined;
             }
-            tx.set(docRef, outcome.kind === 'succeeded' ? {
-                transcription: outcome.transcription,
+            // 🔴 本文以外（title 等）を除いた余地に本文が収まらないときだけ末尾を省く。
+            //    超過が本文以外だけで起きているなら、本文を削っても収まらない＝削らない（本文を無駄に失わない）。
+            const overheadBytes = projectedBytes('', undefined);
+            if (overheadBytes < budget && projectedBytes(transcriptionToWrite, undefined) > budget) {
+                // 本文だけで上限を超える。末尾を省いてでも必ず終端化する（finalizing で固めない）。
+                let maxBodyBytes = Math.max(
+                    0, budget - overheadBytes - Buffer.byteLength(TRANSCRIPT_TRUNCATION_NOTICE, 'utf8'));
+                transcriptionToWrite = truncateUtf8AtLine(outcome.transcription, maxBodyBytes) + TRANSCRIPT_TRUNCATION_NOTICE;
+                // JSON エスケープ（改行・引用符）で概算を超えることがあるので、収まるまで詰める（有界: 0.9 倍ずつ）
+                while (maxBodyBytes > 0 && projectedBytes(transcriptionToWrite, undefined) > budget) {
+                    maxBodyBytes = Math.floor(maxBodyBytes * 0.9);
+                    transcriptionToWrite = truncateUtf8AtLine(outcome.transcription, maxBodyBytes) + TRANSCRIPT_TRUNCATION_NOTICE;
+                }
+                reviewToWrite = undefined; // 末尾を省くと候補の行番号がずれるので候補は載せない
+                logger.warn('本文が保存上限を超えるため末尾を省いて保存', { docId });
+            } else if (overheadBytes >= budget) {
+                // 本文以外だけで上限超（例: 極端に長い title）。本文の切り詰めでは収まらない異常ケース。
+                logger.warn('本文以外のフィールドだけで保存上限を超えている（本文の切り詰めでは収まらない）', { docId });
+            }
+            tx.set(docRef, {
+                transcription: transcriptionToWrite,
                 generatedByModel: outcome.generatedByModel,
                 // 書く先は processing 文書だけ（上の分岐）。processing 文書は候補を持たないので merge で旧候補と混ざらない。
                 ...(reviewToWrite !== undefined && { transcriptReview: reviewToWrite }),
                 status: 'completed' satisfies TranscriptionDocStatus,
                 processingProgress: FieldValue.delete(),
                 updatedAt,
-            } : {
+            }, { merge: true });
+        } else {
+            tx.set(docRef, {
                 transcription: `文字起こしに失敗しました。\n\n理由: ${outcome.reason}\n\nお手数ですが、もう一度お試しください。`,
                 status: 'failed' satisfies TranscriptionDocStatus,
                 processingProgress: FieldValue.delete(),


### PR DESCRIPTION
## 背景
Opus による「全文文字起こし」エラー面の総点検で検出した major。PR#57 の権限修正は intact（別経路の欠陥）。

## 欠陥
`commitTerminalOutcome` のサイズガードは「本文＋review」で 1MiB を超えるとき review を落とすだけで、**本文だけで Firestore の 1 文書上限(1MiB)を超える場合**を見ていなかった。240 分の時間上限内でも密度が高い文字起こしは本文だけで 1MiB を超えうる。超えたまま `tx.set` すると Firestore がトランザクションを拒否 → `commitTerminalOutcome` が throw → status route が `upstream_error`（「しばらくしてから再試行してください」）を返し、ジョブは `finalizing` のまま**「処理中」で固着**。3 分リース切れごとに同じ確定を再試行して同じ throw を繰り返し、Azure 結果も削除されず、利用者は成功済みの文字起こしを受け取れない（最終的に Azure TTL 切れで誤った理由の `failed`）。

## 修正
本文優先(B4)で**必ず終端化**する。まず review を落とし、それでも本文だけで超えるなら本文の末尾を省いて（断りを付けて）でも `completed` にする。超過が本文以外(title 等)だけで起きている場合は本文を削っても無駄なので削らない。UTF-8 は多バイト文字を割らず、可能なら行境界で切る。JSON エスケープ差は詰めて吸収。

## テスト
- 追加: 本文だけで 1MiB 超 → 末尾を省いて `completed`・1MiB 以内・candidates 無し・`succeeded`・Azure 後始末あり（再確定ループにならない）。バグ版で赤・修正版で緑を実機確認。
- 既存の「本文＋review 超過は review だけ落として本文は切り詰めない」テストは、本文が上限内なら従来どおり全文保存で緑のまま。
- tsc / eslint / 全 2034 テスト green。

上限 500MB(PR#59)とは独立（本文長は 240 分の時間上限で決まる）。